### PR TITLE
Epic #2: Profile defaults, subscription display, dev toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ COGNITO_IDENTITY_POOL_ID=
 # Enable dev override logic
 FIAPP_SUBSCRIPTION_DEV_MODE=true
 
+# Show dev subscription toggle in header (local only; never set in prod)
+# Set to "true" in .env.local to toggle Free/Paid for testing
+NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=
+
 # Force subscription status in dev
-# Allowed values: free | paid
-FIAPP_FORCE_SUBSCRIPTION_STATUS=free
+# Allowed values: FREE | PAID
+FIAPP_FORCE_SUBSCRIPTION_STATUS=FREE

--- a/_docs/canon/api-contract.md
+++ b/_docs/canon/api-contract.md
@@ -109,8 +109,8 @@ This endpoint is the **only** way to modify active/trial/paused/focus state.
 
 **Server rules**
 - Enforce caps based on `subscriptionStatus`:
-  - free cap=1
-  - paid cap=10
+  - FREE cap=1
+  - PAID cap=10
 - Warning thresholds on paid:
   - at 5 → include warning
   - at 7 → strong warning

--- a/_docs/canon/db-schema.md
+++ b/_docs/canon/db-schema.md
@@ -19,7 +19,7 @@
 - **SK:** `PROFILE`
 - **Purpose:** user-level state, caps, focus pointers, counters, milestones pointers.
 - **Fields (canonical):**
-  - `subscriptionStatus`: `"free" | "paid"` (dev override allowed elsewhere; schema supports both)
+  - `subscriptionStatus`: `"FREE" | "PAID"` (dev override allowed elsewhere; schema supports both)
   - `activePracticeIds`: `string[]` (IDs)
   - `activePracticeSkById`: `{ [practiceId: string]: string }`  
     - Used by **Option 2 pause logic** (lets you locate the user-practice record SK even if “paused”)

--- a/_docs/canon/state-machine.md
+++ b/_docs/canon/state-machine.md
@@ -12,7 +12,7 @@ The router/guards depend on:
 
 1. `isAuthed`
 2. `hasAssessment` (PROFILE.latestAssessmentId)
-3. `subscriptionStatus` (`free|paid`)
+3. `subscriptionStatus` (`FREE|PAID`)
 4. `activePracticeIds.length`
 5. `todayFocusPracticeId` (optional)
 6. Trial presence (TRIAL items) (optional for routing, important for UI)

--- a/_docs/canon/testing-checklist.md
+++ b/_docs/canon/testing-checklist.md
@@ -24,9 +24,11 @@
 ### 1.1 PROFILE creation
 - [ ] `GET /api/me` creates PROFILE if missing
 - [ ] PROFILE contains required fields with safe defaults:
-  - `subscriptionStatus` default (free unless dev override)
+  - `subscriptionStatus` default (FREE unless dev override)
   - `activePracticeIds` defaults to `[]`
   - `latestAssessmentId` defaults to `null`
+- [ ] PROFILE creation is idempotent: calling `GET /api/me` twice returns same profile (no overwrite)
+- **Manual verification:** Sign in → call `GET /api/me` twice → both return same `userId`, `subscriptionStatus`, `createdAt`; default fields present
 
 ### 1.2 Returns table shape
 - [ ] `POST /api/return` writes to **FIAPP_RETURNS**:

--- a/_docs/plans/epic2-dev-subscription-toggle.md
+++ b/_docs/plans/epic2-dev-subscription-toggle.md
@@ -1,0 +1,123 @@
+# Epic #2 — Dev Subscription Toggle Plan
+
+**Status:** Implemented
+
+**Purpose:** Allow testing paid flows without payment integration.
+
+**Success criteria:**
+- Dev can toggle subscriptionStatus ✓
+- Prod unaffected ✓
+- UI reacts immediately ✓
+
+---
+
+## Local setup
+
+Add to `.env.local`:
+```
+NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true
+```
+Restart dev server. The "Free | Paid" toggle appears in the header. Click to switch; UI updates immediately.
+
+---
+
+## Current State
+
+| Item | Status |
+|------|--------|
+| **POST /api/dev/subscription** | Exists; gated by `NODE_ENV === "production"` → 404 in prod |
+| **setMySubscriptionStatus** | Updates PROFILE in DynamoDB |
+| **ProfileContext.refetch** | Exposed via `useProfile().refetch()` |
+| **Dev UI control** | Missing — dev must use curl/Postman |
+| **Auto-refresh after API call** | Missing — page refresh required to see change |
+
+---
+
+## Plan
+
+### Step 1: Ensure dev endpoint is properly gated
+
+**File:** `app/api/dev/subscription/route.ts`
+
+- Already returns 404 when `NODE_ENV === "production"`. No change if that suffices.
+- Optional: add `FIAPP_SUBSCRIPTION_DEV_MODE` check so the route is disabled even in non-prod when explicitly turned off. Low priority.
+
+**Verification:** Deploy to prod → `POST /api/dev/subscription` returns 404.
+
+---
+
+### Step 2: Add dev-only env flag for UI
+
+**Files:** `.env.example`, `next.config.*` (if needed)
+
+Add `NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true` so the client can gate the dev control. In production, omit or set to `false`; the control will not render.
+
+---
+
+### Step 3: Create DevSubscriptionToggle component
+
+**File:** `components/DevSubscriptionToggle.tsx` (new)
+
+- Client component
+- Renders only when `process.env.NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION === "true"`
+- Shows Free | Premium toggle (or two buttons: "Set Free" / "Set Paid")
+- On click:
+  1. `POST /api/dev/subscription` with `{ subscriptionStatus: "FREE" | "PAID" }`
+  2. On success: call `refetch()` from `useProfile()`
+  3. On error: show toast
+- Place in header near PlanBadge (e.g. only when dev flag is on)
+- Uses outline/ghost styling so it’s clearly dev-only
+
+---
+
+### Step 4: Integrate into AppShell
+
+**File:** `components/layout/AppShell.tsx`
+
+- Import and render `<DevSubscriptionToggle />` in the header (e.g. next to PlanBadge)
+- Wrapped in same visibility check or inside component
+
+---
+
+### Step 5: Refetch flow
+
+**File:** `contexts/ProfileContext.tsx`
+
+- No change; `refetch` is already exposed
+- DevSubscriptionToggle will call `refetch()` after a successful POST
+
+**Flow:**
+1. User clicks "Set Paid" in DevSubscriptionToggle
+2. POST /api/dev/subscription with `{ subscriptionStatus: "PAID" }`
+3. API updates PROFILE.subscriptionStatus via setMySubscriptionStatus
+4. On success, DevSubscriptionToggle calls `refetch()`
+5. ProfileContext fetches `/api/me` and updates state
+6. PlanBadge and UpgradeButton re-render with new status (Premium, no Upgrade button)
+
+---
+
+### Step 6: Manual verification
+
+1. Set `NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true` in `.env.local`
+2. Restart dev server (env vars need rebuild)
+3. Sign in → dev toggle appears in header
+4. Click "Set Paid" → PlanBadge shows Premium, Upgrade button hides
+5. Click "Set Free" → PlanBadge shows Free, Upgrade button appears
+6. No full page refresh required
+
+---
+
+## Files to touch
+
+| File | Action |
+|------|--------|
+| `app/api/dev/subscription/route.ts` | Verify prod gate (no change if already correct) |
+| `.env.example` | Add `NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION` |
+| `components/DevSubscriptionToggle.tsx` | **New** — dev-only toggle UI |
+| `components/layout/AppShell.tsx` | Add DevSubscriptionToggle to header |
+
+---
+
+## Estimated effort
+
+~30 minutes

