### PR TITLE
Epic #5: Trial activation engine

### DIFF
--- a/app/api/practice/route.ts
+++ b/app/api/practice/route.ts
@@ -1,0 +1,190 @@
+import { NextResponse } from 'next/server'
+import { createDynamoClient } from '@/utils/dynamoClient'
+import { withAuth } from '@/utils/authServer'
+import { practicesById } from '@/lib/practices/library'
+import {
+  TRIAL_DURATION_DAYS,
+  MAX_CONCURRENT_TRIALS,
+  isTrialActive,
+  isTrialExpired,
+  checkActiveCap,
+  makeTrialSK,
+  makeUPracticeSK,
+  type TrialItem,
+  type ProfileData,
+} from '@/lib/practices/trial'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type Body = {
+  mode: 'startTrial' | 'promoteTrial' | 'discardTrial'
+  practiceId: string
+}
+
+export async function POST(req: Request) {
+  return withAuth(req, async (user) => {
+    let body: Body
+    try {
+      body = (await req.json()) as Body
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+    }
+
+    const { mode, practiceId } = body ?? {}
+    if (!mode || !practiceId) {
+      return NextResponse.json({ error: 'mode and practiceId required' }, { status: 400 })
+    }
+
+    const pk = `USER#${user.userId}`
+    const client = createDynamoClient()
+
+    // ── startTrial ──────────────────────────────────────────────────────────
+    if (mode === 'startTrial') {
+      const practice = practicesById.get(practiceId)
+      if (!practice) {
+        return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
+      }
+
+      const [profile, trials] = await Promise.all([
+        client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
+        client.query<TrialItem>({
+          KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+          ExpressionAttributeValues: { ':pk': pk, ':prefix': 'TRIAL#' },
+        }),
+      ])
+
+      const activePracticeIds = profile?.activePracticeIds ?? []
+
+      if (activePracticeIds.includes(practiceId)) {
+        return NextResponse.json({ error: 'ALREADY_ACTIVE' }, { status: 409 })
+      }
+
+      if (trials.find((t) => t.practiceId === practiceId && isTrialActive(t))) {
+        return NextResponse.json({ error: 'ALREADY_TRIALING' }, { status: 409 })
+      }
+
+      const activeTrials = trials.filter(isTrialActive)
+      if (activeTrials.length >= MAX_CONCURRENT_TRIALS) {
+        return NextResponse.json(
+          { error: 'TRIAL_LIMIT_REACHED', max: MAX_CONCURRENT_TRIALS },
+          { status: 409 }
+        )
+      }
+
+      const startedAt = new Date().toISOString()
+      const expiresAt = new Date(
+        Date.now() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000
+      ).toISOString()
+
+      const trial: TrialItem = {
+        PK: pk,
+        SK: makeTrialSK(startedAt, practiceId),
+        practiceId,
+        pillar: practice.pillar,
+        startedAt,
+        status: 'trial',
+        expiresAt,
+      }
+
+      await client.putItem(trial)
+      return NextResponse.json({ trial }, { status: 201 })
+    }
+
+    // ── promoteTrial ────────────────────────────────────────────────────────
+    if (mode === 'promoteTrial') {
+      const practice = practicesById.get(practiceId)
+      if (!practice) {
+        return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
+      }
+
+      const [profile, trials] = await Promise.all([
+        client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
+        client.query<TrialItem>({
+          KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+          ExpressionAttributeValues: { ':pk': pk, ':prefix': 'TRIAL#' },
+        }),
+      ])
+
+      const activeTrial = trials.find(
+        (t) => t.practiceId === practiceId && t.status === 'trial'
+      )
+      if (!activeTrial) {
+        return NextResponse.json({ error: 'TRIAL_NOT_FOUND' }, { status: 404 })
+      }
+      if (isTrialExpired(activeTrial)) {
+        return NextResponse.json({ error: 'TRIAL_EXPIRED' }, { status: 409 })
+      }
+
+      const activePracticeIds = profile?.activePracticeIds ?? []
+      const activePracticeSkById = profile?.activePracticeSkById ?? {}
+      const capCheck = checkActiveCap(profile?.subscriptionStatus, activePracticeIds.length)
+      if (!capCheck.allowed) {
+        return NextResponse.json(
+          { error: capCheck.reason, cap: capCheck.cap },
+          { status: 409 }
+        )
+      }
+
+      const addedAt = new Date().toISOString()
+      const upracticeSK = makeUPracticeSK(practiceId)
+      const resolvedAt = addedAt
+
+      await Promise.all([
+        client.putItem({ PK: pk, SK: upracticeSK, practiceId, pillar: practice.pillar, addedAt }),
+        client.updateItem({
+          Key: { PK: pk, SK: 'PROFILE' },
+          UpdateExpression: 'SET activePracticeIds = :ids, activePracticeSkById = :skById',
+          ExpressionAttributeValues: {
+            ':ids': [...activePracticeIds, practiceId],
+            ':skById': { ...activePracticeSkById, [practiceId]: upracticeSK },
+          },
+        }),
+        client.updateItem({
+          Key: { PK: pk, SK: activeTrial.SK },
+          UpdateExpression: 'SET #s = :status, resolvedAt = :resolvedAt',
+          ExpressionAttributeNames: { '#s': 'status' },
+          ExpressionAttributeValues: { ':status': 'promoted', ':resolvedAt': resolvedAt },
+        }),
+      ])
+
+      return NextResponse.json(
+        {
+          practiceId,
+          warning: capCheck.allowed && capCheck.warning ? capCheck.warning : undefined,
+          remaining: capCheck.allowed ? capCheck.remaining : undefined,
+        },
+        { status: 200 }
+      )
+    }
+
+    // ── discardTrial ────────────────────────────────────────────────────────
+    if (mode === 'discardTrial') {
+      const trials = await client.query<TrialItem>({
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+        ExpressionAttributeValues: { ':pk': pk, ':prefix': 'TRIAL#' },
+      })
+
+      const activeTrial = trials.find(
+        (t) => t.practiceId === practiceId && t.status === 'trial'
+      )
+      if (!activeTrial) {
+        return NextResponse.json({ error: 'TRIAL_NOT_FOUND' }, { status: 404 })
+      }
+
+      await client.updateItem({
+        Key: { PK: pk, SK: activeTrial.SK },
+        UpdateExpression: 'SET #s = :status, resolvedAt = :resolvedAt',
+        ExpressionAttributeNames: { '#s': 'status' },
+        ExpressionAttributeValues: {
+          ':status': 'discarded',
+          ':resolvedAt': new Date().toISOString(),
+        },
+      })
+
+      return NextResponse.json({ ok: true }, { status: 200 })
+    }
+
+    return NextResponse.json({ error: 'Unknown mode' }, { status: 400 })
+  })
+}

