### PR TITLE
Epic #7: Daily returns habit loop

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -21,3 +21,12 @@ const fiappMainTable = new aws_dynamodb.Table(externalDataSourcesStack, "FIAPP_M
 
 // IMPORTANT: This string is the DataSource name your schema must reference
 backend.data.addDynamoDbDataSource("FIAppMainDataSource", fiappMainTable);
+
+// Returns table — high-write habit loop data (separate table for prod scale)
+new aws_dynamodb.Table(externalDataSourcesStack, "FIAPP_RETURNS", {
+  tableName: "FIAPP_RETURNS",
+  partitionKey: { name: "PK", type: aws_dynamodb.AttributeType.STRING },
+  sortKey: { name: "SK", type: aws_dynamodb.AttributeType.STRING },
+  billingMode: aws_dynamodb.BillingMode.PAY_PER_REQUEST,
+  removalPolicy: RemovalPolicy.DESTROY,
+});

--- a/app/api/return/route.ts
+++ b/app/api/return/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server'
+import { createDynamoClient, createReturnsClient } from '@/utils/dynamoClient'
+import { withAuth } from '@/utils/authServer'
+import { practicesById } from '@/lib/practices/library'
+import { isTrialActive, type TrialItem, type ProfileData } from '@/lib/practices/trial'
+import {
+  todayUTC,
+  makeReturnPK,
+  makeReturnSK,
+  computeDelta,
+  applyDelta,
+  type ReturnItem,
+} from '@/lib/returns/returns'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type Body = {
+  practiceId: string
+  didIt: boolean
+  date?: string
+}
+
+export async function POST(req: Request) {
+  return withAuth(req, async (user) => {
+    let body: Body
+    try {
+      body = (await req.json()) as Body
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+    }
+
+    const { practiceId, didIt, date } = body ?? {}
+    if (!practiceId || typeof didIt !== 'boolean') {
+      return NextResponse.json({ error: 'practiceId and didIt required' }, { status: 400 })
+    }
+    if (!practicesById.get(practiceId)) {
+      return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
+    }
+
+    const returnDate = date ?? todayUTC()
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(returnDate)) {
+      return NextResponse.json({ error: 'Invalid date format, use YYYY-MM-DD' }, { status: 400 })
+    }
+
+    const pk = `USER#${user.userId}`
+    const mainClient = createDynamoClient()
+    const returnsClient = createReturnsClient()
+
+    // Validate practice is active or active trial
+    const [profile, trials] = await Promise.all([
+      mainClient.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
+      mainClient.query<TrialItem>({
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+        ExpressionAttributeValues: { ':pk': pk, ':prefix': 'TRIAL#' },
+      }),
+    ])
+
+    const activePracticeIds = profile?.activePracticeIds ?? []
+    const isActive = activePracticeIds.includes(practiceId)
+    const hasActiveTrial = trials.some((t) => t.practiceId === practiceId && isTrialActive(t))
+
+    if (!isActive && !hasActiveTrial) {
+      return NextResponse.json({ error: 'PRACTICE_NOT_ACTIVE_OR_TRIAL' }, { status: 409 })
+    }
+
+    // Read existing return for idempotency
+    const returnPK = makeReturnPK(user.userId, practiceId)
+    const returnSK = makeReturnSK(returnDate)
+    const existing = await returnsClient.getItem<ReturnItem>({ PK: returnPK, SK: returnSK })
+
+    const delta = computeDelta(existing?.didIt, didIt)
+
+    // No-op if value unchanged
+    if (existing && delta === 0) {
+      return NextResponse.json({ ok: true, noop: true, didIt, date: returnDate }, { status: 200 })
+    }
+
+    const now = new Date().toISOString()
+
+    // Upsert return record
+    await returnsClient.putItem({
+      PK: returnPK,
+      SK: returnSK,
+      didIt,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    })
+
+    // Update returnCounters in PROFILE if delta != 0
+    if (delta !== 0) {
+      const raw = profile?.returnCounters
+      const counters: Record<string, number> =
+        typeof raw === 'string'
+          ? JSON.parse(raw || '{}')
+          : (raw as Record<string, number> | undefined) ?? {}
+      const updated = applyDelta(counters, practiceId, delta)
+      await mainClient.updateItem({
+        Key: { PK: pk, SK: 'PROFILE' },
+        UpdateExpression: 'SET returnCounters = :counters',
+        ExpressionAttributeValues: { ':counters': updated },
+      })
+    }
+
+    return NextResponse.json({ ok: true, didIt, date: returnDate, delta }, { status: 200 })
+  })
+}