--- a/_docs/plans/epic2-profile-defaults.md
+++ b/_docs/plans/epic2-profile-defaults.md
@@ -1,0 +1,169 @@
+# Epic #2 — PROFILE Defaults Plan
+
+**Status:** Implemented
+
+**Purpose:** Ensure PROFILE exists for all future flows without extra checks elsewhere.
+
+**Success criteria:**
+- Default fields present (`subscriptionStatus` = free etc.)
+- Create is idempotent
+- No overwriting existing profile
+
+---
+
+## Cross-reference: Compatibility with Canon Docs
+
+Cross-checked against `_docs/canon/*.md` and implementation. Resolutions below.
+
+### PROFILE fields — consistent
+
+| Source | Fields |
+|--------|--------|
+| **db-schema.md** | subscriptionStatus, activePracticeIds, activePracticeSkById, todayFocusPracticeId, latestAssessmentId, focusPillar, returnCounters, practiceCounters, milestonesAchieved |
+| **api-contract.md** (GET /api/me) | subscriptionStatus, activePracticeIds, todayFocusPracticeId, latestAssessmentId, focusPillar, counters + milestones |
+| **testing-checklist.md** | subscriptionStatus, activePracticeIds, latestAssessmentId |
+| **state-machine.md** | hasAssessment (latestAssessmentId), subscriptionStatus, activePracticeIds, todayFocusPracticeId |
+| **Plan defaults** | All above + userId, createdAt, updatedAt (implementation fields) |
+
+→ **Compatible.** Plan’s default fields match db-schema and api-contract.
+
+### subscriptionStatus casing — inconsistent (resolve before implementation)
+
+| Source | Value |
+|--------|-------|
+| **db-schema.md** | `"FREE" \| "PAID"` |
+| **state-machine.md** | `FREE|PAID` |
+| **testing-checklist.md** | FREE unless dev override |
+| **.env.example** | `FIAPP_FORCE_SUBSCRIPTION_STATUS=FREE` |
+| **Code** (createMyProfile, resource.ts, dev/subscription) | `"FREE"` / `"PAID"` (uppercase) |
+| **api-contract.md** (cap rules) | FREE cap=1, PAID cap=10 |
+
+**Resolution:** All canon docs and .env.example updated to use `FREE`/`PAID`. Code unchanged.
+
+### Epic numbering
+
+- **execution-plan.md** Epic 2 = "Core Screens / UX Skeleton"
+- This plan = "PROFILE Defaults" (profile creation, defaults, idempotency)
+
+Different scope; no conflict. This work aligns with Epic 1 (Identity, Profile & Subscription) in execution-plan.
+
+### Other canon references
+
+- **routing-table.md:** uses subscriptionStatus, hasAssessment, activePracticeCount — all derived from PROFILE. Compatible.
+- **practice-caps-and-trials.md:** cap rules use subscriptionStatus — compatible.
+- **design-guardrails.md:** UI-focused, no PROFILE schema. N/A.
+
+---
+
+## Current State
+
+| Item | Status |
+|------|--------|
+| Conditional write | ✅ Already in `createMyProfile.js`: `attribute_not_exists(PK) AND attribute_not_exists(SK)` |
+| `/api/me` create-if-missing flow | ✅ Reads first, creates only when missing |
+| Default fields | ⚠️ Partial: only `userId`, `subscriptionStatus`, `createdAt`, `updatedAt` |
+
+**Gap:** db-schema and api-contract define additional canonical fields that flows will expect. Defaults are missing for `activePracticeIds`, `activePracticeSkById`, `todayFocusPracticeId`, `latestAssessmentId`, `focusPillar`, and (optional for now) `returnCounters`, `practiceCounters`, `milestonesAchieved`.
+
+---
+
+## Plan
+
+### Step 1: Define default PROFILE shape
+
+**Location:** `_docs/canon/db-schema.md` (reference) + `amplify/data/handlers/profile/createMyProfile.js` (implementation)
+
+Add a single source of truth for the "default PROFILE" shape. Options:
+- **A)** Add `_docs/canon/profile-defaults.md` with the exact default item
+- **B)** Define inline in createMyProfile with a comment pointing to db-schema
+
+**Default fields to include** (per db-schema + testing-checklist):
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `userId` | `sub` | Already present |
+| `subscriptionStatus` | `"FREE"` | Already present; schema uses FREE/PAID |
+| `createdAt` / `updatedAt` | ISO8601 | Already present |
+| `activePracticeIds` | `[]` | testing-checklist requires |
+| `activePracticeSkById` | `{}` | db-schema |
+| `todayFocusPracticeId` | `null` | db-schema |
+| `latestAssessmentId` | `null` | testing-checklist requires |
+| `focusPillar` | `null` | db-schema |
+| `returnCounters` | `{}` | stub for Counters epic |
+| `practiceCounters` | `{}` | stub for Counters epic |
+| `milestonesAchieved` | `[]` | db-schema |
+
+**Amplify schema note:** `Profile` in `amplify/data/resource.ts` currently only declares `userId`, `subscriptionStatus`, `createdAt`, `updatedAt`. Extra fields written to DynamoDB will be returned by getMyProfile; Amplify types may need optional fields if consumers expect them. Decision: add optional fields to Profile type or keep type minimal and rely on runtime shape.
+
+---
+
+### Step 2: Update createMyProfile with full default shape
+
+**File:** `amplify/data/handlers/profile/createMyProfile.js`
+
+- Extend the `item` object with all default fields from Step 1
+- Ensure condition remains: `attribute_not_exists(PK) AND attribute_not_exists(SK)` (no change)
+- Optionally extract defaults to a shared constant for reuse in tests
+
+---
+
+### Step 3: (Optional) Update Amplify Profile type
+
+**File:** `amplify/data/resource.ts`
+
+- Add optional fields to `Profile` custom type if downstream code (e.g. `lib/apiClient`, `DecideRouteClient`) expects them
+- Or leave as-is if those consumers already handle partial shape
+
+---
+
+### Step 4: Add minimal test — /api/me twice
+
+**Approach:**
+
+1. **Unit test** (recommended)  
+   - File: `tests/unit/api/me.test.ts` (new) or extend existing  
+   - Mock `getDataClient()`:
+     - First `GET /api/me`: `getMyProfile` returns `null` → `createMyProfile` returns new profile → response `{ ok: true, data }`
+     - Second `GET /api/me`: `getMyProfile` returns existing profile → no `createMyProfile` call → same profile returned
+   - Assert: second response matches first (or at least has same `userId`, `subscriptionStatus`, no overwrite)
+   - Assert: `createMyProfile` invoked exactly once across both calls
+
+2. **Integration / handler test** (optional, if DynamoDB mock available)  
+   - Call createMyProfile twice with same user
+   - Second call should throw `ConditionalCheckFailedException` (or equivalent) — we treat that as "already exists" and re-read in `/api/me`
+
+---
+
+### Step 5: Manual verification
+
+Document in testing-checklist or README:
+
+1. Start dev server, sign in
+2. Open `GET /api/me` in browser (or DevTools → copy as cURL)
+3. Note response, e.g. `{ ok: true, data: { userId, subscriptionStatus: "FREE", ... } }`
+4. Refresh or call `GET /api/me` again
+5. Assert: same `userId`, `subscriptionStatus`, `createdAt`; no 500
+6. (Optional) In DynamoDB console, confirm single PROFILE item per user
+
+---
+
+## Checklist before starting
+
+- [ ] Confirm which default fields to include (all above vs. minimal set)
+- [ ] Decide: new `profile-defaults.md` vs. inline comment in createMyProfile
+- [ ] Decide: update Amplify Profile type now or later
+- [x] Resolve subscriptionStatus casing: db-schema, state-machine, testing-checklist, api-contract, .env.example updated to FREE/PAID
+
+---
+
+## Estimated effort
+
+| Step | Effort |
+|------|--------|
+| 1. Define shape | ~10 min |
+| 2. Update createMyProfile | ~15 min |
+| 3. Update Profile type (optional) | ~5 min |
+| 4. Unit test | ~20 min |
+| 5. Manual verify + doc | ~10 min |
+
+**Total:** ~1 hour

