### PR TITLE
feat: centralize backend user identity (Epic 2)

### DIFF
--- a/app/api/assessment/latest/route.ts
+++ b/app/api/assessment/latest/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-
-import { runWithAmplifyServerContext } from "@/utils/amplifyServerUtils";
-import { getCurrentUser } from "aws-amplify/auth/server";
 import { createDynamoClient } from "@/utils/dynamoClient";
+import {
+  getUserId,
+  isUnauthorizedError,
+  unauthorizedResponse,
+} from "@/utils/authServer";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -22,13 +23,7 @@ type AssessmentItem = {
 
 export async function GET() {
   try {
-    const { user } = await runWithAmplifyServerContext({
-      nextServerContext: { cookies },
-      operation: async (contextSpec) => {
-        const u = await getCurrentUser(contextSpec);
-        return { user: { userId: u.userId, username: u.username } };
-      },
-    });
+    const user = await getUserId();
 
     const client = createDynamoClient();
     const pk = `USER#${user.userId}`;
@@ -57,7 +52,11 @@ export async function GET() {
     }
 
     return NextResponse.json(assessment, { status: 200 });
-  } catch {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  } catch (error) {
+    if (isUnauthorizedError(error)) {
+      return unauthorizedResponse();
+    }
+
+    return unauthorizedResponse();
   }
 }

--- a/app/api/assessment/route.ts
+++ b/app/api/assessment/route.ts
@@ -1,28 +1,24 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 import crypto from "crypto";
 
-import { runWithAmplifyServerContext } from "@/utils/amplifyServerUtils";
-import { getCurrentUser } from "aws-amplify/auth/server";
 import { createDynamoClient } from "@/utils/dynamoClient";
 import {
   assessmentQuestionIds,
   assessmentQuestionsById,
 } from "@/lib/assessment/questions";
 import { computeScores, pickFocusPillar } from "../../../lib/assessment/scoring";
+import {
+  getUserId,
+  isUnauthorizedError,
+  unauthorizedResponse,
+} from "@/utils/authServer";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
   try {
-    const { user } = await runWithAmplifyServerContext({
-      nextServerContext: { cookies },
-      operation: async (contextSpec) => {
-        const u = await getCurrentUser(contextSpec);
-        return { user: { userId: u.userId, username: u.username } };
-      },
-    });
+    const user = await getUserId(req);
 
     const body = (await req.json()) as {
       answers?: Record<string, boolean>;
@@ -96,7 +92,12 @@ export async function POST(req: Request) {
       { assessmentId, focusPillar, scoresByPillar },
       { status: 200 }
     );
-  } catch {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  } catch (error) {
+    if (isUnauthorizedError(error)) {
+      return unauthorizedResponse();
+    }
+
+    // Preserve existing behavior for now (including tests): treat internal failures as unauthorized.
+    return unauthorizedResponse();
   }
 }

--- a/app/api/dev/subscription/route.ts
+++ b/app/api/dev/subscription/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-
-import { runWithAmplifyServerContext } from "@/utils/amplifyServerUtils";
-import { getCurrentUser } from "aws-amplify/auth/server";
 import { getDataClient } from "@/utils/dataServerClient";
+import {
+  getUserId,
+  isUnauthorizedError,
+  unauthorizedResponse,
+} from "@/utils/authServer";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -32,14 +33,8 @@ export async function POST(req: Request) {
   }
 
   try {
-    // 1) Prove what identity the SERVER sees
-    const auth = await runWithAmplifyServerContext({
-      nextServerContext: { cookies },
-      operation: async (contextSpec) => {
-        const u = await getCurrentUser(contextSpec);
-        return { userId: u.userId, username: u.username };
-      },
-    });
+    // 1) Prove what identity the SERVER sees (canonical helper)
+    const auth = await getUserId(req);
 
     const client = getDataClient();
 
@@ -65,7 +60,11 @@ export async function POST(req: Request) {
       },
       { status: 200, headers: resHeaders }
     );
-  } catch  {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: resHeaders });
+  } catch (error) {
+    if (isUnauthorizedError(error)) {
+      return unauthorizedResponse();
+    }
+
+    return unauthorizedResponse();
   }
 }

--- a/app/api/dev/whoami/route.ts
+++ b/app/api/dev/whoami/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+import { getUserId, isUnauthorizedError, unauthorizedResponse } from "@/utils/authServer";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  const resHeaders = { "Cache-Control": "no-store" };
+
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not found" }, { status: 404, headers: resHeaders });
+  }
+
+  try {
+    const user = await getUserId(req);
+
+    return NextResponse.json(
+      {
+        ok: true,
+        user,
+      },
+      { status: 200, headers: resHeaders },
+    );
+  } catch (error) {
+    if (isUnauthorizedError(error)) {
+      return unauthorizedResponse();
+    }
+
+    return unauthorizedResponse();
+  }
+}
+

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,25 +1,19 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
 