--- a/app/api/practices/active/route.ts
+++ b/app/api/practices/active/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server'
+import { createDynamoClient } from '@/utils/dynamoClient'
+import { withAuth } from '@/utils/authServer'
+import { practicesById } from '@/lib/practices/library'
+import {
+  isTrialActive,
+  isTrialExpired,
+  getTrialDaysRemaining,
+  type TrialItem,
+  type ProfileData,
+} from '@/lib/practices/trial'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type UPracticeItem = {
+  practiceId: string
+  pillar: string
+  addedAt: string
+}
+
+export async function GET() {
+  return withAuth(undefined, async (user) => {
+    const pk = `USER#${user.userId}`
+    const client = createDynamoClient()
+
+    const [profile, trials, upractices] = await Promise.all([
+      client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
+      client.query<TrialItem>({
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+        ExpressionAttributeValues: { ':pk': pk, ':prefix': 'TRIAL#' },
+      }),
+      client.query<UPracticeItem>({
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+        ExpressionAttributeValues: { ':pk': pk, ':prefix': 'UPRACTICE#' },
+      }),
+    ])
+
+    // Enrich active practices with library data
+    const activePractices = upractices
+      .map((up) => {
+        const lib = practicesById.get(up.practiceId)
+        if (!lib) return null
+        return { ...lib, addedAt: up.addedAt }
+      })
+      .filter(Boolean)
+
+    // Enrich active trials with library data and computed fields
+    const activeTrial = trials
+      .filter((t) => t.status === 'trial')
+      .map((t) => {
+        const lib = practicesById.get(t.practiceId)
+        if (!lib) return null
+        const expired = isTrialExpired(t)
+        return {
+          ...lib,
+          trialSK: t.SK,
+          startedAt: t.startedAt,
+          expiresAt: t.expiresAt,
+          status: expired ? 'expired' : 'trial',
+          daysRemaining: expired ? 0 : getTrialDaysRemaining(t),
+          active: isTrialActive(t),
+        }
+      })
+      .filter(Boolean)
+
+    return NextResponse.json(
+      {
+        activePractices,
+        trials: activeTrial,
+        subscriptionStatus: profile?.subscriptionStatus ?? 'FREE',
+      },
+      { status: 200 }
+    )
+  })
+}

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -1,20 +1,44 @@
 'use client';
 
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { StandardPage } from '@/components/layout';
-import { Card, Button, EmptyState } from '@/components/ui';
+import { Card, Button, EmptyState, Loading, ErrorState } from '@/components/ui';
 import { pillarColors } from '@/lib/design/pillarColors';