--- a/_docs/plans/epic2-subscription-display.md
+++ b/_docs/plans/epic2-subscription-display.md
@@ -1,0 +1,32 @@
+# Epic #2 — Subscription / Plan Display
+
+**Status:** Implemented
+
+**Purpose:** Enable free vs paid gating and UI behavior.
+
+**Success criteria:**
+- PROFILE contains subscriptionStatus ✓ (from profile-defaults)
+- Defaults to FREE ✓
+- Returned by /api/me ✓
+- Front-end displays plan state somewhere simple ✓
+- Upgrade CTA exists but stubbed ✓
+
+---
+
+## Implementation
+
+### Backend (already done)
+- `createMyProfile` sets `subscriptionStatus: "FREE"`
+- `/api/me` returns full profile including `subscriptionStatus`
+- `POST /api/dev/subscription` allows dev override to PAID
+
+### Front-end
+- **PlanBadge** (`components/PlanBadge.tsx`): shows "Free" or "Premium" pill in header (from profile context)
+- **UpgradeButton** (`components/UpgradeButton.tsx`): stubbed Upgrade CTA, shown only when `subscriptionStatus === "FREE"`; click → toast "Upgrade coming soon"
+- **AppShell**: renders PlanBadge + UpgradeButton in header
+- Free = muted pill, Paid = primary-tinted pill; no Upgrade button for Premium
+
+### Manual test
+1. Sign in → header shows "Free" badge + Upgrade button
+2. Click Upgrade → toast "Upgrade coming soon"
+3. `POST /api/dev/subscription` with `{ subscriptionStatus: "PAID" }` → refresh → header shows "Premium", Upgrade button hidden

--- a/_docs/plans/profile-state-driven-ui.md
+++ b/_docs/plans/profile-state-driven-ui.md
@@ -1,0 +1,35 @@
+# Profile State-Driven UI
+
+**Status:** Implemented
+
+**Purpose:** Make UI state-driven from backend profile response.
+
+**Success criteria:**
+- App fetches /api/me after auth ✓
+- Stores profile in client state ✓
+- Handles loading/error cleanly ✓
+- Renders subscription status + basic info ✓
+
+---
+
+## Implementation
+
+### ProfileContext (`contexts/ProfileContext.tsx`)
+- Fetches `GET /api/me` when `authStatus === "authenticated"`
+- Stores `profile`, `loading`, `error`, `refetch` in React context
+- Provides `useProfile()` hook for consumers
+- Handles 401/403 by setting error (consumers redirect to /auth)
+
+### ProfileProvider
+- Wraps app content in `AppChrome`
+- Runs fetch on mount when authenticated
+- Profile persists across navigation (single fetch)
+
+### Consumers
+- **PlanBadge** – reads `profile.subscriptionStatus` from context, no direct fetch
+- **DecideRouteClient** – uses profile for routing; shows Loading/Error states appropriately
+
+### Loading/Error handling
+- **Loading:** `FullPageSpinner` with "Loading..." or "Redirecting..."
+- **Error (401/403):** Redirect to /auth
+- **Error (5xx/network):** Error card with Retry button