--- a/app/api/returns/route.ts
+++ b/app/api/returns/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+import { createReturnsClient } from '@/utils/dynamoClient'
+import { withAuth } from '@/utils/authServer'
+import { practicesById } from '@/lib/practices/library'
+import {
+  RETURNS_DEFAULT_DAYS,
+  RETURNS_MIN_DAYS,
+  RETURNS_MAX_DAYS,
+  dateRange,
+  makeReturnPK,
+  makeReturnSK,
+  type ReturnItem,
+  type DotEntry,
+} from '@/lib/returns/returns'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: Request) {
+  return withAuth(req, async (user) => {
+    const url = new URL(req.url)
+    const practiceId = url.searchParams.get('practiceId')
+    const daysParam = parseInt(url.searchParams.get('days') ?? String(RETURNS_DEFAULT_DAYS), 10)
+
+    if (!practiceId) {
+      return NextResponse.json({ error: 'practiceId required' }, { status: 400 })
+    }
+    if (!practicesById.get(practiceId)) {
+      return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
+    }
+    const days = Math.min(RETURNS_MAX_DAYS, Math.max(RETURNS_MIN_DAYS, isNaN(daysParam) ? RETURNS_DEFAULT_DAYS : daysParam))
+
+    const dates = dateRange(days)
+    const startDate = dates[0]
+    const endDate = dates[dates.length - 1]
+
+    const client = createReturnsClient()
+    const items = await client.query<ReturnItem>({
+      KeyConditionExpression: 'PK = :pk AND SK BETWEEN :start AND :end',
+      ExpressionAttributeValues: {
+        ':pk': makeReturnPK(user.userId, practiceId),
+        ':start': makeReturnSK(startDate),
+        ':end': makeReturnSK(endDate),
+      },
+    })
+
+    const byDate = new Map(items.map((r) => [r.SK.replace('DATE#', ''), r.didIt]))
+
+    const returns: DotEntry[] = dates.map((date) => ({
+      date,
+      didIt: byDate.has(date) ? (byDate.get(date) ?? null) : null,
+    }))
+
+    const total = items.filter((r) => r.didIt).length
+
+    return NextResponse.json({ returns, total, days }, { status: 200 })
+  })
+}

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -1,23 +1,41 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { NarrowFormPage } from '@/components/layout';
 import { Card, Button, Loading, ErrorState } from '@/components/ui';
 import { pillarColors } from '@/lib/design/pillarColors';
-import { MOCK_RETURN_DOTS, MOCK_PILLAR_LABELS } from '@/lib/mockState';
+import { MOCK_PILLAR_LABELS } from '@/lib/mockState';
 import { practicesById } from '@/lib/practices/library';
+import { todayUTC } from '@/lib/returns/returns';
 import type { Practice } from '@/lib/practices/library';
+import type { DotEntry } from '@/lib/returns/returns';
 
 type ActiveData = {
   todayFocusPracticeId: string | null
 }
 