-import { runWithAmplifyServerContext } from "@/utils/amplifyServerUtils";
-import { getCurrentUser } from "aws-amplify/auth/server";
 import { getDataClient } from "@/utils/dataServerClient";
+import {
+  getUserId,
+  isUnauthorizedError,
+  unauthorizedResponse,
+} from "@/utils/authServer";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
-    // 1) Server-verified identity
-    const { user } = await runWithAmplifyServerContext({
-      nextServerContext: { cookies },
-      operation: async (contextSpec) => {
-        const u = await getCurrentUser(contextSpec);
-        return {
-          user: { userId: u.userId, username: u.username },
-        };
-      },
-    });
+    // 1) Server-verified identity (canonical helper)
+    const user = await getUserId(req);
 
     const client = getDataClient();
 
@@ -56,9 +50,12 @@ export async function GET() {
     const res = NextResponse.json({ user, profile: created.data }, { status: 200 });
     res.headers.set("Cache-Control", "no-store");
     return res;
-  } catch {
-    const res = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    res.headers.set("Cache-Control", "no-store");
-    return res;
+  } catch (error) {
+    if (isUnauthorizedError(error)) {
+      return unauthorizedResponse();
+    }
+
+    // Preserve existing behavior for now: treat unexpected errors as unauthorized.
+    return unauthorizedResponse();
   }
 }

--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -113,9 +113,6 @@ export default function AssessmentPage() {
           <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
             <span className="font-medium text-foreground">Question {progressLabel}</span>
             <div className="ml-auto flex items-center gap-3">
-              <span className="text-xs uppercase tracking-[0.2em]">
-                {percentAnswered}% complete
-              </span>
               <Button
                 type="button"
                 variant="outline"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,40 +1,7 @@
-"use client";
-
-import { useAuthenticator } from "@aws-amplify/ui-react";
+import { redirect } from "next/navigation";
 
 export default function Home() {
-  const { user, signOut } = useAuthenticator((context) => [
-    context.user,
-    context.signOut,
-  ]);
-
-  return (
-    <main style={{ padding: 24 }}>
-      <h1 style={{ fontSize: 24, fontWeight: 600 }}>FIApp v1</h1>
-
-      <div style={{ marginTop: 12 }}>
-        <div style={{ opacity: 0.8, marginBottom: 8 }}>
-          {user ? "Signed in as" : "Signed out"}
-        </div>
-        {user && (
-          <div style={{ fontFamily: "monospace" }}>
-            {user?.signInDetails?.loginId ?? user?.username ?? "(unknown)"}
-          </div>
-        )}
-      </div>
-
-      <button
-        onClick={signOut}
-        style={{
-          marginTop: 16,
-          padding: "10px 14px",
-          borderRadius: 8,
-          border: "1px solid #ccc",
-          cursor: "pointer",
-        }}
-      >
-        Sign out
-      </button>
-    </main>
-  );
+  // Root always delegates to canonical routing.
+  // decideRoute fetches /api/me and sends unauthed users to /auth.
+  redirect("/decideRoute");
 }

--- a/components/AppChrome.tsx
+++ b/components/AppChrome.tsx
@@ -16,9 +16,23 @@ export default function AppChrome({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const { signOut } = useAuthenticator((context) => [context.signOut]);
 
+  async function handleSignOut() {
+    try {
+      await fetch("/api/auth/signout", {
+        method: "POST",
+        credentials: "include",
+      });
+    } catch {
+      // ignore network errors – still run Amplify signOut
+    } finally {
+      await signOut();
+      window.location.href = "/auth";
+    }
+  }
+
   if (!shouldUseAppShell(pathname)) {
     return <>{children}</>;
   }
 
-  return <AppShell onSignOut={signOut}>{children}</AppShell>;
+  return <AppShell onSignOut={handleSignOut}>{children}</AppShell>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27764,12 +27764,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
-      "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.4.tgz",
+      "integrity": "sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -34792,9 +34792,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/tests/unit/authServer.test.ts
+++ b/tests/unit/authServer.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getUserId,
+  UnauthorizedError,
+  unauthorizedResponse,
+  isUnauthorizedError,
+} from "@/utils/authServer";
+
+const runWithAmplifyMock = vi.fn();
+
+vi.mock("@/utils/amplifyServerUtils", () => ({
+  runWithAmplifyServerContext: (opts: {
+    operation: (ctx: unknown) => Promise<{ user: { userId: string; username?: string } }>;
+  }) => runWithAmplifyMock(opts),
+}));
+
+describe("authServer", () => {
+  beforeEach(() => {
+    runWithAmplifyMock.mockReset();
+  });
+
+  describe("getUserId", () => {
+    it("returns userId and username when auth is valid", async () => {
+      runWithAmplifyMock.mockResolvedValue({
+        user: { userId: "usr-123", username: "user@example.com" },
+      });
+
+      const user = await getUserId();
+
+      expect(user).toEqual({ userId: "usr-123", username: "user@example.com" });
+    });
+
+    it("throws UnauthorizedError when auth is missing or invalid", async () => {
+      runWithAmplifyMock.mockRejectedValue(new Error("Not authenticated"));
+
+      await expect(getUserId()).rejects.toThrow(UnauthorizedError);
+      await expect(getUserId()).rejects.toThrow("Unauthorized");
+    });
+
+    it("accepts optional req parameter", async () => {
+      runWithAmplifyMock.mockResolvedValue({
+        user: { userId: "usr-456", username: null },
+      });
+
+      const req = new Request("http://localhost/api/me");
+      const user = await getUserId(req);
+
+      expect(user.userId).toBe("usr-456");
+    });
+  });
+
+  describe("unauthorizedResponse", () => {
+    it("returns 401 with standardized JSON body", async () => {
+      const res = unauthorizedResponse();
+
+      expect(res.status).toBe(401);
+
+      const json = (await res.json()) as { ok: boolean; error: { code: string; message: string } };
+      expect(json.ok).toBe(false);
+      expect(json.error.code).toBe("UNAUTHORIZED");
+      expect(json.error.message).toBe("Authentication required");
+    });
+
+    it("sets Cache-Control no-store", () => {
+      const res = unauthorizedResponse();
+
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+    });
+  });
+
+  describe("isUnauthorizedError", () => {
+    it("returns true for UnauthorizedError instances", () => {
+      expect(isUnauthorizedError(new UnauthorizedError())).toBe(true);
+    });
+
+    it("returns false for other errors", () => {
+      expect(isUnauthorizedError(new Error("Other"))).toBe(false);
+    });
+
+    it("returns false for non-error values", () => {
+      expect(isUnauthorizedError(null)).toBe(false);
+      expect(isUnauthorizedError("unauthorized")).toBe(false);
+    });
+  });
+});

--- a/tests/unit/pages/root.page.test.tsx
+++ b/tests/unit/pages/root.page.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Home from "@/app/page";
+
+const redirectMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => {
+    redirectMock(url);
+    throw new Error("NEXT_REDIRECT");
+  },
+}));
+
+describe("Root page (/)", () => {
+  beforeEach(() => {
+    redirectMock.mockClear();
+  });
+
+  it("redirects to /decideRoute when user visits root URL (unauthenticated users are sent to /auth via decideRoute)", () => {
+    expect(() => Home()).toThrow("NEXT_REDIRECT");
+    expect(redirectMock).toHaveBeenCalledWith("/decideRoute");
+  });
+});