--- a/amplify/data/handlers/profile/createMyProfile.js
+++ b/amplify/data/handlers/profile/createMyProfile.js
@@ -15,6 +15,14 @@ export function request(ctx) {
     subscriptionStatus: "FREE",
     createdAt: now,
     updatedAt: now,
+    activePracticeIds: [],
+    activePracticeSkById: {},
+    todayFocusPracticeId: null,
+    latestAssessmentId: null,
+    focusPillar: null,
+    returnCounters: {},
+    practiceCounters: {},
+    milestonesAchieved: [],
   };
 
   const req = ddb.put({ key, item });

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -15,6 +15,15 @@ const schema = a.schema({
     subscriptionStatus: a.string().required(), // FREE | PAID
     createdAt: a.string().required(),
     updatedAt: a.string().required(),
+    // Canon defaults (db-schema); optional for backwards compat with existing profiles
+    activePracticeIds: a.string().array(),
+    activePracticeSkById: a.json(),
+    todayFocusPracticeId: a.string(),
+    latestAssessmentId: a.string(),
+    focusPillar: a.string(),
+    returnCounters: a.json(),
+    practiceCounters: a.json(),
+    milestonesAchieved: a.string().array(),
   }),
 
   /**

--- a/app/api/assessment/latest/route.ts
+++ b/app/api/assessment/latest/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from "next/server";
 import { createDynamoClient } from "@/utils/dynamoClient";
-import {
-  getUserId,
-  isUnauthorizedError,
-  unauthorizedResponse,
-} from "@/utils/authServer";
+import { withAuth } from "@/utils/authServer";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -22,9 +18,7 @@ type AssessmentItem = {
 };
 
 export async function GET() {
-  try {
-    const user = await getUserId();
-
+  return withAuth(undefined, async (user) => {
     const client = createDynamoClient();
     const pk = `USER#${user.userId}`;
     const profile = await client.getItem<ProfileItem>({
@@ -52,11 +46,5 @@ export async function GET() {
     }
 
     return NextResponse.json(assessment, { status: 200 });
-  } catch (error) {
-    if (isUnauthorizedError(error)) {
-      return unauthorizedResponse();
-    }
-
-    return unauthorizedResponse();
-  }
+  });
 }

--- a/app/api/assessment/route.ts
+++ b/app/api/assessment/route.ts
@@ -7,19 +7,13 @@ import {
   assessmentQuestionsById,
 } from "@/lib/assessment/questions";
 import { computeScores, pickFocusPillar } from "../../../lib/assessment/scoring";
-import {
-  getUserId,
-  isUnauthorizedError,
-  unauthorizedResponse,
-} from "@/utils/authServer";
+import { withAuth } from "@/utils/authServer";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
-  try {
-    const user = await getUserId(req);
-
+  return withAuth(req, async (user) => {
     const body = (await req.json()) as {
       answers?: Record<string, boolean>;
     };
@@ -92,12 +86,5 @@ export async function POST(req: Request) {
       { assessmentId, focusPillar, scoresByPillar },
       { status: 200 }
     );
-  } catch (error) {
-    if (isUnauthorizedError(error)) {
-      return unauthorizedResponse();
-    }
-
-    // Preserve existing behavior for now (including tests): treat internal failures as unauthorized.
-    return unauthorizedResponse();
-  }
+  });
 }

--- a/app/api/dev/subscription/route.ts
+++ b/app/api/dev/subscription/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDataClient } from "@/utils/dataServerClient";
-import {
-  getUserId,
-  isUnauthorizedError,
-  unauthorizedResponse,
-} from "@/utils/authServer";
+import { withAuth } from "@/utils/authServer";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -32,21 +28,12 @@ export async function POST(req: Request) {
     );
   }
 
-  try {
-    // 1) Prove what identity the SERVER sees (canonical helper)
-    const auth = await getUserId(req);
-
+  return withAuth(req, async (auth) => {
     const client = getDataClient();
-
-    // 2) Read BEFORE
     const before = await client.queries.getMyProfile();
-
-    // 3) Mutate
     const mutation = await client.mutations.setMySubscriptionStatus({
       subscriptionStatus: body.subscriptionStatus,
     });
-
-    // 4) Read AFTER
     const after = await client.queries.getMyProfile();
 
     return NextResponse.json(
@@ -60,11 +47,5 @@ export async function POST(req: Request) {
       },
       { status: 200, headers: resHeaders }
     );
-  } catch (error) {
-    if (isUnauthorizedError(error)) {
-      return unauthorizedResponse();
-    }
-
-    return unauthorizedResponse();
-  }
+  });
 }

--- a/app/api/dev/whoami/route.ts
+++ b/app/api/dev/whoami/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getUserId, isUnauthorizedError, unauthorizedResponse } from "@/utils/authServer";
+import { withAuth } from "@/utils/authServer";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -12,22 +12,8 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Not found" }, { status: 404, headers: resHeaders });
   }
 
-  try {
-    const user = await getUserId(req);
-
-    return NextResponse.json(
-      {
-        ok: true,
-        user,
-      },
-      { status: 200, headers: resHeaders },
-    );
-  } catch (error) {
-    if (isUnauthorizedError(error)) {
-      return unauthorizedResponse();
-    }
-
-    return unauthorizedResponse();
-  }
+  return withAuth(req, async (user) =>
+    NextResponse.json({ ok: true, user }, { status: 200, headers: resHeaders })
+  );
 }
 

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,61 +1,52 @@
 import { NextResponse } from "next/server";
 
 import { getDataClient } from "@/utils/dataServerClient";
-import {
-  getUserId,
-  isUnauthorizedError,
-  unauthorizedResponse,
-} from "@/utils/authServer";
+import { withAuth } from "@/utils/authServer";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
-  try {
-    // 1) Server-verified identity (canonical helper)
-    const user = await getUserId(req);
-
+  return withAuth(req, async () => {
     const client = getDataClient();
 
-    // 2) Read profile
+    // 1) Read PROFILE (PK=USER#id, SK=PROFILE)
     const read1 = await client.queries.getMyProfile();
     if (read1.errors?.length) {
-      const res = NextResponse.json({ error: read1.errors }, { status: 500 });
+      const res = NextResponse.json(
+        { ok: false, error: { code: "INTERNAL_ERROR", message: "Failed to read profile" } },
+        { status: 500 }
+      );
       res.headers.set("Cache-Control", "no-store");
       return res;
     }
 
     if (read1.data) {
-      const res = NextResponse.json({ user, profile: read1.data }, { status: 200 });
+      const res = NextResponse.json({ ok: true, data: read1.data }, { status: 200 });
       res.headers.set("Cache-Control", "no-store");
       return res;
     }
 
-    // 3) Create profile if missing
+    // 2) If missing, create default PROFILE (idempotent; does not overwrite)
     const created = await client.mutations.createMyProfile();
     if (created.errors?.length) {
-      // handle race/conditional by re-reading once
+      // Race: another request created it; re-read
       const read2 = await client.queries.getMyProfile();
-      if (read2.errors?.length) {
-        const res = NextResponse.json({ error: read2.errors }, { status: 500 });
+      if (read2.errors?.length || !read2.data) {
+        const res = NextResponse.json(
+          { ok: false, error: { code: "INTERNAL_ERROR", message: "Failed to create or read profile" } },
+          { status: 500 }
+        );
         res.headers.set("Cache-Control", "no-store");
         return res;
       }
-
-      const res = NextResponse.json({ user, profile: read2.data }, { status: 200 });
+      const res = NextResponse.json({ ok: true, data: read2.data }, { status: 200 });
       res.headers.set("Cache-Control", "no-store");
       return res;
     }
 
-    const res = NextResponse.json({ user, profile: created.data }, { status: 200 });
+    const res = NextResponse.json({ ok: true, data: created.data }, { status: 200 });
     res.headers.set("Cache-Control", "no-store");
     return res;
-  } catch (error) {
-    if (isUnauthorizedError(error)) {
-      return unauthorizedResponse();
-    }
-
-    // Preserve existing behavior for now: treat unexpected errors as unauthorized.
-    return unauthorizedResponse();
-  }
+  });
 }

--- a/components/AppChrome.tsx
+++ b/components/AppChrome.tsx
@@ -4,6 +4,7 @@ import { type ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import { useAuthenticator } from "@aws-amplify/ui-react";
 import { AppShell } from "@/components/layout";
+import { ProfileProvider } from "@/contexts/ProfileContext";
 
 function shouldUseAppShell(pathname: string | null) {
   if (!pathname) return true;
@@ -30,9 +31,13 @@ export default function AppChrome({ children }: { children: ReactNode }) {
     }
   }
 
-  if (!shouldUseAppShell(pathname)) {
-    return <>{children}</>;
-  }
-
-  return <AppShell onSignOut={handleSignOut}>{children}</AppShell>;
+  return (
+    <ProfileProvider>
+      {!shouldUseAppShell(pathname) ? (
+        <>{children}</>
+      ) : (
+        <AppShell onSignOut={handleSignOut}>{children}</AppShell>
+      )}
+    </ProfileProvider>
+  );
 }

--- a/components/AuthenticatorWrapper.tsx
+++ b/components/AuthenticatorWrapper.tsx
@@ -2,8 +2,26 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { Authenticator } from "@aws-amplify/ui-react";
+import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react";
 import { ensureAmplifyConfigured } from "@/lib/amplifyClient";
+
+function SignInFooter() {
+  const { toForgotPassword } = useAuthenticator();
+  return (
+    <div className="mt-3 flex flex-col items-center gap-2">
+      <button
+        type="button"
+        onClick={toForgotPassword}
+        className="text-xs text-primary hover:text-primary/80 font-medium"
+      >
+        Forgot password?
+      </button>
+      <p className="text-xs text-muted-foreground">
+        We&apos;ll never share your data.
+      </p>
+    </div>
+  );
+}
 
 function AuthRedirect() {
   const router = useRouter();
@@ -63,11 +81,7 @@ export default function AuthenticatorWrapper() {
             }}
             components={{
               SignIn: {
-                Footer: () => (
-                  <p className="mt-3 text-center text-xs text-muted-foreground">
-                    We’ll never share your data.
-                  </p>
-                ),
+                Footer: SignInFooter,
               },
             }}
           >

--- a/components/DecideRouteClient.tsx
+++ b/components/DecideRouteClient.tsx
@@ -1,62 +1,62 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { fetchMe } from "@/lib/apiClient";
+import { useAuthenticator } from "@aws-amplify/ui-react";
 import { decideRoute, type ProfileForRouting } from "@/lib/decideRoute";
+import { useProfile } from "@/contexts/ProfileContext";
 import FullPageSpinner from "@/components/FullPageSpinner";
 import { Button } from "@/components/ui";
 
-type Status = "loading" | "error";
-
 export default function DecideRouteClient() {
   const router = useRouter();
-  const [status, setStatus] = useState<Status>("loading");
-
-  const run = useCallback(async () => {
-    setStatus("loading");
-
-    try {
-      const { status: httpStatus, data } = await fetchMe<ProfileForRouting>();
-
-      if (httpStatus === 401 || httpStatus === 403) {
-        router.replace("/auth");
-        return;
-      }
-
-      if (!data?.profile) {
-        setStatus("error");
-        return;
-      }
-
-      const next = decideRoute(data.profile);
-      router.replace(next);
-    } catch {
-      setStatus("error");
-    }
-  }, [router]);
+  const { authStatus } = useAuthenticator((context) => [context.authStatus]);
+  const { profile, loading, error, refetch } = useProfile();
 
   useEffect(() => {
-    run();
-  }, [run]);
+    if (authStatus === "unauthenticated") {
+      router.replace("/auth");
+      return;
+    }
 
-  if (status === "loading") {
+    if (error?.status === 401 || error?.status === 403) {
+      router.replace("/auth");
+      return;
+    }
+
+    if (loading || !profile) return;
+
+    if (error) return;
+
+    const next = decideRoute(profile as ProfileForRouting);
+    router.replace(next);
+  }, [authStatus, loading, profile, error, router]);
+
+  if (authStatus === "unauthenticated") {
+    return <FullPageSpinner label="Redirecting..." />;
+  }
+
+  if (loading) {
     return <FullPageSpinner label="Loading..." />;
   }
 
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-muted/40">
-      <div className="rounded-xl border border-border bg-card p-6 text-center shadow-sm max-w-sm">
-        <div className="text-base font-semibold text-foreground">
-          Something went wrong
-        </div>
-        <p className="mt-2 text-sm text-muted-foreground">
-          We couldn’t load your profile. Please try again.
-        </p>
-        <div className="mt-4">
-          <Button onClick={run}>Retry</Button>
+  if (error && error.status !== 401 && error.status !== 403) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-muted/40">
+        <div className="rounded-xl border border-border bg-card p-6 text-center shadow-sm max-w-sm">
+          <div className="text-base font-semibold text-foreground">
+            Something went wrong
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            We couldn&apos;t load your profile. Please try again.
+          </p>
+          <div className="mt-4">
+            <Button onClick={refetch}>Retry</Button>
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  }
+
+  return <FullPageSpinner label="Redirecting..." />;
 }

--- a/components/DevSubscriptionToggle.tsx
+++ b/components/DevSubscriptionToggle.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { useProfile } from "@/contexts/ProfileContext";
+import { Button } from "@/components/ui";
+
+/**
+ * Dev-only control to toggle subscriptionStatus for testing paid flows.
+ * Renders only when NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true (e.g. in .env.local).
+ */
+export function DevSubscriptionToggle() {
+  if (process.env.NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION !== "true") return null;
+
+  const { refetch } = useProfile();
+  const [loading, setLoading] = useState(false);
+
+  async function setStatus(status: "FREE" | "PAID") {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/dev/subscription", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ subscriptionStatus: status }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        toast.error("Failed to update", {
+          description: data?.error || `HTTP ${res.status}`,
+        });
+        return;
+      }
+
+      await refetch();
+      toast.success(`Set to ${status === "PAID" ? "Premium" : "Free"}`);
+    } catch (err) {
+      toast.error("Failed to update", {
+        description: err instanceof Error ? err.message : "Network error",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1" title="Dev: toggle subscription">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setStatus("FREE")}
+        disabled={loading}
+        className="text-xs text-muted-foreground hover:text-foreground h-7 px-2"
+      >
+        Free
+      </Button>
+      <span className="text-muted-foreground/60 text-xs">|</span>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setStatus("PAID")}
+        disabled={loading}
+        className="text-xs text-muted-foreground hover:text-foreground h-7 px-2"
+      >
+        Paid
+      </Button>
+    </div>
+  );
+}