+type ReturnsData = {
+  returns: DotEntry[]
+}
+
 export default function TodayPage() {
   const [focusPractice, setFocusPractice] = useState<Practice | null>(null)
+  const [dots, setDots] = useState<DotEntry[]>([])
+  const [todayDidIt, setTodayDidIt] = useState<boolean | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
-  const [todayStatus, setTodayStatus] = useState<'did-it' | 'not-today' | null>(null)
+  const [logging, setLogging] = useState(false)
+  const [logError, setLogError] = useState('')
+
+  const loadReturns = useCallback(async (practiceId: string) => {
+    const res = await fetch(`/api/returns?practiceId=${practiceId}&days=14`)
+    if (!res.ok) return
+    const data: ReturnsData = await res.json()
+    setDots(data.returns)
+    const today = data.returns.find((d) => d.date === todayUTC())
+    setTodayDidIt(today?.didIt ?? null)
+  }, [])
 
   useEffect(() => {
     fetch('/api/practices/active')
@@ -25,22 +43,46 @@ export default function TodayPage() {
         if (!res.ok) throw new Error('Failed')
         return res.json() as Promise<ActiveData>
       })
-      .then((data) => {
+      .then(async (data) => {
         const practice = data.todayFocusPracticeId
           ? practicesById.get(data.todayFocusPracticeId) ?? null
           : null
         setFocusPractice(practice)
+        if (practice) await loadReturns(practice.id)
       })
       .catch(() => setError(true))
       .finally(() => setLoading(false))
-  }, [])
+  }, [loadReturns])
+
+  async function handleLog(value: boolean) {
+    if (!focusPractice) return
+
+    // Toggle: clicking the active button again un-logs it
+    const newValue = todayDidIt === value ? !value : value
+
+    setLogging(true)
+    setLogError('')
+    try {
+      const res = await fetch('/api/return', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ practiceId: focusPractice.id, didIt: newValue }),
+      })
+      if (!res.ok) throw new Error('Failed to log return')
+      setTodayDidIt(newValue)
+      await loadReturns(focusPractice.id)
+    } catch {
+      setLogError('Could not save. Please try again.')
+    } finally {
+      setLogging(false)
+    }
+  }
 
   return (
     <NarrowFormPage title="Today" description="Your daily check-in." metaLabel="OVERVIEW">
       <div className="space-y-6">
 
         {loading && <Loading text="Loading today's practice…" />}
-
         {!loading && error && (
           <ErrorState message="Couldn't load today's practice." onRetry={() => window.location.reload()} />
         )}
@@ -58,7 +100,6 @@ export default function TodayPage() {
 
         {!loading && !error && focusPractice && (
           <>
-            {/* Focus practice card */}
             <Card>
               <div className="space-y-4">
                 <div>
@@ -74,40 +115,49 @@ export default function TodayPage() {
 
                 <div className="grid grid-cols-2 gap-3 pt-2">
                   <Button
-                    variant={todayStatus === 'did-it' ? 'default' : 'outline'}
-                    onClick={() => setTodayStatus('did-it')}
+                    variant={todayDidIt === true ? 'default' : 'outline'}
+                    disabled={logging}
+                    onClick={() => handleLog(true)}
                   >
-                    ✓ Did it
+                    {logging && todayDidIt !== true ? '…' : '✓ Did it'}
                   </Button>
                   <Button
-                    variant={todayStatus === 'not-today' ? 'secondary' : 'outline'}
-                    onClick={() => setTodayStatus('not-today')}
+                    variant={todayDidIt === false ? 'secondary' : 'outline'}
+                    disabled={logging}
+                    onClick={() => handleLog(false)}
                   >
-                    Not today
+                    {logging && todayDidIt !== false ? '…' : 'Not today'}
                   </Button>
                 </div>
 
-                {todayStatus && (
+                {todayDidIt === true && !logging && (
                   <p className="text-sm text-center text-muted-foreground">
-                    {todayStatus === 'did-it'
-                      ? 'Nice work. Keep it up tomorrow.'
-                      : 'No worries. Tomorrow is a fresh start.'}
+                    Nice work. Keep it up tomorrow.
                   </p>
+                )}
+                {todayDidIt === false && !logging && (
+                  <p className="text-sm text-center text-muted-foreground">
+                    No worries. Tomorrow is a fresh start.
+                  </p>
+                )}
+                {logError && (
+                  <p className="text-xs text-destructive text-center">{logError}</p>
                 )}
               </div>
             </Card>
 
-            {/* Recent days dots */}
+            {/* 14-day dots */}
             <Card variant="subtle">
               <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Last 14 days</p>
               <div className="flex flex-wrap gap-2">
-                {MOCK_RETURN_DOTS.map((dot, i) => (
+                {dots.map((dot) => (
                   <span
-                    key={i}
-                    className={`h-6 w-6 rounded-full border ${
-                      dot === true
+                    key={dot.date}
+                    title={dot.date}
+                    className={`h-6 w-6 rounded-full border transition-colors ${
+                      dot.didIt === true
                         ? 'bg-primary border-primary'
-                        : dot === false
+                        : dot.didIt === false
                         ? 'bg-muted border-border'
                         : 'bg-transparent border-border/40'
                     }`}

--- a/lib/returns/returns.ts
+++ b/lib/returns/returns.ts
@@ -1,0 +1,56 @@
+export const RETURNS_MIN_DAYS = 1
+export const RETURNS_MAX_DAYS = 30
+export const RETURNS_DEFAULT_DAYS = 14
+
+export type ReturnItem = {
+  PK: string
+  SK: string
+  didIt: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export type DotEntry = {
+  date: string       // YYYY-MM-DD
+  didIt: boolean | null
+}
+
+export function todayUTC(): string {
+  return new Date().toISOString().split('T')[0]
+}
+
+export function dateRange(days: number, endDate = todayUTC()): string[] {
+  const end = new Date(`${endDate}T00:00:00Z`)
+  const dates: string[] = []
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(end)
+    d.setUTCDate(d.getUTCDate() - i)
+    dates.push(d.toISOString().split('T')[0])
+  }
+  return dates
+}
+
+export function makeReturnPK(userId: string, practiceId: string): string {
+  return `USER#${userId}#PRACTICE#${practiceId}`
+}
+
+export function makeReturnSK(date: string): string {
+  return `DATE#${date}`
+}
+
+/** delta to apply to the didIt counter (+1, -1, or 0) */
+export function computeDelta(oldDidIt: boolean | undefined, newDidIt: boolean): number {
+  if (oldDidIt === newDidIt) return 0          // no-op
+  if (oldDidIt === undefined) return newDidIt ? 1 : 0   // new record
+  return newDidIt ? 1 : -1                     // toggle
+}
+
+export function applyDelta(
+  counters: Record<string, number>,
+  practiceId: string,
+  delta: number
+): Record<string, number> {
+  if (delta === 0) return counters
+  const current = counters[practiceId] ?? 0
+  return { ...counters, [practiceId]: Math.max(0, current + delta) }
+}

--- a/tests/unit/api/return.post.test.ts
+++ b/tests/unit/api/return.post.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from '@/app/api/return/route'
+
+const mainGetItemMock = vi.fn()
+const mainQueryMock = vi.fn()
+const mainUpdateItemMock = vi.fn()
+const returnsGetItemMock = vi.fn()
+const returnsPutItemMock = vi.fn()
+
+vi.mock('@/utils/dynamoClient', () => ({
+  createDynamoClient: () => ({
+    getItem: mainGetItemMock,
+    query: mainQueryMock,
+    updateItem: mainUpdateItemMock,
+  }),
+  createReturnsClient: () => ({
+    getItem: returnsGetItemMock,
+    putItem: returnsPutItemMock,
+  }),
+}))
+
+const getCurrentUserMock = vi.fn()
+vi.mock('aws-amplify/auth/server', () => ({
+  getCurrentUser: () => getCurrentUserMock(),
+}))
+vi.mock('@/utils/amplifyServerUtils', () => ({
+  runWithAmplifyServerContext: ({
+    operation,
+  }: {
+    operation: (ctx: unknown) => Promise<unknown>
+  }) => operation({}),
+}))
+
+function makeReq(body: object) {
+  return new Request('http://localhost/api/return', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  getCurrentUserMock.mockResolvedValue({ userId: 'u1', username: 'user' })
+  mainGetItemMock.mockReset()
+  mainQueryMock.mockReset()
+  mainUpdateItemMock.mockReset()
+  returnsGetItemMock.mockReset()
+  returnsPutItemMock.mockReset()
+  mainUpdateItemMock.mockResolvedValue(undefined)
+  returnsPutItemMock.mockResolvedValue(undefined)
+  mainQueryMock.mockResolvedValue([])
+})
+
+describe('POST /api/return', () => {
+  it('creates a new return record (didIt=true) and returns delta=1', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], returnCounters: {} })
+    returnsGetItemMock.mockResolvedValue(undefined)
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: true }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.didIt).toBe(true)
+    expect(json.delta).toBe(1)
+    expect(returnsPutItemMock).toHaveBeenCalledOnce()
+    expect(mainUpdateItemMock).toHaveBeenCalledOnce()
+  })
+
+  it('creates a new return record (didIt=false) and returns delta=0, skips counter update', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], returnCounters: {} })
+    returnsGetItemMock.mockResolvedValue(undefined)
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: false }))
+    const json = await res.json()
+    expect(json.delta).toBe(0)
+    expect(returnsPutItemMock).toHaveBeenCalledOnce()
+    expect(mainUpdateItemMock).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent — same value returns noop=true', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], returnCounters: {} })
+    returnsGetItemMock.mockResolvedValue({ didIt: true, createdAt: 'x', updatedAt: 'x' })
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: true }))
+    const json = await res.json()
+    expect(json.noop).toBe(true)
+    expect(returnsPutItemMock).not.toHaveBeenCalled()
+    expect(mainUpdateItemMock).not.toHaveBeenCalled()
+  })
+
+  it('toggle true→false returns delta=-1', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], returnCounters: { 'sleep-consistent-bedtime': 5 } })
+    returnsGetItemMock.mockResolvedValue({ didIt: true, createdAt: 'x', updatedAt: 'x' })
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: false }))
+    const json = await res.json()
+    expect(json.delta).toBe(-1)
+    expect(mainUpdateItemMock).toHaveBeenCalledOnce()
+    const counters = mainUpdateItemMock.mock.calls[0][0].ExpressionAttributeValues[':counters']
+    expect(counters['sleep-consistent-bedtime']).toBe(4)
+  })
+
+  it('toggle false→true returns delta=+1', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], returnCounters: {} })
+    returnsGetItemMock.mockResolvedValue({ didIt: false, createdAt: 'x', updatedAt: 'x' })
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: true }))
+    const json = await res.json()
+    expect(json.delta).toBe(1)
+  })
+
+  // E5-T13: returns during trial count toward counters
+  it('E5-T13: counts return during active trial', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: [], returnCounters: {} })
+    mainQueryMock.mockResolvedValue([{
+      practiceId: 'sleep-consistent-bedtime',
+      status: 'trial',
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      SK: 'TRIAL#x#sleep-consistent-bedtime',
+    }])
+    returnsGetItemMock.mockResolvedValue(undefined)
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: true }))
+    expect(res.status).toBe(200)
+    expect((await res.json()).delta).toBe(1)
+    expect(mainUpdateItemMock).toHaveBeenCalledOnce()
+  })
+
+  it('returns 409 when practice is not active or trial', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: [], returnCounters: {} })
+    mainQueryMock.mockResolvedValue([])
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: true }))
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toBe('PRACTICE_NOT_ACTIVE_OR_TRIAL')
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    getCurrentUserMock.mockRejectedValue(new Error('Unauthorized'))
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: true }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 for missing fields', async () => {
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(400)
+  })
+})