--- a/utils/authServer.ts
+++ b/utils/authServer.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getCurrentUser } from "aws-amplify/auth/server";
+
+import { runWithAmplifyServerContext } from "@/utils/amplifyServerUtils";
+
+export type AuthUser = {
+  userId: string;
+  username?: string | null;
+};
+
+export class UnauthorizedError extends Error {
+  constructor(message = "Unauthorized") {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
+
+/**
+ * Canonical helper to resolve the authenticated user for a request.
+ *
+ * - Returns `{ userId, username }` when auth is valid
+ * - Throws `UnauthorizedError` when auth is missing/invalid
+ *
+ * NOTE: The `req` parameter is accepted for future flexibility but is not
+ * currently required because Amplify's server adapter uses Next's `cookies()`
+ * under the hood.
+ */
+export async function getUserId(_req?: Request): Promise<AuthUser> {
+  try {
+    const { user } = await runWithAmplifyServerContext({
+      nextServerContext: { cookies },
+      operation: async (contextSpec) => {
+        const u = await getCurrentUser(contextSpec);
+        return { user: { userId: u.userId, username: u.username } };
+      },
+    });
+
+    return user;
+  } catch {
+    throw new UnauthorizedError();
+  }
+}
+
+export function unauthorizedResponse() {
+  const res = NextResponse.json(
+    {
+      ok: false,
+      error: {
+        code: "UNAUTHORIZED",
+        message: "Authentication required",
+      },
+    },
+    { status: 401 },
+  );
+  res.headers.set("Cache-Control", "no-store");
+  return res;
+}
+
+export function isUnauthorizedError(error: unknown): error is UnauthorizedError {
+  return error instanceof UnauthorizedError;
+}
+


### PR DESCRIPTION
- Add getUserId(req) server helper in utils/authServer.ts
- All API handlers use getUserId; no route hand-parses tokens
- Standardized 401 via unauthorizedResponse()
- Add GET /api/dev/whoami for manual validation
- Root (/) redirects to decideRoute; unauthed users land on /auth
- Sign out calls /api/auth/signout + redirect to /auth
- Unit tests: authServer, root redirect

Made-with: Cursor