--- a/components/PlanBadge.tsx
+++ b/components/PlanBadge.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useProfile } from "@/contexts/ProfileContext";
+
+export function PlanBadge() {
+  const { profile, loading } = useProfile();
+
+  if (loading || !profile?.subscriptionStatus) return null;
+
+  const plan = profile.subscriptionStatus;
+  const label = plan === "PAID" ? "Premium" : "Free";
+  const variant = plan === "PAID" ? "primary" : "muted";
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+        variant === "primary"
+          ? "bg-primary/15 text-primary"
+          : "bg-muted text-muted-foreground"
+      }`}
+      aria-label={`Plan: ${label}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/components/UpgradeButton.tsx
+++ b/components/UpgradeButton.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { toast } from "sonner";
+import { useProfile } from "@/contexts/ProfileContext";
+import { Button } from "@/components/ui";
+
+/**
+ * Upgrade CTA shown only for Free plan users.
+ * Stubbed: no payments yet; shows toast on click.
+ */
+export function UpgradeButton() {
+  const { profile, loading } = useProfile();
+
+  if (loading || profile?.subscriptionStatus !== "FREE") return null;
+
+  function handleClick() {
+    toast.info("Upgrade coming soon", {
+      description: "Premium features are in development.",
+    });
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleClick}
+      className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary/50"
+    >
+      Upgrade
+    </Button>
+  );
+}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
 import { Button } from '@/components/ui'