--- a/tests/unit/api/returns.get.test.ts
+++ b/tests/unit/api/returns.get.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET } from '@/app/api/returns/route'
+
+const returnsQueryMock = vi.fn()
+
+vi.mock('@/utils/dynamoClient', () => ({
+  createReturnsClient: () => ({
+    query: returnsQueryMock,
+  }),
+}))
+
+const getCurrentUserMock = vi.fn()
+vi.mock('aws-amplify/auth/server', () => ({
+  getCurrentUser: () => getCurrentUserMock(),
+}))
+vi.mock('@/utils/amplifyServerUtils', () => ({
+  runWithAmplifyServerContext: ({
+    operation,
+  }: {
+    operation: (ctx: unknown) => Promise<unknown>
+  }) => operation({}),
+}))
+
+function makeReq(params: Record<string, string>) {
+  const url = new URL('http://localhost/api/returns')
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  return new Request(url)
+}
+
+beforeEach(() => {
+  getCurrentUserMock.mockResolvedValue({ userId: 'u1', username: 'user' })
+  returnsQueryMock.mockReset()
+  returnsQueryMock.mockResolvedValue([])
+})
+
+describe('GET /api/returns', () => {
+  it('returns exactly 14 entries by default', async () => {
+    const res = await GET(makeReq({ practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.returns).toHaveLength(14)
+    expect(json.days).toBe(14)
+  })
+
+  it('returns exactly N entries for custom days param', async () => {
+    const res = await GET(makeReq({ practiceId: 'sleep-consistent-bedtime', days: '7' }))
+    const json = await res.json()
+    expect(json.returns).toHaveLength(7)
+  })
+
+  it('clamps days to max 30', async () => {
+    const res = await GET(makeReq({ practiceId: 'sleep-consistent-bedtime', days: '999' }))
+    const json = await res.json()
+    expect(json.returns).toHaveLength(30)
+  })
+
+  it('clamps days to min 1', async () => {
+    const res = await GET(makeReq({ practiceId: 'sleep-consistent-bedtime', days: '0' }))
+    const json = await res.json()
+    expect(json.returns).toHaveLength(1)
+  })
+
+  it('fills missing dates with didIt=null', async () => {
+    returnsQueryMock.mockResolvedValue([])
+    const res = await GET(makeReq({ practiceId: 'sleep-consistent-bedtime', days: '3' }))
+    const json = await res.json()
+    expect(json.returns.every((d: { didIt: unknown }) => d.didIt === null)).toBe(true)
+  })
+
+  it('maps existing return records correctly', async () => {
+    returnsQueryMock.mockResolvedValue([
+      { PK: 'x', SK: `DATE#${new Date().toISOString().split('T')[0]}`, didIt: true, createdAt: '', updatedAt: '' },
+    ])
+    const res = await GET(makeReq({ practiceId: 'sleep-consistent-bedtime', days: '1' }))
+    const json = await res.json()
+    expect(json.returns[0].didIt).toBe(true)
+    expect(json.total).toBe(1)
+  })
+
+  it('returns ordered oldest → newest', async () => {
+    const res = await GET(makeReq({ practiceId: 'sleep-consistent-bedtime', days: '3' }))
+    const json = await res.json()
+    const dates = json.returns.map((d: { date: string }) => d.date)
+    expect(dates[0] < dates[1] && dates[1] < dates[2]).toBe(true)
+  })
+
+  it('returns 400 when practiceId is missing', async () => {
+    const res = await GET(makeReq({}))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    getCurrentUserMock.mockRejectedValue(new Error('Unauthorized'))
+    const res = await GET(makeReq({ practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(401)
+  })
+})

--- a/tests/unit/returns/returns.test.ts
+++ b/tests/unit/returns/returns.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  dateRange,
+  computeDelta,
+  applyDelta,
+  makeReturnPK,
+  makeReturnSK,
+  todayUTC,
+} from '@/lib/returns/returns'
+
+describe('todayUTC', () => {
+  it('returns a YYYY-MM-DD string', () => {
+    expect(todayUTC()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+
+describe('dateRange', () => {
+  it('returns exactly N dates', () => {
+    expect(dateRange(14)).toHaveLength(14)
+    expect(dateRange(7)).toHaveLength(7)
+    expect(dateRange(30)).toHaveLength(30)
+  })
+
+  it('last entry is the end date', () => {
+    const range = dateRange(7, '2026-01-10')
+    expect(range[range.length - 1]).toBe('2026-01-10')
+  })
+
+  it('first entry is N-1 days before end', () => {
+    const range = dateRange(7, '2026-01-10')
+    expect(range[0]).toBe('2026-01-04')
+  })
+
+  it('is ordered oldest → newest', () => {
+    const range = dateRange(5, '2026-01-05')
+    expect(range).toEqual(['2026-01-01', '2026-01-02', '2026-01-03', '2026-01-04', '2026-01-05'])
+  })
+})
+
+describe('computeDelta', () => {
+  it('new record didIt=true → +1', () => expect(computeDelta(undefined, true)).toBe(1))
+  it('new record didIt=false → 0', () => expect(computeDelta(undefined, false)).toBe(0))
+  it('toggle true→false → -1', () => expect(computeDelta(true, false)).toBe(-1))
+  it('toggle false→true → +1', () => expect(computeDelta(false, true)).toBe(1))
+  it('same value true→true → 0', () => expect(computeDelta(true, true)).toBe(0))
+  it('same value false→false → 0', () => expect(computeDelta(false, false)).toBe(0))
+})
+
+describe('applyDelta', () => {
+  it('increments counter', () => {
+    expect(applyDelta({ 'p1': 3 }, 'p1', 1)).toEqual({ 'p1': 4 })
+  })
+
+  it('decrements counter', () => {
+    expect(applyDelta({ 'p1': 3 }, 'p1', -1)).toEqual({ 'p1': 2 })
+  })
+
+  it('initialises missing key at 0 + delta', () => {
+    expect(applyDelta({}, 'p1', 1)).toEqual({ 'p1': 1 })
+  })
+
+  it('guards against negative counters', () => {
+    expect(applyDelta({ 'p1': 0 }, 'p1', -1)).toEqual({ 'p1': 0 })
+  })
+
+  it('no-op when delta is 0', () => {
+    const counters = { 'p1': 5 }
+    expect(applyDelta(counters, 'p1', 0)).toBe(counters)
+  })
+})
+
+describe('SK helpers', () => {
+  it('makeReturnPK', () => {
+    expect(makeReturnPK('u1', 'sleep-consistent-bedtime')).toBe(
+      'USER#u1#PRACTICE#sleep-consistent-bedtime'
+    )
+  })
+  it('makeReturnSK', () => {
+    expect(makeReturnSK('2026-01-15')).toBe('DATE#2026-01-15')
+  })
+})

--- a/utils/dynamoClient.ts
+++ b/utils/dynamoClient.ts
@@ -77,3 +77,8 @@ export class DynamoClient {
 export function createDynamoClient(options: DynamoClientOptions = {}) {
   return new DynamoClient(options);
 }
+
+export function createReturnsClient(options: Omit<DynamoClientOptions, 'tableName'> = {}) {
+  const tableName = process.env.FIAPP_RETURNS_TABLE ?? process.env.FIAPP_MAIN_TABLE;
+  return new DynamoClient({ ...options, tableName });
+}


### PR DESCRIPTION
## Summary
- **`POST /api/return`** — idempotent per-day return logging with toggle delta logic (true→false = -1, false→true = +1, same = no-op). Validates practice is active or active trial, updates `PROFILE.returnCounters`
- **`GET /api/returns`** — variable lookback (1–30 days, default 14), returns ordered `DotEntry[]` with `null` for unlogged days
- **`createReturnsClient()`** — falls back to `FIAPP_MAIN_TABLE` locally; `FIAPP_RETURNS` table added to CDK for future deployment
- **Today page** — fully wired: loads `todayFocusPracticeId` + 14-day dots on mount; "Did it" / "Not today" call `POST /api/return` with toggle support and loading/error states
- **E5-T13 completed** — returns logged during an active trial increment `returnCounters`

## Test plan
- [ ] Set focus on a practice → navigate to `/today` → focus practice shown
- [ ] Click "Did it" → dot turns filled for today, counter logs
- [ ] Click "Did it" again (toggle) → dot clears, counter decrements
- [ ] Click "Not today" → dot shown as logged-but-skipped
- [ ] Reload `/today` → buttons and dots reflect persisted state
- [ ] `npm test` — 208 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)