-import {
-  MOCK_ACTIVE_PRACTICES,
-  MOCK_TRIALS,
-  MOCK_PILLAR_LABELS,
-} from '@/lib/mockState';
+import { MOCK_PILLAR_LABELS } from '@/lib/mockState';
 import type { Pillar } from '@/lib/assessment/pillars';
+
+type ActivePractice = {
+  id: string
+  pillar: Pillar
+  title: string
+  description: string
+  addedAt: string
+}
+
+type Trial = {
+  id: string
+  pillar: Pillar
+  title: string
+  description: string
+  trialSK: string
+  startedAt: string
+  expiresAt: string
+  status: 'trial' | 'expired'
+  daysRemaining: number
+  active: boolean
+}
+
+type ActiveData = {
+  activePractices: ActivePractice[]
+  trials: Trial[]
+  subscriptionStatus: string
+}
 
 function PillarBadge({ pillar }: { pillar: Pillar }) {
   return (
     <span
-      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
+      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
       style={{ backgroundColor: pillarColors[pillar] }}
     >
       {MOCK_PILLAR_LABELS[pillar]}
@@ -22,75 +46,174 @@ function PillarBadge({ pillar }: { pillar: Pillar }) {
   );
 }
 
+function TrialBadge() {
+  return (
+    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-amber-100 text-amber-800 border border-amber-300">
+      Trial
+    </span>
+  );
+}
+
 export default function PracticesPage() {
+  const [data, setData] = useState<ActiveData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({})
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(false)
+    try {
+      const res = await fetch('/api/practices/active')
+      if (!res.ok) throw new Error('Failed to load')
+      setData(await res.json())
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  async function handleAction(mode: 'promoteTrial' | 'discardTrial', practiceId: string) {
+    setActionLoading((prev) => ({ ...prev, [practiceId]: true }))
+    try {
+      const res = await fetch('/api/practice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode, practiceId }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        const msg = err.error === 'CAP_REACHED'
+          ? `You've reached your active practice limit (${err.cap}).`
+          : err.error === 'TRIAL_EXPIRED'
+          ? 'This trial has expired and can no longer be promoted.'
+          : 'Something went wrong. Please try again.'
+        alert(msg)
+        return
+      }
+      await load()
+    } finally {
+      setActionLoading((prev) => ({ ...prev, [practiceId]: false }))
+    }
+  }
+
   return (
     <StandardPage
       title="Active Practices"
       description="Manage your practices and trials."
       metaLabel="PRACTICES"
       actions={
-        <Button variant="outline" size="sm">
-          + Add practice
+        <Button variant="outline" size="sm" asChild>
+          <Link href="/results">+ Add practice</Link>
         </Button>
       }
     >
       <div className="space-y-10">
-        {/* Active practices */}
-        <section>
-          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Active</p>
-          {MOCK_ACTIVE_PRACTICES.length === 0 ? (
-            <EmptyState
-              title="No active practices"
-              text="Start a practice or promote a trial to get going."
-              action={<Button variant="outline">Browse suggestions</Button>}
-            />
-          ) : (
-            <div className="space-y-3">
-              {MOCK_ACTIVE_PRACTICES.map((p) => (
-                <Card key={p.id} variant="interactive" className="flex items-start justify-between gap-4">
-                  <div className="space-y-2 min-w-0">
-                    <PillarBadge pillar={p.pillar} />
-                    <p className="font-semibold text-foreground">{p.title}</p>
-                    <p className="text-sm text-muted-foreground">{p.description}</p>
-                  </div>
-                  <div className="flex flex-col gap-2 shrink-0">
-                    <Button size="sm" variant="outline">Set focus</Button>
-                    <Button size="sm" variant="ghost">Pause</Button>
-                    <Button size="sm" variant="ghost">Replace</Button>
-                  </div>
-                </Card>
-              ))}
-            </div>
-          )}
-        </section>
+        {loading && <Loading text="Loading your practices…" />}
 
-        {/* Trials */}
-        <section>
-          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Trials</p>
-          {MOCK_TRIALS.length === 0 ? (
-            <EmptyState
-              title="No active trials"
-              text="Try a practice for a few days before committing."
-            />
-          ) : (
-            <div className="space-y-3">
-              {MOCK_TRIALS.map((t) => (
-                <Card key={t.id} variant="interactive" className="flex items-start justify-between gap-4">
-                  <div className="space-y-2 min-w-0">
-                    <PillarBadge pillar={t.pillar} />
-                    <p className="font-semibold text-foreground">{t.title}</p>
-                    <p className="text-sm text-muted-foreground">{t.description}</p>
-                    <p className="text-xs text-muted-foreground">{t.daysLeft} days left in trial</p>
-                  </div>
-                  <div className="flex flex-col gap-2 shrink-0">
-                    <Button size="sm" variant="default">Promote</Button>
-                    <Button size="sm" variant="ghost">Discard</Button>
-                  </div>
-                </Card>
-              ))}
-            </div>
-          )}
-        </section>
+        {!loading && error && (
+          <ErrorState message="Couldn't load practices." onRetry={load} />
+        )}
+
+        {!loading && !error && data && (
+          <>
+            {/* Active practices */}
+            <section>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Active</p>
+              {data.activePractices.length === 0 ? (
+                <EmptyState
+                  title="No active practices"
+                  text="Promote a trial or pick one from your results to get started."
+                  action={
+                    <Button variant="outline" asChild>
+                      <Link href="/results">Browse suggestions</Link>
+                    </Button>
+                  }
+                />
+              ) : (
+                <div className="space-y-3">
+                  {data.activePractices.map((p) => (
+                    <Card key={p.id} variant="interactive" className="flex items-start justify-between gap-4">
+                      <div className="space-y-2 min-w-0">
+                        <PillarBadge pillar={p.pillar} />
+                        <p className="font-semibold text-foreground">{p.title}</p>
+                        <p className="text-sm text-muted-foreground">{p.description}</p>
+                      </div>
+                      <div className="flex flex-col gap-2 shrink-0">
+                        <Button size="sm" variant="outline">Set focus</Button>
+                        <Button size="sm" variant="ghost">Pause</Button>
+                      </div>
+                    </Card>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            {/* Trials */}
+            <section>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Trials</p>
+              {data.trials.length === 0 ? (
+                <EmptyState
+                  title="No active trials"
+                  text="Try a practice for 7 days before committing."
+                  action={
+                    <Button variant="outline" asChild>
+                      <Link href="/results">Find a practice</Link>
+                    </Button>
+                  }
+                />
+              ) : (
+                <div className="space-y-3">
+                  {data.trials.map((t) => (
+                    <Card key={t.id} variant="interactive" className="flex items-start justify-between gap-4">
+                      <div className="space-y-2 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <PillarBadge pillar={t.pillar} />
+                          <TrialBadge />
+                        </div>
+                        <p className="font-semibold text-foreground">{t.title}</p>
+                        <p className="text-sm text-muted-foreground">{t.description}</p>
+                        {t.active && (
+                          <p className="text-xs text-amber-700 font-medium">
+                            {t.daysRemaining === 0
+                              ? 'Expires today'
+                              : `${t.daysRemaining} day${t.daysRemaining === 1 ? '' : 's'} remaining`}
+                          </p>
+                        )}
+                        {!t.active && (
+                          <p className="text-xs text-muted-foreground">Trial expired</p>
+                        )}
+                      </div>
+                      {t.active && (
+                        <div className="flex flex-col gap-2 shrink-0">
+                          <Button
+                            size="sm"
+                            variant="default"
+                            disabled={!!actionLoading[t.id]}
+                            onClick={() => handleAction('promoteTrial', t.id)}
+                          >
+                            {actionLoading[t.id] ? '…' : 'Promote'}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            disabled={!!actionLoading[t.id]}
+                            onClick={() => handleAction('discardTrial', t.id)}
+                          >
+                            Discard
+                          </Button>
+                        </div>
+                      )}
+                    </Card>
+                  ))}
+                </div>
+              )}
+            </section>
+          </>
+        )}
 
         {/* CTA */}
         <div className="pt-2">

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { StandardPage } from '@/components/layout';
 import { Card, Button, Loading, ErrorState } from '@/components/ui';
@@ -30,10 +31,42 @@ type SuggestionsData = {
 }
 
 export default function ResultsPage() {
+  const router = useRouter()
   const [assessment, setAssessment] = useState<AssessmentData | null>(null)
   const [suggestions, setSuggestions] = useState<Practice[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
+  const [trialLoading, setTrialLoading] = useState<Record<string, boolean>>({})
+  const [trialError, setTrialError] = useState<Record<string, string>>({})
+
+  const handleTryThis = useCallback(async (practiceId: string) => {
+    setTrialLoading((prev) => ({ ...prev, [practiceId]: true }))
+    setTrialError((prev) => ({ ...prev, [practiceId]: '' }))
+    try {
+      const res = await fetch('/api/practice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'startTrial', practiceId }),
+      })
+      if (res.ok || res.status === 409) {
+        const data = await res.json()
+        if (res.ok || data.error === 'ALREADY_TRIALING' || data.error === 'ALREADY_ACTIVE') {
+          router.push('/practices')
+          return
+        }
+        const msg = data.error === 'TRIAL_LIMIT_REACHED'
+          ? 'You already have an active trial. Promote or discard it first.'
+          : 'Could not start trial. Please try again.'
+        setTrialError((prev) => ({ ...prev, [practiceId]: msg }))
+      } else {
+        setTrialError((prev) => ({ ...prev, [practiceId]: 'Could not start trial. Please try again.' }))
+      }
+    } catch {
+      setTrialError((prev) => ({ ...prev, [practiceId]: 'Could not start trial. Please try again.' }))
+    } finally {
+      setTrialLoading((prev) => ({ ...prev, [practiceId]: false }))
+    }
+  }, [router])
 
   useEffect(() => {
     async function load() {
@@ -166,10 +199,21 @@ export default function ResultsPage() {
                         Why: {practice.rationale}
                       </p>
                     </div>
-                    {/* TODO E5: wire to trial activation API */}
-                    <Button size="sm" variant="outline" className="shrink-0" asChild>
-                      <Link href="/practices">Try this</Link>
-                    </Button>
+                    <div className="flex flex-col items-end gap-1 shrink-0">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={!!trialLoading[practice.id]}
+                        onClick={() => handleTryThis(practice.id)}
+                      >
+                        {trialLoading[practice.id] ? '…' : 'Try this'}
+                      </Button>
+                      {trialError[practice.id] && (
+                        <p className="text-[11px] text-destructive text-right max-w-[140px]">
+                          {trialError[practice.id]}
+                        </p>
+                      )}
+                    </div>
                   </div>
                 </Card>
               ))}

--- a/lib/practices/trial.ts
+++ b/lib/practices/trial.ts
@@ -1,0 +1,72 @@
+import type { Pillar } from '@/lib/assessment/pillars'
+
+export const TRIAL_DURATION_DAYS = 7
+export const MAX_CONCURRENT_TRIALS = 1
+
+export const FREE_CAP = 1
+export const PAID_CAP = 10
+export const PAID_WARN_HIGH = 7
+export const PAID_WARN_LOW = 5
+
+export type TrialStatus = 'trial' | 'promoted' | 'expired' | 'discarded'
+
+export type TrialItem = {
+  PK: string
+  SK: string
+  practiceId: string
+  pillar: Pillar
+  startedAt: string
+  status: TrialStatus
+  expiresAt: string
+  resolvedAt?: string
+}
+
+export type ProfileData = {
+  subscriptionStatus?: string
+  activePracticeIds?: string[]
+  activePracticeSkById?: Record<string, string>
+}
+
+export type CapCheckResult =
+  | { allowed: true; warning?: 'APPROACHING_CAP'; remaining?: number }
+  | { allowed: false; reason: 'CAP_REACHED'; cap: number }
+
+export function isTrialActive(trial: TrialItem): boolean {
+  return trial.status === 'trial' && !isTrialExpired(trial)
+}
+
+export function isTrialExpired(trial: TrialItem): boolean {
+  return new Date(trial.expiresAt) < new Date()
+}
+
+export function getTrialDaysRemaining(trial: TrialItem): number {
+  const ms = new Date(trial.expiresAt).getTime() - Date.now()
+  return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)))
+}
+
+export function checkActiveCap(
+  subscriptionStatus: string | undefined,
+  activeCount: number
+): CapCheckResult {
+  const isPaid = subscriptionStatus?.toUpperCase() === 'PAID'
+
+  if (!isPaid) {
+    if (activeCount >= FREE_CAP) return { allowed: false, reason: 'CAP_REACHED', cap: FREE_CAP }
+    return { allowed: true }
+  }
+
+  if (activeCount >= PAID_CAP) return { allowed: false, reason: 'CAP_REACHED', cap: PAID_CAP }
+  if (activeCount >= PAID_WARN_HIGH)
+    return { allowed: true, warning: 'APPROACHING_CAP', remaining: PAID_CAP - activeCount }
+  if (activeCount >= PAID_WARN_LOW)
+    return { allowed: true, warning: 'APPROACHING_CAP', remaining: PAID_CAP - activeCount }
+  return { allowed: true }
+}
+
+export function makeTrialSK(startedAt: string, practiceId: string): string {
+  return `TRIAL#${startedAt}#${practiceId}`
+}
+
+export function makeUPracticeSK(practiceId: string): string {
+  return `UPRACTICE#${practiceId}`
+}

--- a/tests/unit/api/assessment.post.test.ts
+++ b/tests/unit/api/assessment.post.test.ts
@@ -117,8 +117,7 @@ describe("POST /api/assessment", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 401 on dynamo failures (TODO: return 500 later)", async () => {
-    // TODO: refine handler to return 500 for internal errors.
+  it("returns 500 on dynamo failures", async () => {
     getCurrentUserMock.mockResolvedValue({ userId: "u1", username: "user" });
     putItemMock.mockRejectedValue(new Error("Dynamo failure"));
 
@@ -128,6 +127,6 @@ describe("POST /api/assessment", () => {
     });
 
     const res = await POST(req);
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(500);
   });
 });

--- a/tests/unit/api/practice.post.test.ts
+++ b/tests/unit/api/practice.post.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from '@/app/api/practice/route'
+
+const getItemMock = vi.fn()
+const putItemMock = vi.fn()
+const updateItemMock = vi.fn()
+const queryMock = vi.fn()
+
+vi.mock('@/utils/dynamoClient', () => ({
+  createDynamoClient: () => ({
+    getItem: getItemMock,
+    putItem: putItemMock,
+    updateItem: updateItemMock,
+    query: queryMock,
+  }),
+}))
+
+const getCurrentUserMock = vi.fn()
+vi.mock('aws-amplify/auth/server', () => ({
+  getCurrentUser: () => getCurrentUserMock(),
+}))
+vi.mock('@/utils/amplifyServerUtils', () => ({
+  runWithAmplifyServerContext: ({
+    operation,
+  }: {
+    operation: (ctx: unknown) => Promise<unknown>
+  }) => operation({}),
+}))
+
+function makeReq(body: object) {
+  return new Request('http://localhost/api/practice', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function futureIso(days = 7) {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+function pastIso(days = 1) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+describe('POST /api/practice — startTrial', () => {
+  beforeEach(() => {
+    getCurrentUserMock.mockResolvedValue({ userId: 'u1', username: 'user' })
+    getItemMock.mockReset()
+    putItemMock.mockReset()
+    updateItemMock.mockReset()
+    queryMock.mockReset()
+  })
+
+  it('creates a trial and returns 201', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: [], subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([])
+    putItemMock.mockResolvedValue(undefined)
+
+    const res = await POST(makeReq({ mode: 'startTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(201)
+    const json = await res.json()
+    expect(json.trial.practiceId).toBe('sleep-consistent-bedtime')
+    expect(json.trial.status).toBe('trial')
+  })
+
+  it('returns 404 for unknown practiceId', async () => {
+    const res = await POST(makeReq({ mode: 'startTrial', practiceId: 'nonexistent-id' }))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 409 ALREADY_ACTIVE if practice is already active', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([])
+
+    const res = await POST(makeReq({ mode: 'startTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toBe('ALREADY_ACTIVE')
+  })
+
+  it('returns 409 ALREADY_TRIALING if active trial exists for the practice', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: [], subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([
+      {
+        practiceId: 'sleep-consistent-bedtime',
+        status: 'trial',
+        expiresAt: futureIso(),
+        SK: 'TRIAL#x#sleep-consistent-bedtime',
+      },
+    ])
+
+    const res = await POST(makeReq({ mode: 'startTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toBe('ALREADY_TRIALING')
+  })
+
+  it('returns 409 TRIAL_LIMIT_REACHED when at max concurrent trials', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: [], subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([
+      {
+        practiceId: 'sleep-screen-off',
+        status: 'trial',
+        expiresAt: futureIso(),
+        SK: 'TRIAL#x#sleep-screen-off',
+      },
+    ])
+
+    const res = await POST(makeReq({ mode: 'startTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toBe('TRIAL_LIMIT_REACHED')
+  })
+
+  // E5-T12: trial does NOT affect active cap
+  it('E5-T12: FREE user at active cap can still start a trial', async () => {
+    // User has 1 active practice (FREE cap = 1)
+    getItemMock.mockResolvedValue({ activePracticeIds: ['financial-weekly-review'], subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([])
+    putItemMock.mockResolvedValue(undefined)
+
+    const res = await POST(makeReq({ mode: 'startTrial', practiceId: 'sleep-consistent-bedtime' }))
+    // startTrial doesn't check the active cap — it's only checked on promote
+    expect(res.status).toBe(201)
+    // activePracticeIds is NOT modified
+    expect(updateItemMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/practice — promoteTrial', () => {
+  beforeEach(() => {
+    getCurrentUserMock.mockResolvedValue({ userId: 'u1', username: 'user' })
+    getItemMock.mockReset()
+    putItemMock.mockReset()
+    updateItemMock.mockReset()
+    queryMock.mockReset()
+  })
+
+  it('promotes a valid trial and returns 200', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: [], activePracticeSkById: {}, subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([
+      { practiceId: 'sleep-consistent-bedtime', status: 'trial', expiresAt: futureIso(), SK: 'TRIAL#x#sleep-consistent-bedtime' },
+    ])
+    putItemMock.mockResolvedValue(undefined)
+    updateItemMock.mockResolvedValue(undefined)
+
+    const res = await POST(makeReq({ mode: 'promoteTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 409 CAP_REACHED for FREE user at cap', async () => {
+    getItemMock.mockResolvedValue({
+      activePracticeIds: ['financial-weekly-review'],
+      activePracticeSkById: {},
+      subscriptionStatus: 'FREE',
+    })
+    queryMock.mockResolvedValue([
+      { practiceId: 'sleep-consistent-bedtime', status: 'trial', expiresAt: futureIso(), SK: 'TRIAL#x#sleep-consistent-bedtime' },
+    ])
+
+    const res = await POST(makeReq({ mode: 'promoteTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toBe('CAP_REACHED')
+    // trial state is NOT mutated when blocked
+    expect(updateItemMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 TRIAL_EXPIRED for an expired trial', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: [], activePracticeSkById: {}, subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([
+      { practiceId: 'sleep-consistent-bedtime', status: 'trial', expiresAt: pastIso(), SK: 'TRIAL#x#sleep-consistent-bedtime' },
+    ])
+
+    const res = await POST(makeReq({ mode: 'promoteTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toBe('TRIAL_EXPIRED')
+  })
+
+  it('returns 404 TRIAL_NOT_FOUND when no active trial exists', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: [], activePracticeSkById: {}, subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([])
+
+    const res = await POST(makeReq({ mode: 'promoteTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('POST /api/practice — discardTrial', () => {
+  beforeEach(() => {
+    getCurrentUserMock.mockResolvedValue({ userId: 'u1', username: 'user' })
+    queryMock.mockReset()
+    updateItemMock.mockReset()
+  })
+
+  it('discards a trial and returns 200', async () => {
+    queryMock.mockResolvedValue([
+      { practiceId: 'sleep-consistent-bedtime', status: 'trial', expiresAt: futureIso(), SK: 'TRIAL#x#sleep-consistent-bedtime' },
+    ])
+    updateItemMock.mockResolvedValue(undefined)
+
+    const res = await POST(makeReq({ mode: 'discardTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(200)
+    expect(updateItemMock).toHaveBeenCalledOnce()
+    const call = updateItemMock.mock.calls[0][0]
+    expect(call.ExpressionAttributeValues[':status']).toBe('discarded')
+  })
+
+  it('returns 404 when no active trial to discard', async () => {
+    queryMock.mockResolvedValue([])
+    const res = await POST(makeReq({ mode: 'discardTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('POST /api/practice — auth', () => {
+  it('returns 401 when unauthenticated', async () => {
+    getCurrentUserMock.mockRejectedValue(new Error('Unauthorized'))
+    const res = await POST(makeReq({ mode: 'startTrial', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(401)
+  })
+})

--- a/tests/unit/practices/trial.test.ts
+++ b/tests/unit/practices/trial.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  isTrialActive,
+  isTrialExpired,
+  getTrialDaysRemaining,
+  checkActiveCap,
+  makeTrialSK,
+  makeUPracticeSK,
+  FREE_CAP,
+  PAID_CAP,
+  PAID_WARN_HIGH,
+  PAID_WARN_LOW,
+  type TrialItem,
+} from '@/lib/practices/trial'
+
+function makeTrial(overrides: Partial<TrialItem> = {}): TrialItem {
+  const now = new Date()
+  const expires = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+  return {
+    PK: 'USER#u1',
+    SK: `TRIAL#${now.toISOString()}#practice-1`,
+    practiceId: 'practice-1',
+    pillar: 'sleep',
+    startedAt: now.toISOString(),
+    status: 'trial',
+    expiresAt: expires.toISOString(),
+    ...overrides,
+  }
+}
+
+describe('isTrialExpired', () => {
+  it('returns false for a future expiresAt', () => {
+    const trial = makeTrial()
+    expect(isTrialExpired(trial)).toBe(false)
+  })
+
+  it('returns true for a past expiresAt', () => {
+    const trial = makeTrial({ expiresAt: new Date(Date.now() - 1000).toISOString() })
+    expect(isTrialExpired(trial)).toBe(true)
+  })
+})
+
+describe('isTrialActive', () => {
+  it('returns true when status=trial and not expired', () => {
+    expect(isTrialActive(makeTrial())).toBe(true)
+  })
+
+  it('returns false when status=promoted', () => {
+    expect(isTrialActive(makeTrial({ status: 'promoted' }))).toBe(false)
+  })
+
+  it('returns false when status=discarded', () => {
+    expect(isTrialActive(makeTrial({ status: 'discarded' }))).toBe(false)
+  })
+
+  it('returns false when expired even if status=trial', () => {
+    const trial = makeTrial({ expiresAt: new Date(Date.now() - 1000).toISOString() })
+    expect(isTrialActive(trial)).toBe(false)
+  })
+})
+
+describe('getTrialDaysRemaining', () => {
+  it('returns 7 for a brand-new trial', () => {
+    const days = getTrialDaysRemaining(makeTrial())
+    expect(days).toBe(7)
+  })
+
+  it('returns 0 for an expired trial', () => {
+    const trial = makeTrial({ expiresAt: new Date(Date.now() - 1000).toISOString() })
+    expect(getTrialDaysRemaining(trial)).toBe(0)
+  })
+})
+
+describe('checkActiveCap', () => {
+  it('FREE: allows when count is 0', () => {
+    expect(checkActiveCap('FREE', 0)).toEqual({ allowed: true })
+  })
+
+  it(`FREE: blocks at ${FREE_CAP}`, () => {
+    const result = checkActiveCap('FREE', FREE_CAP)
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) expect(result.reason).toBe('CAP_REACHED')
+  })
+
+  it('PAID: allows when count is 0', () => {
+    expect(checkActiveCap('PAID', 0)).toEqual({ allowed: true })
+  })
+
+  it(`PAID: warns at ${PAID_WARN_LOW}`, () => {
+    const result = checkActiveCap('PAID', PAID_WARN_LOW)
+    expect(result.allowed).toBe(true)
+    if (result.allowed) expect(result.warning).toBe('APPROACHING_CAP')
+  })
+
+  it(`PAID: warns at ${PAID_WARN_HIGH}`, () => {
+    const result = checkActiveCap('PAID', PAID_WARN_HIGH)
+    expect(result.allowed).toBe(true)
+    if (result.allowed) expect(result.warning).toBe('APPROACHING_CAP')
+  })
+
+  it(`PAID: blocks at ${PAID_CAP}`, () => {
+    const result = checkActiveCap('PAID', PAID_CAP)
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) expect(result.reason).toBe('CAP_REACHED')
+  })
+
+  it('defaults to FREE behaviour when status is undefined', () => {
+    const result = checkActiveCap(undefined, FREE_CAP)
+    expect(result.allowed).toBe(false)
+  })
+})
+
+describe('SK helpers', () => {
+  it('makeTrialSK produces correct format', () => {
+    expect(makeTrialSK('2026-01-01T00:00:00.000Z', 'sleep-rest')).toBe(
+      'TRIAL#2026-01-01T00:00:00.000Z#sleep-rest'
+    )
+  })
+
+  it('makeUPracticeSK produces correct format', () => {
+    expect(makeUPracticeSK('sleep-rest')).toBe('UPRACTICE#sleep-rest')
+  })
+})

--- a/utils/authServer.ts
+++ b/utils/authServer.ts
@@ -76,6 +76,14 @@ export async function withAuth(
   } catch {
     return unauthorizedResponse();
   }
-  return handler(user);
+  try {
+    return await handler(user);
+  } catch (error) {
+    console.error('[withAuth] handler error:', error);
+    return NextResponse.json(
+      { ok: false, error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      { status: 500 }
+    );
+  }
 }
 


### PR DESCRIPTION
## Summary
- **Data model**: `TRIAL` item with `SK=TRIAL#startedAt#practiceId`, 7-day expiry, status transitions `trial → promoted | expired | discarded`
- **`POST /api/practice`**: `startTrial` (max 1 concurrent, no cap check), `promoteTrial` (enforces FREE=1 / PAID=10 caps), `discardTrial`
- **`GET /api/practices/active`**: returns active practices + live trials with days remaining, enriched from practice library
- **`/practices` page**: wired to real API — trial badge, days remaining, Promote/Discard buttons with loading states
- **`/results` page**: "Try this" calls `startTrial` and redirects to `/practices`; shows inline error on `TRIAL_LIMIT_REACHED`
- **`withAuth` hardened**: handler errors now return 500, not 401

## Test plan
- [ ] On `/results`, click "Try this" → redirects to `/practices` with trial showing
- [ ] On `/practices`, click Promote → practice moves to Active section
- [ ] On `/practices`, click Discard → trial disappears
- [ ] Try starting a second trial while one is active → inline error shown
- [ ] FREE user with 1 active practice: start trial succeeds, promote is blocked with CAP_REACHED
- [ ] `npm test` — 156 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)