+import { PlanBadge } from '@/components/PlanBadge'
+import { UpgradeButton } from '@/components/UpgradeButton'
+import { DevSubscriptionToggle } from '@/components/DevSubscriptionToggle'
 
 interface AppShellProps {
   children: React.ReactNode
@@ -28,6 +31,9 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
             </nav>
           </div>
           <div className="flex items-center gap-2">
+            <PlanBadge />
+            <DevSubscriptionToggle />
+            <UpgradeButton />
             <Button variant="ghost" size="sm" className="hidden sm:inline-flex">
               Account
             </Button>

--- a/contexts/ProfileContext.tsx
+++ b/contexts/ProfileContext.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { useAuthenticator } from "@aws-amplify/ui-react";
+import { fetchMe } from "@/lib/apiClient";
+
+export type Profile = {
+  userId?: string;
+  subscriptionStatus?: "FREE" | "PAID";
+  latestAssessmentId?: string | null;
+  activePracticeIds?: string[] | null;
+  todayFocusPracticeId?: string | null;
+  [key: string]: unknown;
+};
+
+type ProfileState = {
+  profile: Profile | null;
+  loading: boolean;
+  error: { status?: number; message?: string } | null;
+  refetch: () => Promise<void>;
+};
+
+const ProfileContext = createContext<ProfileState | null>(null);
+
+export function useProfile(): ProfileState {
+  const ctx = useContext(ProfileContext);
+  if (!ctx) {
+    return {
+      profile: null,
+      loading: false,
+      error: null,
+      refetch: async () => {},
+    };
+  }
+  return ctx;
+}
+
+export function ProfileProvider({ children }: { children: ReactNode }) {
+  const { authStatus } = useAuthenticator((context) => [context.authStatus]);
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<{ status?: number; message?: string } | null>(null);
+
+  const fetchProfile = useCallback(async () => {
+    if (authStatus !== "authenticated") return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { status, data } = await fetchMe<Profile>();
+
+      if (status === 401 || status === 403) {
+        setProfile(null);
+        setError({ status, message: "Unauthorized" });
+        return;
+      }
+
+      if (!data?.profile && !data?.data) {
+        setProfile(null);
+        setError({ status, message: "Failed to load profile" });
+        return;
+      }
+
+      const p = (data?.profile ?? data?.data) as Profile;
+      setProfile(p);
+      setError(null);
+    } catch (err) {
+      setProfile(null);
+      setError({
+        message: err instanceof Error ? err.message : "Failed to load profile",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [authStatus]);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  return (
+    <ProfileContext.Provider
+      value={{ profile, loading, error, refetch: fetchProfile }}
+    >
+      {children}
+    </ProfileContext.Provider>
+  );
+}

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -1,9 +1,7 @@
 export type ApiMeResponse<TProfile = unknown> = {
-  user?: {
-    userId?: string;
-    username?: string;
-  };
-  profile?: TProfile;
+  ok?: boolean;
+  data?: TProfile;
+  profile?: TProfile; // normalized for backwards compat when ok/data envelope
 };
 
 export async function fetchMe<TProfile>(): Promise<{
@@ -15,12 +13,18 @@ export async function fetchMe<TProfile>(): Promise<{
     credentials: "include",
   });
 
-  let data: ApiMeResponse<TProfile> | null = null;
+  let body: { ok?: boolean; data?: TProfile } | null = null;
   try {
-    data = (await res.json()) as ApiMeResponse<TProfile>;
+    body = (await res.json()) as { ok?: boolean; data?: TProfile };
   } catch {
-    data = null;
+    return { status: res.status, data: null };
   }
+
+  // Normalize { ok: true, data } envelope to { profile } for consumers
+  const data: ApiMeResponse<TProfile> =
+    body?.ok && body?.data !== undefined
+      ? { ok: true, data: body.data, profile: body.data }
+      : (body as ApiMeResponse<TProfile>);
 
   return { status: res.status, data };
 }

--- a/tests/unit/api/dev/subscription.post.test.ts
+++ b/tests/unit/api/dev/subscription.post.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { POST } from "@/app/api/dev/subscription/route";
+
+const getMyProfileMock = vi.fn();
+const setMySubscriptionStatusMock = vi.fn();
+
+vi.mock("@/utils/dataServerClient", () => ({
+  getDataClient: () => ({
+    queries: { getMyProfile: getMyProfileMock },
+    mutations: {
+      setMySubscriptionStatus: setMySubscriptionStatusMock,
+    },
+  }),
+}));
+
+const runWithAmplifyMock = vi.fn();
+vi.mock("@/utils/amplifyServerUtils", () => ({
+  runWithAmplifyServerContext: (opts: {
+    operation: (ctx: unknown) => Promise<{ user: { userId: string } }>;
+  }) => runWithAmplifyMock(opts),
+}));
+
+describe("POST /api/dev/subscription", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = "development";
+    getMyProfileMock.mockResolvedValue({
+      data: { subscriptionStatus: "FREE" },
+      errors: undefined,
+    });
+    setMySubscriptionStatusMock.mockResolvedValue({ data: true, errors: undefined });
+    runWithAmplifyMock.mockResolvedValue({
+      user: { userId: "usr-1", username: "test@example.com" },
+    });
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("returns 404 in production", async () => {
+    process.env.NODE_ENV = "production";
+
+    const req = new Request("http://localhost/api/dev/subscription", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ subscriptionStatus: "PAID" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("Not found");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/dev/subscription", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "invalid json",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when subscriptionStatus is not FREE or PAID", async () => {
+    const req = new Request("http://localhost/api/dev/subscription", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ subscriptionStatus: "INVALID" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("FREE or PAID");
+  });
+
+  it("updates subscription and returns 200 for valid FREE", async () => {
+    getMyProfileMock
+      .mockResolvedValueOnce({
+        data: { subscriptionStatus: "PAID" },
+        errors: undefined,
+      })
+      .mockResolvedValueOnce({
+        data: { subscriptionStatus: "FREE" },
+        errors: undefined,
+      });
+
+    const req = new Request("http://localhost/api/dev/subscription", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ subscriptionStatus: "FREE" }),
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.requested).toBe("FREE");
+    expect(setMySubscriptionStatusMock).toHaveBeenCalledWith({
+      subscriptionStatus: "FREE",
+    });
+  });
+
+  it("updates subscription and returns 200 for valid PAID", async () => {
+    getMyProfileMock
+      .mockResolvedValueOnce({
+        data: { subscriptionStatus: "FREE" },
+        errors: undefined,
+      })
+      .mockResolvedValueOnce({
+        data: { subscriptionStatus: "PAID" },
+        errors: undefined,
+      });
+
+    const req = new Request("http://localhost/api/dev/subscription", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ subscriptionStatus: "PAID" }),
+    });
+
+    const res = await POST(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.requested).toBe("PAID");
+    expect(setMySubscriptionStatusMock).toHaveBeenCalledWith({
+      subscriptionStatus: "PAID",
+    });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    runWithAmplifyMock.mockRejectedValue(new Error("Not authenticated"));
+
+    const req = new Request("http://localhost/api/dev/subscription", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ subscriptionStatus: "PAID" }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/unit/api/me.test.ts
+++ b/tests/unit/api/me.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "@/app/api/me/route";
+
+const getMyProfileMock = vi.fn();
+const createMyProfileMock = vi.fn();
+
+vi.mock("@/utils/dataServerClient", () => ({
+  getDataClient: () => ({
+    queries: { getMyProfile: getMyProfileMock },
+    mutations: { createMyProfile: createMyProfileMock },
+  }),
+}));
+
+const runWithAmplifyMock = vi.fn();
+vi.mock("@/utils/amplifyServerUtils", () => ({
+  runWithAmplifyServerContext: (opts: {
+    operation: (ctx: unknown) => Promise<{ user: { userId: string; username?: string } }>;
+  }) => runWithAmplifyMock(opts),
+}));
+
+describe("GET /api/me", () => {
+  beforeEach(() => {
+    getMyProfileMock.mockReset();
+    createMyProfileMock.mockReset();
+    runWithAmplifyMock.mockResolvedValue({
+      user: { userId: "usr-test", username: "test@example.com" },
+    });
+  });
+
+  it("returns existing profile without calling createMyProfile", async () => {
+    const existingProfile = {
+      userId: "usr-1",
+      subscriptionStatus: "FREE",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+      activePracticeIds: [],
+      latestAssessmentId: null,
+    };
+
+    getMyProfileMock.mockResolvedValue({ data: existingProfile, errors: undefined });
+
+    const req = new Request("http://localhost/api/me");
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ ok: true, data: existingProfile });
+    expect(getMyProfileMock).toHaveBeenCalledTimes(1);
+    expect(createMyProfileMock).not.toHaveBeenCalled();
+  });
+
+  it("creates profile when missing, returns it", async () => {
+    getMyProfileMock.mockResolvedValue({ data: null, errors: undefined });
+
+    const newProfile = {
+      userId: "usr-2",
+      subscriptionStatus: "FREE",
+      createdAt: "2024-01-02T00:00:00Z",
+      updatedAt: "2024-01-02T00:00:00Z",
+      activePracticeIds: [],
+      activePracticeSkById: {},
+      todayFocusPracticeId: null,
+      latestAssessmentId: null,
+      focusPillar: null,
+    };
+
+    createMyProfileMock.mockResolvedValue({ data: newProfile, errors: undefined });
+
+    const req = new Request("http://localhost/api/me");
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ ok: true, data: newProfile });
+    expect(json.data.subscriptionStatus).toBe("FREE");
+    expect(getMyProfileMock).toHaveBeenCalledTimes(1);
+    expect(createMyProfileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns same profile on second call (idempotent, no overwrite)", async () => {
+    const profile = {
+      userId: "usr-3",
+      subscriptionStatus: "FREE",
+      createdAt: "2024-01-03T00:00:00Z",
+      updatedAt: "2024-01-03T00:00:00Z",
+      activePracticeIds: [],
+      latestAssessmentId: null,
+    };
+
+    getMyProfileMock.mockResolvedValue({ data: profile, errors: undefined });
+
+    const req = new Request("http://localhost/api/me");
+    const res1 = await GET(req);
+    const json1 = await res1.json();
+    const res2 = await GET(req);
+    const json2 = await res2.json();
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(json1.data).toEqual(json2.data);
+    expect(json1.data.userId).toBe("usr-3");
+    expect(json1.data.subscriptionStatus).toBe("FREE");
+    expect(createMyProfileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    runWithAmplifyMock.mockRejectedValue(new Error("Not authenticated"));
+
+    const req = new Request("http://localhost/api/me");
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.ok).toBe(false);
+    expect(json.error?.code).toBe("UNAUTHORIZED");
+  });
+});

--- a/tests/unit/authServer.test.ts
+++ b/tests/unit/authServer.test.ts
@@ -82,4 +82,33 @@ describe("authServer", () => {
       expect(isUnauthorizedError("unauthorized")).toBe(false);
     });
   });
