### PR TITLE
Epic #6: Active practice management

### DIFF
--- a/app/api/practice/route.ts
+++ b/app/api/practice/route.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import { NextResponse } from 'next/server'
 import { createDynamoClient } from '@/utils/dynamoClient'
 import { withAuth } from '@/utils/authServer'
@@ -17,9 +18,61 @@ import {
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-type Body = {
-  mode: 'startTrial' | 'promoteTrial' | 'discardTrial'
+// ── Replace confirm tokens (in-memory, 5-min TTL) ───────────────────────────
+type ConfirmEntry = {
+  userId: string
+  replacePracticeId: string
   practiceId: string
+  exp: number
+}
+const pendingReplaces = new Map<string, ConfirmEntry>()
+
+function newConfirmToken(entry: Omit<ConfirmEntry, 'exp'>): string {
+  const token = crypto.randomUUID()
+  pendingReplaces.set(token, { ...entry, exp: Date.now() + 5 * 60 * 1000 })
+  return token
+}
+
+function consumeConfirmToken(
+  token: string,
+  userId: string,
+  replacePracticeId: string,
+  practiceId: string
+): boolean {
+  const entry = pendingReplaces.get(token)
+  if (!entry) return false
+  if (entry.exp < Date.now()) {
+    pendingReplaces.delete(token)
+    return false
+  }
+  if (
+    entry.userId !== userId ||
+    entry.replacePracticeId !== replacePracticeId ||
+    entry.practiceId !== practiceId
+  )
+    return false
+  pendingReplaces.delete(token)
+  return true
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+
+type UPracticeItem = {
+  PK: string
+  SK: string
+  practiceId: string
+  pillar: string
+  addedAt: string
+  status?: 'active' | 'paused'
+  pausedAt?: string
+  resumedAt?: string
+}
+
+type Body = {
+  mode: string
+  practiceId: string
+  replacePracticeId?: string
+  confirmToken?: string
 }
 
 export async function POST(req: Request) {
@@ -31,7 +84,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
     }
 
-    const { mode, practiceId } = body ?? {}
+    const { mode, practiceId, replacePracticeId, confirmToken } = body ?? {}
     if (!mode || !practiceId) {
       return NextResponse.json({ error: 'mode and practiceId required' }, { status: 400 })
     }
@@ -42,9 +95,7 @@ export async function POST(req: Request) {
     // ── startTrial ──────────────────────────────────────────────────────────
     if (mode === 'startTrial') {
       const practice = practicesById.get(practiceId)
-      if (!practice) {
-        return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
-      }
+      if (!practice) return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
 
       const [profile, trials] = await Promise.all([
         client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
@@ -55,28 +106,15 @@ export async function POST(req: Request) {
       ])
 
       const activePracticeIds = profile?.activePracticeIds ?? []
-
-      if (activePracticeIds.includes(practiceId)) {
+      if (activePracticeIds.includes(practiceId))
         return NextResponse.json({ error: 'ALREADY_ACTIVE' }, { status: 409 })
-      }
-
-      if (trials.find((t) => t.practiceId === practiceId && isTrialActive(t))) {
+      if (trials.find((t) => t.practiceId === practiceId && isTrialActive(t)))
         return NextResponse.json({ error: 'ALREADY_TRIALING' }, { status: 409 })
-      }
-
-      const activeTrials = trials.filter(isTrialActive)
-      if (activeTrials.length >= MAX_CONCURRENT_TRIALS) {
-        return NextResponse.json(
-          { error: 'TRIAL_LIMIT_REACHED', max: MAX_CONCURRENT_TRIALS },
-          { status: 409 }
-        )
-      }
+      if (trials.filter(isTrialActive).length >= MAX_CONCURRENT_TRIALS)
+        return NextResponse.json({ error: 'TRIAL_LIMIT_REACHED', max: MAX_CONCURRENT_TRIALS }, { status: 409 })
 
       const startedAt = new Date().toISOString()
-      const expiresAt = new Date(
-        Date.now() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000
-      ).toISOString()
-
+      const expiresAt = new Date(Date.now() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000).toISOString()
       const trial: TrialItem = {
         PK: pk,
         SK: makeTrialSK(startedAt, practiceId),
@@ -86,7 +124,6 @@ export async function POST(req: Request) {
         status: 'trial',
         expiresAt,
       }
-
       await client.putItem(trial)
       return NextResponse.json({ trial }, { status: 201 })
     }
@@ -94,9 +131,7 @@ export async function POST(req: Request) {
     // ── promoteTrial ────────────────────────────────────────────────────────
     if (mode === 'promoteTrial') {
       const practice = practicesById.get(practiceId)
-      if (!practice) {
-        return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
-      }
+      if (!practice) return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
 
       const [profile, trials] = await Promise.all([
         client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
@@ -106,32 +141,20 @@ export async function POST(req: Request) {
         }),
       ])
 
-      const activeTrial = trials.find(
-        (t) => t.practiceId === practiceId && t.status === 'trial'
-      )
-      if (!activeTrial) {
-        return NextResponse.json({ error: 'TRIAL_NOT_FOUND' }, { status: 404 })
-      }
-      if (isTrialExpired(activeTrial)) {
-        return NextResponse.json({ error: 'TRIAL_EXPIRED' }, { status: 409 })
-      }
+      const activeTrial = trials.find((t) => t.practiceId === practiceId && t.status === 'trial')
+      if (!activeTrial) return NextResponse.json({ error: 'TRIAL_NOT_FOUND' }, { status: 404 })
+      if (isTrialExpired(activeTrial)) return NextResponse.json({ error: 'TRIAL_EXPIRED' }, { status: 409 })
 
       const activePracticeIds = profile?.activePracticeIds ?? []
       const activePracticeSkById = profile?.activePracticeSkById ?? {}
       const capCheck = checkActiveCap(profile?.subscriptionStatus, activePracticeIds.length)
-      if (!capCheck.allowed) {
-        return NextResponse.json(
-          { error: capCheck.reason, cap: capCheck.cap },
-          { status: 409 }
-        )
-      }
+      if (!capCheck.allowed)
+        return NextResponse.json({ error: capCheck.reason, cap: capCheck.cap }, { status: 409 })
 
       const addedAt = new Date().toISOString()
       const upracticeSK = makeUPracticeSK(practiceId)
-      const resolvedAt = addedAt
-
       await Promise.all([
-        client.putItem({ PK: pk, SK: upracticeSK, practiceId, pillar: practice.pillar, addedAt }),
+        client.putItem({ PK: pk, SK: upracticeSK, practiceId, pillar: practice.pillar, addedAt, status: 'active' }),
         client.updateItem({
           Key: { PK: pk, SK: 'PROFILE' },
           UpdateExpression: 'SET activePracticeIds = :ids, activePracticeSkById = :skById',
@@ -144,16 +167,11 @@ export async function POST(req: Request) {
           Key: { PK: pk, SK: activeTrial.SK },
           UpdateExpression: 'SET #s = :status, resolvedAt = :resolvedAt',
           ExpressionAttributeNames: { '#s': 'status' },
-          ExpressionAttributeValues: { ':status': 'promoted', ':resolvedAt': resolvedAt },
+          ExpressionAttributeValues: { ':status': 'promoted', ':resolvedAt': addedAt },
         }),
       ])
-
       return NextResponse.json(
-        {
-          practiceId,
-          warning: capCheck.allowed && capCheck.warning ? capCheck.warning : undefined,
-          remaining: capCheck.allowed ? capCheck.remaining : undefined,
-        },
+        { practiceId, warning: capCheck.allowed && capCheck.warning ? capCheck.warning : undefined },
         { status: 200 }
       )
     }
@@ -164,25 +182,196 @@ export async function POST(req: Request) {
         KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
         ExpressionAttributeValues: { ':pk': pk, ':prefix': 'TRIAL#' },
       })
-
-      const activeTrial = trials.find(
-        (t) => t.practiceId === practiceId && t.status === 'trial'
-      )
-      if (!activeTrial) {
-        return NextResponse.json({ error: 'TRIAL_NOT_FOUND' }, { status: 404 })
-      }
+      const activeTrial = trials.find((t) => t.practiceId === practiceId && t.status === 'trial')
+      if (!activeTrial) return NextResponse.json({ error: 'TRIAL_NOT_FOUND' }, { status: 404 })
 
       await client.updateItem({
         Key: { PK: pk, SK: activeTrial.SK },
         UpdateExpression: 'SET #s = :status, resolvedAt = :resolvedAt',
         ExpressionAttributeNames: { '#s': 'status' },
+        ExpressionAttributeValues: { ':status': 'discarded', ':resolvedAt': new Date().toISOString() },
+      })
+      return NextResponse.json({ ok: true }, { status: 200 })
+    }
+
+    // ── add ─────────────────────────────────────────────────────────────────
+    if (mode === 'add') {
+      const practice = practicesById.get(practiceId)
+      if (!practice) return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
+
+      const profile = await client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' })
+      const activePracticeIds = profile?.activePracticeIds ?? []
+      const activePracticeSkById = profile?.activePracticeSkById ?? {}
+
+      if (activePracticeIds.includes(practiceId))
+        return NextResponse.json({ error: 'ALREADY_ACTIVE' }, { status: 409 })
+
+      const capCheck = checkActiveCap(profile?.subscriptionStatus, activePracticeIds.length)
+      if (!capCheck.allowed)
+        return NextResponse.json({ error: capCheck.reason, cap: capCheck.cap }, { status: 409 })
+
+      const addedAt = new Date().toISOString()
+      const upracticeSK = makeUPracticeSK(practiceId)
+      await Promise.all([
+        client.putItem({ PK: pk, SK: upracticeSK, practiceId, pillar: practice.pillar, addedAt, status: 'active' }),
+        client.updateItem({
+          Key: { PK: pk, SK: 'PROFILE' },
+          UpdateExpression: 'SET activePracticeIds = :ids, activePracticeSkById = :skById',
+          ExpressionAttributeValues: {
+            ':ids': [...activePracticeIds, practiceId],
+            ':skById': { ...activePracticeSkById, [practiceId]: upracticeSK },
+          },
+        }),
+      ])
+      return NextResponse.json(
+        { practiceId, warning: capCheck.allowed && capCheck.warning ? capCheck.warning : undefined },
+        { status: 201 }
+      )
+    }
+
+    // ── replace ─────────────────────────────────────────────────────────────
+    if (mode === 'replace') {
+      if (!replacePracticeId)
+        return NextResponse.json({ error: 'replacePracticeId required' }, { status: 400 })
+
+      const newPractice = practicesById.get(practiceId)
+      if (!newPractice) return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
+
+      // First call — return confirm token
+      if (!confirmToken) {
+        const token = newConfirmToken({ userId: user.userId, replacePracticeId, practiceId })
+        return NextResponse.json(
+          { confirmRequired: true, confirmToken: token, replacePracticeId, practiceId },
+          { status: 202 }
+        )
+      }
+
+      // Second call — validate token and execute
+      if (!consumeConfirmToken(confirmToken, user.userId, replacePracticeId, practiceId))
+        return NextResponse.json({ error: 'INVALID_CONFIRM_TOKEN' }, { status: 409 })
+
+      const profile = await client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' })
+      const activePracticeIds = profile?.activePracticeIds ?? []
+      const activePracticeSkById = profile?.activePracticeSkById ?? {}
+
+      if (!activePracticeIds.includes(replacePracticeId))
+        return NextResponse.json({ error: 'PRACTICE_NOT_ACTIVE' }, { status: 409 })
+      if (activePracticeIds.includes(practiceId))
+        return NextResponse.json({ error: 'ALREADY_ACTIVE' }, { status: 409 })
+
+      const addedAt = new Date().toISOString()
+      const newSK = makeUPracticeSK(practiceId)
+      const newIds = activePracticeIds.filter((id) => id !== replacePracticeId).concat(practiceId)
+      const newSkById = { ...activePracticeSkById }
+      delete newSkById[replacePracticeId]
+      newSkById[practiceId] = newSK
+
+      await Promise.all([
+        client.putItem({ PK: pk, SK: newSK, practiceId, pillar: newPractice.pillar, addedAt, status: 'active' }),
+        client.updateItem({
+          Key: { PK: pk, SK: makeUPracticeSK(replacePracticeId) },
+          UpdateExpression: 'SET #s = :status, endedAt = :endedAt',
+          ExpressionAttributeNames: { '#s': 'status' },
+          ExpressionAttributeValues: { ':status': 'replaced', ':endedAt': addedAt },
+        }),
+        client.updateItem({
+          Key: { PK: pk, SK: 'PROFILE' },
+          UpdateExpression: 'SET activePracticeIds = :ids, activePracticeSkById = :skById',
+          ExpressionAttributeValues: { ':ids': newIds, ':skById': newSkById },
+        }),
+      ])
+      return NextResponse.json({ ok: true, practiceId, replaced: replacePracticeId }, { status: 200 })
+    }
+
+    // ── pause ────────────────────────────────────────────────────────────────
+    if (mode === 'pause') {
+      const upractice = await client.getItem<UPracticeItem>({ PK: pk, SK: makeUPracticeSK(practiceId) })
+      if (!upractice || (upractice.status && upractice.status !== 'active'))
+        return NextResponse.json({ error: 'PRACTICE_NOT_ACTIVE' }, { status: 404 })
+
+      const profile = await client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' })
+      const activePracticeIds = profile?.activePracticeIds ?? []
+      const newIds = activePracticeIds.filter((id) => id !== practiceId)
+
+      await Promise.all([
+        client.updateItem({
+          Key: { PK: pk, SK: makeUPracticeSK(practiceId) },
+          UpdateExpression: 'SET #s = :status, pausedAt = :pausedAt',
+          ExpressionAttributeNames: { '#s': 'status' },
+          ExpressionAttributeValues: { ':status': 'paused', ':pausedAt': new Date().toISOString() },
+        }),
+        client.updateItem({
+          Key: { PK: pk, SK: 'PROFILE' },
+          UpdateExpression: 'SET activePracticeIds = :ids',
+          ExpressionAttributeValues: { ':ids': newIds },
+        }),
+      ])
+      return NextResponse.json({ ok: true }, { status: 200 })
+    }
+
+    // ── resume ───────────────────────────────────────────────────────────────
+    if (mode === 'resume') {
+      const [upractice, profile] = await Promise.all([
+        client.getItem<UPracticeItem>({ PK: pk, SK: makeUPracticeSK(practiceId) }),
+        client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
+      ])
+
+      if (!upractice || upractice.status !== 'paused')
+        return NextResponse.json({ error: 'PRACTICE_NOT_PAUSED' }, { status: 404 })
+
+      const activePracticeIds = profile?.activePracticeIds ?? []
+      const capCheck = checkActiveCap(profile?.subscriptionStatus, activePracticeIds.length)
+      if (!capCheck.allowed)
+        return NextResponse.json({ error: capCheck.reason, cap: capCheck.cap }, { status: 409 })
+
+      await Promise.all([
+        client.updateItem({
+          Key: { PK: pk, SK: makeUPracticeSK(practiceId) },
+          UpdateExpression: 'SET #s = :status, resumedAt = :resumedAt',
+          ExpressionAttributeNames: { '#s': 'status' },
+          ExpressionAttributeValues: { ':status': 'active', ':resumedAt': new Date().toISOString() },
+        }),
+        client.updateItem({
+          Key: { PK: pk, SK: 'PROFILE' },
+          UpdateExpression: 'SET activePracticeIds = :ids',
+          ExpressionAttributeValues: { ':ids': [...activePracticeIds, practiceId] },
+        }),
+      ])
+      return NextResponse.json(
+        { ok: true, warning: capCheck.allowed && capCheck.warning ? capCheck.warning : undefined },
+        { status: 200 }
+      )
+    }
+
+    // ── setFocus ─────────────────────────────────────────────────────────────
+    if (mode === 'setFocus') {
+      const practice = practicesById.get(practiceId)
+      if (!practice) return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
+
+      const [profile, trials] = await Promise.all([
+        client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
+        client.query<TrialItem>({
+          KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+          ExpressionAttributeValues: { ':pk': pk, ':prefix': 'TRIAL#' },
+        }),
+      ])
+
+      const activePracticeIds = profile?.activePracticeIds ?? []
+      const isActive = activePracticeIds.includes(practiceId)
+      const hasActiveTrial = trials.some((t) => t.practiceId === practiceId && isTrialActive(t))
+
+      if (!isActive && !hasActiveTrial)
+        return NextResponse.json({ error: 'PRACTICE_NOT_ACTIVE_OR_TRIAL' }, { status: 409 })
+
+      await client.updateItem({
+        Key: { PK: pk, SK: 'PROFILE' },
+        UpdateExpression: 'SET todayFocusPracticeId = :id, updatedAt = :updatedAt',
         ExpressionAttributeValues: {
-          ':status': 'discarded',
-          ':resolvedAt': new Date().toISOString(),
+          ':id': practiceId,
+          ':updatedAt': new Date().toISOString(),
         },
       })
-
-      return NextResponse.json({ ok: true }, { status: 200 })
+      return NextResponse.json({ ok: true, todayFocusPracticeId: practiceId }, { status: 200 })
     }
 
     return NextResponse.json({ error: 'Unknown mode' }, { status: 400 })

--- a/app/api/practices/active/route.ts
+++ b/app/api/practices/active/route.ts
@@ -17,6 +17,8 @@ type UPracticeItem = {
   practiceId: string
   pillar: string
   addedAt: string
+  status?: 'active' | 'paused' | 'replaced'
+  pausedAt?: string
 }
 
 export async function GET() {
@@ -36,17 +38,24 @@ export async function GET() {
       }),
     ])
 
-    // Enrich active practices with library data
+    function enrich(up: UPracticeItem) {
+      const lib = practicesById.get(up.practiceId)
+      if (!lib) return null
+      return { ...lib, addedAt: up.addedAt, status: up.status ?? 'active' }
+    }
+
+    // Treat no-status (legacy promoted before E6) as active
     const activePractices = upractices
-      .map((up) => {
-        const lib = practicesById.get(up.practiceId)
-        if (!lib) return null
-        return { ...lib, addedAt: up.addedAt }
-      })
+      .filter((up) => !up.status || up.status === 'active')
+      .map(enrich)
       .filter(Boolean)
 
-    // Enrich active trials with library data and computed fields
-    const activeTrial = trials
+    const pausedPractices = upractices
+      .filter((up) => up.status === 'paused')
+      .map(enrich)
+      .filter(Boolean)
+
+    const activeTrials = trials
       .filter((t) => t.status === 'trial')
       .map((t) => {
         const lib = practicesById.get(t.practiceId)
@@ -67,8 +76,10 @@ export async function GET() {
     return NextResponse.json(
       {
         activePractices,
-        trials: activeTrial,
+        pausedPractices,
+        trials: activeTrials,
         subscriptionStatus: profile?.subscriptionStatus ?? 'FREE',
+        todayFocusPracticeId: profile?.todayFocusPracticeId ?? null,
       },
       { status: 200 }
     )

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -6,14 +6,16 @@ import { StandardPage } from '@/components/layout';
 import { Card, Button, EmptyState, Loading, ErrorState } from '@/components/ui';
 import { pillarColors } from '@/lib/design/pillarColors';
 import { MOCK_PILLAR_LABELS } from '@/lib/mockState';
+import { practices } from '@/lib/practices/library';
 import type { Pillar } from '@/lib/assessment/pillars';
 
-type ActivePractice = {
+type EnrichedPractice = {
   id: string
   pillar: Pillar
   title: string
   description: string
   addedAt: string
+  status: 'active' | 'paused'
 }
 
 type Trial = {
@@ -30,9 +32,11 @@ type Trial = {
 }
 
 type ActiveData = {
-  activePractices: ActivePractice[]
+  activePractices: EnrichedPractice[]
+  pausedPractices: EnrichedPractice[]
   trials: Trial[]
   subscriptionStatus: string
+  todayFocusPracticeId: string | null
 }
 
 function PillarBadge({ pillar }: { pillar: Pillar }) {
@@ -54,11 +58,26 @@ function TrialBadge() {
   );
 }
 
+function FocusBadge() {
+  return (
+    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-primary/10 text-primary border border-primary/30">
+      Today&apos;s focus
+    </span>
+  );
+}
+
 export default function PracticesPage() {
   const [data, setData] = useState<ActiveData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({})
+  const [inlineError, setInlineError] = useState<Record<string, string>>({})
+  const [inlineWarning, setInlineWarning] = useState<Record<string, string>>({})
+
+  // Replace flow state
+  const [replacingId, setReplacingId] = useState<string | null>(null)
+  const [replaceTarget, setReplaceTarget] = useState<string | null>(null)
+  const [replaceToken, setReplaceToken] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -76,29 +95,151 @@ export default function PracticesPage() {
 
   useEffect(() => { load() }, [load])
 
-  async function handleAction(mode: 'promoteTrial' | 'discardTrial', practiceId: string) {
-    setActionLoading((prev) => ({ ...prev, [practiceId]: true }))
+  function setAction(id: string, busy: boolean) {
+    setActionLoading((p) => ({ ...p, [id]: busy }))
+  }
+
+  async function callApi(mode: string, practiceId: string, extra?: Record<string, string>) {
+    const res = await fetch('/api/practice', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode, practiceId, ...extra }),
+    })
+    return res
+  }
+
+  async function handlePause(practiceId: string) {
+    setAction(practiceId, true)
+    setInlineError((p) => ({ ...p, [practiceId]: '' }))
     try {
-      const res = await fetch('/api/practice', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mode, practiceId }),
-      })
+      const res = await callApi('pause', practiceId)
       if (!res.ok) {
-        const err = await res.json().catch(() => ({}))
-        const msg = err.error === 'CAP_REACHED'
-          ? `You've reached your active practice limit (${err.cap}).`
-          : err.error === 'TRIAL_EXPIRED'
-          ? 'This trial has expired and can no longer be promoted.'
-          : 'Something went wrong. Please try again.'
-        alert(msg)
+        setInlineError((p) => ({ ...p, [practiceId]: 'Could not pause. Try again.' }))
         return
       }
       await load()
     } finally {
-      setActionLoading((prev) => ({ ...prev, [practiceId]: false }))
+      setAction(practiceId, false)
     }
   }
+
+  async function handleResume(practiceId: string) {
+    setAction(practiceId, true)
+    setInlineError((p) => ({ ...p, [practiceId]: '' }))
+    try {
+      const res = await callApi('resume', practiceId)
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        const msg = json.error === 'CAP_REACHED'
+          ? `Active practice limit reached (${json.cap}). Pause another first.`
+          : 'Could not resume. Try again.'
+        setInlineError((p) => ({ ...p, [practiceId]: msg }))
+        return
+      }
+      if (json.warning) {
+        setInlineWarning((p) => ({ ...p, [practiceId]: `${json.remaining} slot${json.remaining === 1 ? '' : 's'} remaining` }))
+      }
+      await load()
+    } finally {
+      setAction(practiceId, false)
+    }
+  }
+
+  async function handleSetFocus(practiceId: string) {
+    setAction(practiceId, true)
+    setInlineError((p) => ({ ...p, [practiceId]: '' }))
+    try {
+      const res = await callApi('setFocus', practiceId)
+      if (!res.ok) {
+        setInlineError((p) => ({ ...p, [practiceId]: 'Could not set focus. Try again.' }))
+        return
+      }
+      await load()
+    } finally {
+      setAction(practiceId, false)
+    }
+  }
+
+  async function handleTrialAction(mode: 'promoteTrial' | 'discardTrial', practiceId: string) {
+    setAction(practiceId, true)
+    setInlineError((p) => ({ ...p, [practiceId]: '' }))
+    try {
+      const res = await callApi(mode, practiceId)
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        const msg = json.error === 'CAP_REACHED'
+          ? `Active practice limit reached (${json.cap}).`
+          : json.error === 'TRIAL_EXPIRED'
+          ? 'This trial has expired.'
+          : 'Something went wrong. Try again.'
+        setInlineError((p) => ({ ...p, [practiceId]: msg }))
+        return
+      }
+      await load()
+    } finally {
+      setAction(practiceId, false)
+    }
+  }
+
+  // Replace: step 1 — select target, get confirmToken
+  async function handleReplaceSelect(fromId: string, toId: string) {
+    setAction(fromId, true)
+    setInlineError((p) => ({ ...p, [fromId]: '' }))
+    try {
+      const res = await fetch('/api/practice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mode: 'replace', practiceId: toId, replacePracticeId: fromId }),
+      })
+      const json = await res.json().catch(() => ({}))
+      if (res.status === 202 && json.confirmToken) {
+        setReplaceToken(json.confirmToken)
+        setReplaceTarget(toId)
+        // stay in replace mode to show confirm step
+      } else {
+        setInlineError((p) => ({ ...p, [fromId]: 'Could not initiate replace. Try again.' }))
+        setReplacingId(null)
+      }
+    } finally {
+      setAction(fromId, false)
+    }
+  }
+
+  // Replace: step 2 — confirm
+  async function handleReplaceConfirm(fromId: string) {
+    if (!replaceTarget || !replaceToken) return
+    setAction(fromId, true)
+    setInlineError((p) => ({ ...p, [fromId]: '' }))
+    try {
+      const res = await fetch('/api/practice', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mode: 'replace',
+          practiceId: replaceTarget,
+          replacePracticeId: fromId,
+          confirmToken: replaceToken,
+        }),
+      })
+      if (!res.ok) {
+        setInlineError((p) => ({ ...p, [fromId]: 'Replace failed. Try again.' }))
+        return
+      }
+      setReplacingId(null)
+      setReplaceTarget(null)
+      setReplaceToken(null)
+      await load()
+    } finally {
+      setAction(fromId, false)
+    }
+  }
+
+  // Practices available to replace with (not already active or a trial)
+  const activeAndTrialIds = new Set([
+    ...(data?.activePractices.map((p) => p.id) ?? []),
+    ...(data?.trials.map((t) => t.id) ?? []),
+  ])
+  const replaceCandidates = practices.filter((p) => !activeAndTrialIds.has(p.id))
 
   return (
     <StandardPage
@@ -113,10 +254,7 @@ export default function PracticesPage() {
     >
       <div className="space-y-10">
         {loading && <Loading text="Loading your practices…" />}
-
-        {!loading && error && (
-          <ErrorState message="Couldn't load practices." onRetry={load} />
-        )}
+        {!loading && error && <ErrorState message="Couldn't load practices." onRetry={load} />}
 
         {!loading && !error && data && (
           <>
@@ -126,31 +264,118 @@ export default function PracticesPage() {
               {data.activePractices.length === 0 ? (
                 <EmptyState
                   title="No active practices"
-                  text="Promote a trial or pick one from your results to get started."
-                  action={
-                    <Button variant="outline" asChild>
-                      <Link href="/results">Browse suggestions</Link>
-                    </Button>
-                  }
+                  text="Promote a trial or pick one from your results."
+                  action={<Button variant="outline" asChild><Link href="/results">Browse suggestions</Link></Button>}
                 />
               ) : (
                 <div className="space-y-3">
-                  {data.activePractices.map((p) => (
-                    <Card key={p.id} variant="interactive" className="flex items-start justify-between gap-4">
+                  {data.activePractices.map((p) => {
+                    const isFocus = data.todayFocusPracticeId === p.id
+                    const isReplacing = replacingId === p.id
+                    const confirmed = isReplacing && !!replaceToken
+                    return (
+                      <Card key={p.id} variant="interactive">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="space-y-2 min-w-0 flex-1">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <PillarBadge pillar={p.pillar} />
+                              {isFocus && <FocusBadge />}
+                            </div>
+                            <p className="font-semibold text-foreground">{p.title}</p>
+                            <p className="text-sm text-muted-foreground">{p.description}</p>
+                            {inlineError[p.id] && (
+                              <p className="text-xs text-destructive">{inlineError[p.id]}</p>
+                            )}
+                            {inlineWarning[p.id] && (
+                              <p className="text-xs text-amber-700">{inlineWarning[p.id]}</p>
+                            )}
+
+                            {/* Replace picker */}
+                            {isReplacing && !confirmed && (
+                              <div className="mt-3 space-y-2">
+                                <p className="text-xs font-medium text-muted-foreground">Pick a replacement:</p>
+                                <div className="flex flex-col gap-1 max-h-48 overflow-y-auto pr-1">
+                                  {replaceCandidates.map((c) => (
+                                    <button
+                                      key={c.id}
+                                      className="text-left text-sm px-3 py-2 rounded-lg border border-border hover:bg-muted transition-colors"
+                                      onClick={() => handleReplaceSelect(p.id, c.id)}
+                                      disabled={!!actionLoading[p.id]}
+                                    >
+                                      <span className="font-medium">{c.title}</span>
+                                      <span className="text-muted-foreground"> · {MOCK_PILLAR_LABELS[c.pillar]}</span>
+                                    </button>
+                                  ))}
+                                </div>
+                                <Button size="sm" variant="ghost" onClick={() => { setReplacingId(null); setReplaceToken(null); setReplaceTarget(null) }}>
+                                  Cancel
+                                </Button>
+                              </div>
+                            )}
+
+                            {/* Replace confirm step */}
+                            {isReplacing && confirmed && replaceTarget && (
+                              <div className="mt-3 p-3 rounded-lg bg-amber-50 border border-amber-200 space-y-2">
+                                <p className="text-sm font-medium text-amber-900">
+                                  Replace with &ldquo;{practicesById(replaceTarget)}&rdquo;?
+                                </p>
+                                <div className="flex gap-2">
+                                  <Button size="sm" variant="default" disabled={!!actionLoading[p.id]} onClick={() => handleReplaceConfirm(p.id)}>
+                                    {actionLoading[p.id] ? '…' : 'Confirm'}
+                                  </Button>
+                                  <Button size="sm" variant="ghost" onClick={() => { setReplacingId(null); setReplaceToken(null); setReplaceTarget(null) }}>
+                                    Cancel
+                                  </Button>
+                                </div>
+                              </div>
+                            )}
+                          </div>
+
+                          {!isReplacing && (
+                            <div className="flex flex-col gap-2 shrink-0">
+                              {!isFocus && (
+                                <Button size="sm" variant="outline" disabled={!!actionLoading[p.id]} onClick={() => handleSetFocus(p.id)}>
+                                  {actionLoading[p.id] ? '…' : 'Set focus'}
+                                </Button>
+                              )}
+                              <Button size="sm" variant="ghost" disabled={!!actionLoading[p.id]} onClick={() => handlePause(p.id)}>
+                                Pause
+                              </Button>
+                              <Button size="sm" variant="ghost" disabled={!!actionLoading[p.id]} onClick={() => { setReplacingId(p.id); setReplaceToken(null); setReplaceTarget(null) }}>
+                                Replace
+                              </Button>
+                            </div>
+                          )}
+                        </div>
+                      </Card>
+                    )
+                  })}
+                </div>
+              )}
+            </section>
+
+            {/* Paused practices */}
+            {data.pausedPractices.length > 0 && (
+              <section>
+                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Paused</p>
+                <div className="space-y-3">
+                  {data.pausedPractices.map((p) => (
+                    <Card key={p.id} variant="interactive" className="flex items-start justify-between gap-4 opacity-70">
                       <div className="space-y-2 min-w-0">
                         <PillarBadge pillar={p.pillar} />
                         <p className="font-semibold text-foreground">{p.title}</p>
                         <p className="text-sm text-muted-foreground">{p.description}</p>
+                        {inlineError[p.id] && <p className="text-xs text-destructive">{inlineError[p.id]}</p>}
+                        {inlineWarning[p.id] && <p className="text-xs text-amber-700">{inlineWarning[p.id]}</p>}
                       </div>
-                      <div className="flex flex-col gap-2 shrink-0">
-                        <Button size="sm" variant="outline">Set focus</Button>
-                        <Button size="sm" variant="ghost">Pause</Button>
-                      </div>
+                      <Button size="sm" variant="outline" disabled={!!actionLoading[p.id]} onClick={() => handleResume(p.id)}>
+                        {actionLoading[p.id] ? '…' : 'Resume'}
+                      </Button>
                     </Card>
                   ))}
                 </div>
-              )}
-            </section>
+              </section>
+            )}
 
             {/* Trials */}
             <section>
@@ -159,11 +384,7 @@ export default function PracticesPage() {
                 <EmptyState
                   title="No active trials"
                   text="Try a practice for 7 days before committing."
-                  action={
-                    <Button variant="outline" asChild>
-                      <Link href="/results">Find a practice</Link>
-                    </Button>
-                  }
+                  action={<Button variant="outline" asChild><Link href="/results">Find a practice</Link></Button>}
                 />
               ) : (
                 <div className="space-y-3">
@@ -178,31 +399,18 @@ export default function PracticesPage() {
                         <p className="text-sm text-muted-foreground">{t.description}</p>
                         {t.active && (
                           <p className="text-xs text-amber-700 font-medium">
-                            {t.daysRemaining === 0
-                              ? 'Expires today'
-                              : `${t.daysRemaining} day${t.daysRemaining === 1 ? '' : 's'} remaining`}
+                            {t.daysRemaining === 0 ? 'Expires today' : `${t.daysRemaining} day${t.daysRemaining === 1 ? '' : 's'} remaining`}
                           </p>
                         )}
-                        {!t.active && (
-                          <p className="text-xs text-muted-foreground">Trial expired</p>
-                        )}
+                        {!t.active && <p className="text-xs text-muted-foreground">Trial expired</p>}
+                        {inlineError[t.id] && <p className="text-xs text-destructive">{inlineError[t.id]}</p>}
                       </div>
                       {t.active && (
                         <div className="flex flex-col gap-2 shrink-0">
-                          <Button
-                            size="sm"
-                            variant="default"
-                            disabled={!!actionLoading[t.id]}
-                            onClick={() => handleAction('promoteTrial', t.id)}
-                          >
+                          <Button size="sm" variant="default" disabled={!!actionLoading[t.id]} onClick={() => handleTrialAction('promoteTrial', t.id)}>
                             {actionLoading[t.id] ? '…' : 'Promote'}
                           </Button>
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            disabled={!!actionLoading[t.id]}
-                            onClick={() => handleAction('discardTrial', t.id)}
-                          >
+                          <Button size="sm" variant="ghost" disabled={!!actionLoading[t.id]} onClick={() => handleTrialAction('discardTrial', t.id)}>
                             Discard
                           </Button>
                         </div>
@@ -215,7 +423,6 @@ export default function PracticesPage() {
           </>
         )}
 
-        {/* CTA */}
         <div className="pt-2">
           <Button asChild>
             <Link href="/today">Go to Today →</Link>
@@ -224,4 +431,9 @@ export default function PracticesPage() {
       </div>
     </StandardPage>
   );
+}
+
+// helper used in JSX
+function practicesById(id: string): string {
+  return practices.find((p) => p.id === id)?.title ?? id
 }

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -1,84 +1,123 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { NarrowFormPage } from '@/components/layout';
-import { Card, Button } from '@/components/ui';
+import { Card, Button, Loading, ErrorState } from '@/components/ui';
 import { pillarColors } from '@/lib/design/pillarColors';
-import {
-  MOCK_FOCUS_PRACTICE,
-  MOCK_PILLAR_LABELS,
-  MOCK_RETURN_DOTS,
-} from '@/lib/mockState';
+import { MOCK_RETURN_DOTS, MOCK_PILLAR_LABELS } from '@/lib/mockState';
+import { practicesById } from '@/lib/practices/library';
+import type { Practice } from '@/lib/practices/library';
+
+type ActiveData = {
+  todayFocusPracticeId: string | null
+}
 
 export default function TodayPage() {
-  const [todayStatus, setTodayStatus] = useState<'did-it' | 'not-today' | null>(null);
-  const practice = MOCK_FOCUS_PRACTICE;
-  const color = pillarColors[practice.pillar];
+  const [focusPractice, setFocusPractice] = useState<Practice | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [todayStatus, setTodayStatus] = useState<'did-it' | 'not-today' | null>(null)
+
+  useEffect(() => {
+    fetch('/api/practices/active')
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed')
+        return res.json() as Promise<ActiveData>
+      })
+      .then((data) => {
+        const practice = data.todayFocusPracticeId
+          ? practicesById.get(data.todayFocusPracticeId) ?? null
+          : null
+        setFocusPractice(practice)
+      })
+      .catch(() => setError(true))
+      .finally(() => setLoading(false))
+  }, [])
 
   return (
     <NarrowFormPage title="Today" description="Your daily check-in." metaLabel="OVERVIEW">
       <div className="space-y-6">
-        {/* Focus practice card */}
-        <Card>
-          <div className="space-y-4">
-            <div>
-              <span
-                className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
-                style={{ backgroundColor: color }}
-              >
-                {MOCK_PILLAR_LABELS[practice.pillar]}
-              </span>
-              <p className="mt-3 text-xl font-semibold text-foreground">{practice.title}</p>
-              <p className="mt-1 text-sm text-muted-foreground">{practice.description}</p>
-            </div>
 
-            {/* Did it / Not today */}
-            <div className="grid grid-cols-2 gap-3 pt-2">
-              <Button
-                variant={todayStatus === 'did-it' ? 'default' : 'outline'}
-                onClick={() => setTodayStatus('did-it')}
-              >
-                ✓ Did it
-              </Button>
-              <Button
-                variant={todayStatus === 'not-today' ? 'secondary' : 'outline'}
-                onClick={() => setTodayStatus('not-today')}
-              >
-                Not today
-              </Button>
-            </div>
+        {loading && <Loading text="Loading today's practice…" />}
 
-            {todayStatus && (
-              <p className="text-sm text-center text-muted-foreground">
-                {todayStatus === 'did-it'
-                  ? 'Nice work. Keep it up tomorrow.'
-                  : 'No worries. Tomorrow is a fresh start.'}
-              </p>
-            )}
-          </div>
-        </Card>
+        {!loading && error && (
+          <ErrorState message="Couldn't load today's practice." onRetry={() => window.location.reload()} />
+        )}
 
-        {/* Recent days dots */}
-        <Card variant="subtle">
-          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Last 14 days</p>
-          <div className="flex flex-wrap gap-2">
-            {MOCK_RETURN_DOTS.map((dot, i) => (
-              <span
-                key={i}
-                className={`h-6 w-6 rounded-full border ${
-                  dot === true
-                    ? 'bg-primary border-primary'
-                    : dot === false
-                    ? 'bg-muted border-border'
-                    : 'bg-transparent border-border/40'
-                }`}
-              />
-            ))}
-          </div>
-        </Card>
+        {!loading && !error && !focusPractice && (
+          <Card>
+            <p className="text-sm text-muted-foreground">
+              No focus practice set yet.{' '}
+              <Link href="/practices" className="text-primary underline underline-offset-2">
+                Set one from your practices →
+              </Link>
+            </p>
+          </Card>
+        )}
 
-        {/* Navigation */}
+        {!loading && !error && focusPractice && (
+          <>
+            {/* Focus practice card */}
+            <Card>
+              <div className="space-y-4">
+                <div>
+                  <span
+                    className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
+                    style={{ backgroundColor: pillarColors[focusPractice.pillar] }}
+                  >
+                    {MOCK_PILLAR_LABELS[focusPractice.pillar]}
+                  </span>
+                  <p className="mt-3 text-xl font-semibold text-foreground">{focusPractice.title}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">{focusPractice.description}</p>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3 pt-2">
+                  <Button
+                    variant={todayStatus === 'did-it' ? 'default' : 'outline'}
+                    onClick={() => setTodayStatus('did-it')}
+                  >
+                    ✓ Did it
+                  </Button>
+                  <Button
+                    variant={todayStatus === 'not-today' ? 'secondary' : 'outline'}
+                    onClick={() => setTodayStatus('not-today')}
+                  >
+                    Not today
+                  </Button>
+                </div>
+
+                {todayStatus && (
+                  <p className="text-sm text-center text-muted-foreground">
+                    {todayStatus === 'did-it'
+                      ? 'Nice work. Keep it up tomorrow.'
+                      : 'No worries. Tomorrow is a fresh start.'}
+                  </p>
+                )}
+              </div>
+            </Card>
+
+            {/* Recent days dots */}
+            <Card variant="subtle">
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Last 14 days</p>
+              <div className="flex flex-wrap gap-2">
+                {MOCK_RETURN_DOTS.map((dot, i) => (
+                  <span
+                    key={i}
+                    className={`h-6 w-6 rounded-full border ${
+                      dot === true
+                        ? 'bg-primary border-primary'
+                        : dot === false
+                        ? 'bg-muted border-border'
+                        : 'bg-transparent border-border/40'
+                    }`}
+                  />
+                ))}
+              </div>
+            </Card>
+          </>
+        )}
+
         <div className="flex justify-between items-center pt-2 text-sm">
           <Link href="/practices" className="text-muted-foreground hover:text-foreground transition-colors">
             ← Manage practices

--- a/lib/practices/trial.ts
+++ b/lib/practices/trial.ts
@@ -25,6 +25,7 @@ export type ProfileData = {
   subscriptionStatus?: string
   activePracticeIds?: string[]
   activePracticeSkById?: Record<string, string>
+  todayFocusPracticeId?: string | null
 }
 
 export type CapCheckResult =

--- a/tests/unit/api/practice.e6.test.ts
+++ b/tests/unit/api/practice.e6.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from '@/app/api/practice/route'
+
+const getItemMock = vi.fn()
+const putItemMock = vi.fn()
+const updateItemMock = vi.fn()
+const queryMock = vi.fn()
+
+vi.mock('@/utils/dynamoClient', () => ({
+  createDynamoClient: () => ({
+    getItem: getItemMock,
+    putItem: putItemMock,
+    updateItem: updateItemMock,
+    query: queryMock,
+  }),
+}))
+
+const getCurrentUserMock = vi.fn()
+vi.mock('aws-amplify/auth/server', () => ({
+  getCurrentUser: () => getCurrentUserMock(),
+}))
+vi.mock('@/utils/amplifyServerUtils', () => ({
+  runWithAmplifyServerContext: ({
+    operation,
+  }: {
+    operation: (ctx: unknown) => Promise<unknown>
+  }) => operation({}),
+}))
+
+function makeReq(body: object) {
+  return new Request('http://localhost/api/practice', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  getCurrentUserMock.mockResolvedValue({ userId: 'u1', username: 'user' })
+  getItemMock.mockReset()
+  putItemMock.mockReset()
+  updateItemMock.mockReset()
+  queryMock.mockReset()
+  putItemMock.mockResolvedValue(undefined)
+  updateItemMock.mockResolvedValue(undefined)
+})
+
+// ── add ──────────────────────────────────────────────────────────────────────
+describe('POST /api/practice — add', () => {
+  it('creates UPRACTICE and returns 201', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: [], activePracticeSkById: {}, subscriptionStatus: 'FREE' })
+    const res = await POST(makeReq({ mode: 'add', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(201)
+    expect(putItemMock).toHaveBeenCalledOnce()
+    expect(updateItemMock).toHaveBeenCalledOnce()
+  })
+
+  it('returns 409 ALREADY_ACTIVE when practice is active', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], subscriptionStatus: 'FREE' })
+    const res = await POST(makeReq({ mode: 'add', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toBe('ALREADY_ACTIVE')
+  })
+
+  it('returns 409 CAP_REACHED for FREE user at cap', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: ['financial-weekly-review'], subscriptionStatus: 'FREE' })
+    const res = await POST(makeReq({ mode: 'add', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toBe('CAP_REACHED')
+    expect(putItemMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 for unknown practice', async () => {
+    const res = await POST(makeReq({ mode: 'add', practiceId: 'nonexistent' }))
+    expect(res.status).toBe(404)
+  })
+})
+
+// ── replace ──────────────────────────────────────────────────────────────────
+describe('POST /api/practice — replace', () => {
+  it('returns 202 CONFIRM_REQUIRED on first call', async () => {
+    const res = await POST(makeReq({
+      mode: 'replace',
+      practiceId: 'sleep-consistent-bedtime',
+      replacePracticeId: 'financial-weekly-review',
+    }))
+    expect(res.status).toBe(202)
+    const json = await res.json()
+    expect(json.confirmRequired).toBe(true)
+    expect(typeof json.confirmToken).toBe('string')
+  })
+
+  it('executes replace with valid confirmToken', async () => {
+    // Step 1: get token
+    const r1 = await POST(makeReq({
+      mode: 'replace',
+      practiceId: 'sleep-consistent-bedtime',
+      replacePracticeId: 'financial-weekly-review',
+    }))
+    const { confirmToken } = await r1.json()
+
+    // Step 2: confirm
+    getItemMock.mockResolvedValue({
+      activePracticeIds: ['financial-weekly-review'],
+      activePracticeSkById: { 'financial-weekly-review': 'UPRACTICE#financial-weekly-review' },
+      subscriptionStatus: 'FREE',
+    })
+    const r2 = await POST(makeReq({
+      mode: 'replace',
+      practiceId: 'sleep-consistent-bedtime',
+      replacePracticeId: 'financial-weekly-review',
+      confirmToken,
+    }))
+    expect(r2.status).toBe(200)
+    expect(putItemMock).toHaveBeenCalledOnce()
+    expect(updateItemMock).toHaveBeenCalledTimes(2) // old UPRACTICE + PROFILE
+  })
+
+  it('returns 409 INVALID_CONFIRM_TOKEN for bad token', async () => {
+    getItemMock.mockResolvedValue({
+      activePracticeIds: ['financial-weekly-review'],
+      subscriptionStatus: 'FREE',
+    })
+    const res = await POST(makeReq({
+      mode: 'replace',
+      practiceId: 'sleep-consistent-bedtime',
+      replacePracticeId: 'financial-weekly-review',
+      confirmToken: 'bad-token',
+    }))
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toBe('INVALID_CONFIRM_TOKEN')
+  })
+
+  it('returns 400 when replacePracticeId is missing', async () => {
+    const res = await POST(makeReq({ mode: 'replace', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(400)
+  })
+})
+
+// ── pause ────────────────────────────────────────────────────────────────────
+describe('POST /api/practice — pause', () => {
+  it('pauses an active practice', async () => {
+    getItemMock
+      .mockResolvedValueOnce({ PK: 'USER#u1', SK: 'UPRACTICE#sleep-consistent-bedtime', practiceId: 'sleep-consistent-bedtime', status: 'active' })
+      .mockResolvedValueOnce({ activePracticeIds: ['sleep-consistent-bedtime'], subscriptionStatus: 'FREE' })
+    const res = await POST(makeReq({ mode: 'pause', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(200)
+    expect(updateItemMock).toHaveBeenCalledTimes(2) // UPRACTICE + PROFILE
+    const upracticeCall = updateItemMock.mock.calls[0][0]
+    expect(upracticeCall.ExpressionAttributeValues[':status']).toBe('paused')
+  })
+
+  it('returns 404 when practice is not active', async () => {
+    getItemMock.mockResolvedValue(null)
+    const res = await POST(makeReq({ mode: 'pause', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(404)
+  })
+})
+
+// ── resume ───────────────────────────────────────────────────────────────────
+describe('POST /api/practice — resume', () => {
+  it('resumes a paused practice', async () => {
+    getItemMock
+      .mockResolvedValueOnce({ practiceId: 'sleep-consistent-bedtime', status: 'paused' })
+      .mockResolvedValueOnce({ activePracticeIds: [], subscriptionStatus: 'FREE' })
+    const res = await POST(makeReq({ mode: 'resume', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(200)
+    const upracticeCall = updateItemMock.mock.calls[0][0]
+    expect(upracticeCall.ExpressionAttributeValues[':status']).toBe('active')
+  })
+
+  it('returns 409 CAP_REACHED when at cap', async () => {
+    getItemMock
+      .mockResolvedValueOnce({ practiceId: 'sleep-consistent-bedtime', status: 'paused' })
+      .mockResolvedValueOnce({ activePracticeIds: ['financial-weekly-review'], subscriptionStatus: 'FREE' })
+    const res = await POST(makeReq({ mode: 'resume', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(409)
+    expect(updateItemMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when practice is not paused', async () => {
+    getItemMock
+      .mockResolvedValueOnce({ practiceId: 'sleep-consistent-bedtime', status: 'active' })
+      .mockResolvedValueOnce({ activePracticeIds: [], subscriptionStatus: 'FREE' })
+    const res = await POST(makeReq({ mode: 'resume', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(404)
+  })
+})
+
+// ── setFocus ──────────────────────────────────────────────────────────────────
+describe('POST /api/practice — setFocus', () => {
+  it('sets focus for an active practice', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([])
+    const res = await POST(makeReq({ mode: 'setFocus', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(200)
+    const call = updateItemMock.mock.calls[0][0]
+    expect(call.ExpressionAttributeValues[':id']).toBe('sleep-consistent-bedtime')
+  })
+
+  it('sets focus for an active trial practice', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: [], subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([{
+      practiceId: 'sleep-consistent-bedtime',
+      status: 'trial',
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      SK: 'TRIAL#x#sleep-consistent-bedtime',
+    }])
+    const res = await POST(makeReq({ mode: 'setFocus', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 409 when practice is neither active nor a trial', async () => {
+    getItemMock.mockResolvedValue({ activePracticeIds: [], subscriptionStatus: 'FREE' })
+    queryMock.mockResolvedValue([])
+    const res = await POST(makeReq({ mode: 'setFocus', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(409)
+    expect(updateItemMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- **`add`** — directly add a practice to active (cap enforced)
- **`replace`** — swap one active practice for another via 2-step confirm token flow (prevents accidental swaps)
- **`pause`** — removes from `activePracticeIds` without deleting history, UPRACTICE status=paused
- **`resume`** — re-activates a paused practice (cap enforced)
- **`setFocus`** — sets `PROFILE.todayFocusPracticeId`; validates practice is active or has an active trial
- **GET `/api/practices/active`** — now returns `pausedPractices` and `todayFocusPracticeId`
- **`/practices` page** — all buttons wired: Set focus (with badge), Pause, Resume, Replace (inline picker + confirm step), with per-action loading/error/warning states

## Test plan
- [ ] Start a trial → Promote → appears in Active section
- [ ] Click Set focus → badge appears on that practice, persists on reload
- [ ] Click Pause → practice moves to Paused section
- [ ] Click Resume → practice returns to Active section
- [ ] Click Replace → inline picker appears → select practice → confirm → swap executes
- [ ] FREE user: add/promote/resume blocked at 1 active practice
- [ ] `npm test` — 172 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)