+
+  describe("withAuth guard", () => {
+    it("returns 401 with normalized error envelope when unauthenticated", async () => {
+      runWithAmplifyMock.mockRejectedValue(new Error("Not authenticated"));
+
+      const { withAuth } = await import("@/utils/authServer");
+      const res = await withAuth(undefined, async () =>
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+
+      expect(res.status).toBe(401);
+      const json = (await res.json()) as { ok: boolean; error: { code: string; message: string } };
+      expect(json.ok).toBe(false);
+      expect(json.error.code).toBe("UNAUTHORIZED");
+      expect(json.error.message).toBe("Authentication required");
+    });
+
+    it("invokes handler with user when authenticated", async () => {
+      runWithAmplifyMock.mockResolvedValue({
+        user: { userId: "usr-99", username: "test" },
+      });
+
+      const { withAuth } = await import("@/utils/authServer");
+      const handler = vi.fn(async () => new Response("ok", { status: 200 }));
+      await withAuth(undefined, handler);
+
+      expect(handler).toHaveBeenCalledWith({ userId: "usr-99", username: "test" });
+    });
+  });
 });

--- a/tests/unit/components/DevSubscriptionToggle.test.tsx
+++ b/tests/unit/components/DevSubscriptionToggle.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { DevSubscriptionToggle } from "@/components/DevSubscriptionToggle";
+
+const refetchMock = vi.fn();
+const useProfileMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock("@/contexts/ProfileContext", () => ({
+  useProfile: () => useProfileMock(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+describe("DevSubscriptionToggle", () => {
+  const originalEnv = process.env.NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION = "true";
+    refetchMock.mockReset();
+    refetchMock.mockResolvedValue(undefined);
+    useProfileMock.mockReturnValue({
+      profile: { subscriptionStatus: "FREE" },
+      loading: false,
+      error: null,
+      refetch: refetchMock,
+    });
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it("renders null when NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION is not true", () => {
+    process.env.NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION = "false";
+
+    const { container } = render(<DevSubscriptionToggle />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders Free and Paid buttons when flag is true", () => {
+    render(<DevSubscriptionToggle />);
+
+    expect(screen.getByRole("button", { name: "Free" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Paid" })).toBeInTheDocument();
+  });
+
+  it("calls fetch and refetch when Paid is clicked", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<DevSubscriptionToggle />);
+    fireEvent.click(screen.getByRole("button", { name: "Paid" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/dev/subscription", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ subscriptionStatus: "PAID" }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(refetchMock).toHaveBeenCalled();
+    });
+
+    expect(toastSuccessMock).toHaveBeenCalledWith("Set to Premium");
+  });
+
+  it("calls fetch and refetch when Free is clicked", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<DevSubscriptionToggle />);
+    fireEvent.click(screen.getByRole("button", { name: "Free" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/dev/subscription",
+        expect.objectContaining({
+          body: JSON.stringify({ subscriptionStatus: "FREE" }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(refetchMock).toHaveBeenCalled();
+    });
+
+    expect(toastSuccessMock).toHaveBeenCalledWith("Set to Free");
+  });
+
+  it("shows error toast when fetch fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "Server error" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<DevSubscriptionToggle />);
+    fireEvent.click(screen.getByRole("button", { name: "Paid" }));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to update", {
+        description: expect.any(String),
+      });
+    });
+
+    expect(refetchMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/tests/unit/components/PlanBadge.test.tsx
+++ b/tests/unit/components/PlanBadge.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PlanBadge } from "@/components/PlanBadge";
+
+const useProfileMock = vi.fn();
+
+vi.mock("@/contexts/ProfileContext", () => ({
+  useProfile: () => useProfileMock(),
+}));
+
+describe("PlanBadge", () => {
+  beforeEach(() => {
+    useProfileMock.mockReset();
+  });
+
+  it("renders null when loading", () => {
+    useProfileMock.mockReturnValue({
+      profile: null,
+      loading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<PlanBadge />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders null when no profile", () => {
+    useProfileMock.mockReturnValue({
+      profile: null,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<PlanBadge />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders null when profile has no subscriptionStatus", () => {
+    useProfileMock.mockReturnValue({
+      profile: { userId: "u1" },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<PlanBadge />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders Free when subscriptionStatus is FREE", () => {
+    useProfileMock.mockReturnValue({
+      profile: { subscriptionStatus: "FREE" },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<PlanBadge />);
+    expect(screen.getByText("Free")).toBeInTheDocument();
+    expect(screen.getByLabelText("Plan: Free")).toBeInTheDocument();
+  });
+
+  it("renders Premium when subscriptionStatus is PAID", () => {
+    useProfileMock.mockReturnValue({
+      profile: { subscriptionStatus: "PAID" },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<PlanBadge />);
+    expect(screen.getByText("Premium")).toBeInTheDocument();
+    expect(screen.getByLabelText("Plan: Premium")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/UpgradeButton.test.tsx
+++ b/tests/unit/components/UpgradeButton.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { UpgradeButton } from "@/components/UpgradeButton";
+
+const useProfileMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock("@/contexts/ProfileContext", () => ({
+  useProfile: () => useProfileMock(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: (...args: unknown[]) => toastMock(...args),
+  },
+}));
+
+describe("UpgradeButton", () => {
+  beforeEach(() => {
+    useProfileMock.mockReset();
+    toastMock.mockReset();
+  });
+
+  it("renders null when loading", () => {
+    useProfileMock.mockReturnValue({
+      profile: null,
+      loading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<UpgradeButton />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders null when subscriptionStatus is PAID", () => {
+    useProfileMock.mockReturnValue({
+      profile: { subscriptionStatus: "PAID" },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { container } = render(<UpgradeButton />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders Upgrade button when subscriptionStatus is FREE", () => {
+    useProfileMock.mockReturnValue({
+      profile: { subscriptionStatus: "FREE" },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<UpgradeButton />);
+    expect(screen.getByRole("button", { name: "Upgrade" })).toBeInTheDocument();
+  });
+
+  it("calls toast.info on click when FREE", () => {
+    useProfileMock.mockReturnValue({
+      profile: { subscriptionStatus: "FREE" },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<UpgradeButton />);
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+
+    expect(toastMock).toHaveBeenCalledWith("Upgrade coming soon", {
+      description: "Premium features are in development.",
+    });
+  });
+});

--- a/tests/unit/contexts/ProfileContext.test.tsx
+++ b/tests/unit/contexts/ProfileContext.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { ProfileProvider, useProfile } from "@/contexts/ProfileContext";
+
+function Consumer() {
+  const { profile, loading, error, refetch } = useProfile();
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="profile">{profile ? JSON.stringify(profile) : "null"}</span>
+      <span data-testid="error">{error ? JSON.stringify(error) : "null"}</span>
+      <button onClick={() => refetch()}>Refetch</button>
+    </div>
+  );
+}
+
+const fetchMeMock = vi.fn();
+
+vi.mock("@aws-amplify/ui-react", () => ({
+  useAuthenticator: () => ({ authStatus: "authenticated" }),
+}));
+
+vi.mock("@/lib/apiClient", () => ({
+  fetchMe: (...args: unknown[]) => fetchMeMock(...args),
+}));
+
+describe("ProfileContext", () => {
+  beforeEach(() => {
+    fetchMeMock.mockReset();
+  });
+
+  it("provides loading then profile when fetch succeeds", async () => {
+    const mockProfile = {
+      userId: "u1",
+      subscriptionStatus: "FREE",
+      latestAssessmentId: null,
+    };
+
+    fetchMeMock.mockResolvedValue({
+      status: 200,
+      data: { ok: true, data: mockProfile, profile: mockProfile },
+    });
+
+    render(
+      <ProfileProvider>
+        <Consumer />
+      </ProfileProvider>
+    );
+
+    expect(screen.getByTestId("loading")).toHaveTextContent("true");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    expect(screen.getByTestId("profile")).toHaveTextContent("FREE");
+    expect(fetchMeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("provides error when fetch returns 401", async () => {
+    fetchMeMock.mockResolvedValue({
+      status: 401,
+      data: null,
+    });
+
+    render(
+      <ProfileProvider>
+        <Consumer />
+      </ProfileProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    expect(screen.getByTestId("profile")).toHaveTextContent("null");
+    expect(screen.getByTestId("error")).not.toHaveTextContent("null");
+  });
+
+  it("refetch updates profile", async () => {
+    const profile1 = { userId: "u1", subscriptionStatus: "FREE" };
+    const profile2 = { userId: "u1", subscriptionStatus: "PAID" };
+
+    fetchMeMock
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { ok: true, data: profile1, profile: profile1 },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { ok: true, data: profile2, profile: profile2 },
+      });
+
+    render(
+      <ProfileProvider>
+        <Consumer />
+      </ProfileProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("profile")).toHaveTextContent("FREE");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refetch" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("profile")).toHaveTextContent("PAID");
+    });
+
+    expect(fetchMeMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/decideRouteClient.test.tsx
+++ b/tests/unit/decideRouteClient.test.tsx
@@ -1,39 +1,37 @@
-import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import DecideRouteClient from "@/components/DecideRouteClient";
 
 const replaceMock = vi.fn();
+const useProfileMock = vi.fn();
+let mockAuthStatus = "authenticated";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: replaceMock }),
 }));
 
-type MockResponse = {
-  status: number;
-  json: () => Promise<unknown>;
-};
+vi.mock("@aws-amplify/ui-react", () => ({
+  useAuthenticator: () => ({ authStatus: mockAuthStatus }),
+}));
 
-function makeResponse(status: number, body: unknown): MockResponse {
-  return {
-    status,
-    json: async () => body,
-  };
-}
+vi.mock("@/contexts/ProfileContext", () => ({
+  useProfile: () => useProfileMock(),
+}));
 
 describe("DecideRouteClient", () => {
   beforeEach(() => {
     replaceMock.mockReset();
-    vi.stubGlobal("fetch", vi.fn());
+    useProfileMock.mockReset();
+    mockAuthStatus = "authenticated";
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("shows loading while fetch is pending", () => {
-    (global.fetch as unknown as Mock).mockImplementation(
-      () => new Promise(() => {})
-    );
+  it("shows loading while profile is pending", () => {
+    useProfileMock.mockReturnValue({
+      profile: null,
+      loading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
 
     render(<DecideRouteClient />);
 
@@ -42,15 +40,16 @@ describe("DecideRouteClient", () => {
   });
 
   it("redirects to /assessment when no assessment", async () => {
-    (global.fetch as unknown as Mock).mockResolvedValue(
-      makeResponse(200, {
-        profile: {
-          latestAssessmentId: null,
-          activePracticeIds: ["p1"],
-          todayFocusPracticeId: "p1",
-        },
-      })
-    );
+    useProfileMock.mockReturnValue({
+      profile: {
+        latestAssessmentId: null,
+        activePracticeIds: ["p1"],
+        todayFocusPracticeId: "p1",
+      },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
 
     render(<DecideRouteClient />);
 
@@ -60,15 +59,16 @@ describe("DecideRouteClient", () => {
   });
 
   it("redirects to /results when no active practices", async () => {
-    (global.fetch as unknown as Mock).mockResolvedValue(
-      makeResponse(200, {
-        profile: {
-          latestAssessmentId: "a1",
-          activePracticeIds: [],
-          todayFocusPracticeId: "p1",
-        },
-      })
-    );
+    useProfileMock.mockReturnValue({
+      profile: {
+        latestAssessmentId: "a1",
+        activePracticeIds: [],
+        todayFocusPracticeId: "p1",
+      },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
 
     render(<DecideRouteClient />);
 
@@ -78,15 +78,16 @@ describe("DecideRouteClient", () => {
   });
 
   it("redirects to /practices when no focus practice", async () => {
-    (global.fetch as unknown as Mock).mockResolvedValue(
-      makeResponse(200, {
-        profile: {
-          latestAssessmentId: "a1",
-          activePracticeIds: ["p1"],
-          todayFocusPracticeId: null,
-        },
-      })
-    );
+    useProfileMock.mockReturnValue({
+      profile: {
+        latestAssessmentId: "a1",
+        activePracticeIds: ["p1"],
+        todayFocusPracticeId: null,
+      },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
 
     render(<DecideRouteClient />);
 
@@ -96,15 +97,16 @@ describe("DecideRouteClient", () => {
   });
 
   it("redirects to /today when focus practice exists", async () => {
-    (global.fetch as unknown as Mock).mockResolvedValue(
-      makeResponse(200, {
-        profile: {
-          latestAssessmentId: "a1",
-          activePracticeIds: ["p1"],
-          todayFocusPracticeId: "p1",
-        },
-      })
-    );
+    useProfileMock.mockReturnValue({
+      profile: {
+        latestAssessmentId: "a1",
+        activePracticeIds: ["p1"],
+        todayFocusPracticeId: "p1",
+      },
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
 
     render(<DecideRouteClient />);
 
@@ -113,10 +115,29 @@ describe("DecideRouteClient", () => {
     });
   });
 
-  it("redirects to /auth on 401 or 403", async () => {
-    (global.fetch as unknown as Mock).mockResolvedValue(
-      makeResponse(401, { error: "Unauthorized" })
-    );
+  it("redirects to /auth when unauthenticated", async () => {
+    mockAuthStatus = "unauthenticated";
+    useProfileMock.mockReturnValue({
+      profile: null,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<DecideRouteClient />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/auth");
+    });
+  });
+
+  it("redirects to /auth on 401 or 403 error", async () => {
+    useProfileMock.mockReturnValue({
+      profile: null,
+      loading: false,
+      error: { status: 401 },
+      refetch: vi.fn(),
+    });
 
     render(<DecideRouteClient />);
 
@@ -126,30 +147,17 @@ describe("DecideRouteClient", () => {
   });
 
   it("shows error state on 500 or network error", async () => {
-    (global.fetch as unknown as Mock).mockResolvedValue(
-      makeResponse(500, { error: "Server error" })
-    );
+    useProfileMock.mockReturnValue({
+      profile: null,
+      loading: false,
+      error: { status: 500, message: "Server error" },
+      refetch: vi.fn(),
+    });
 
     render(<DecideRouteClient />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
-    });
-
-    expect(replaceMock).not.toHaveBeenCalled();
-  });
-
-  it("shows error state on network failure", async () => {
-    (global.fetch as unknown as Mock).mockRejectedValue(new Error("Network"));
-
-    render(<DecideRouteClient />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
-    });
-
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
     expect(replaceMock).not.toHaveBeenCalled();
   });
 });

--- a/utils/authServer.ts
+++ b/utils/authServer.ts
@@ -61,3 +61,20 @@ export function isUnauthorizedError(error: unknown): error is UnauthorizedError 
   return error instanceof UnauthorizedError;
 }
 
+/**
+ * Guard wrapper for protected API handlers.
+ * Resolves user or returns standardized 401 response.
+ * Use for all routes that require authentication.
+ */
+export async function withAuth(
+  req: Request | undefined,
+  handler: (user: AuthUser) => Promise<Response>
+): Promise<Response> {
+  try {
+    const user = await getUserId(req);
+    return await handler(user);
+  } catch (error) {
+    return unauthorizedResponse();
+  }
+}
+


### PR DESCRIPTION
- PROFILE: full default shape (subscriptionStatus, activePracticeIds, etc.)
- ProfileContext: fetch /api/me after auth, store in client state
- PlanBadge + UpgradeButton: render plan status in header
- DevSubscriptionToggle: dev-only Free/Paid toggle with refetch
- Forgot password link in Sign In form
- Unit tests for PlanBadge, UpgradeButton, DevSubscriptionToggle, ProfileContext, /api/me, /api/dev/subscription
- subscriptionStatus casing: FREE/PAID across canon docs

Made-with: Cursor