### PR TITLE
Epic 8: Counters & Milestones

### DIFF
--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server'
+import { createDynamoClient } from '@/utils/dynamoClient'
+import { withAuth } from '@/utils/authServer'
+import type { ProfileData } from '@/lib/practices/trial'
+import type { MilestoneItem } from '@/lib/milestones/milestones'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type UPracticeItem = { SK: string; status?: string }
+
+export async function GET(req: Request) {
+  return withAuth(req, async (user) => {
+    const pk = `USER#${user.userId}`
+    const client = createDynamoClient()
+
+    const [profile, upractices, milestones] = await Promise.all([
+      client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
+      client.query<UPracticeItem>({
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+        ExpressionAttributeValues: { ':pk': pk, ':prefix': 'UPRACTICE#' },
+      }),
+      client.query<MilestoneItem>({
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+        ExpressionAttributeValues: { ':pk': pk, ':prefix': 'MILESTONE#' },
+        ScanIndexForward: false,
+      }),
+    ])
+
+    const raw = profile?.returnCounters
+    const counters: Record<string, number> =
+      typeof raw === 'string'
+        ? JSON.parse(raw || '{}')
+        : (raw as Record<string, number> | undefined) ?? {}
+
+    const totalReturns = Object.values(counters).reduce((sum, v) => sum + v, 0)
+    const practicesActivated = upractices.length
+
+    return NextResponse.json({
+      ok: true,
+      totalReturns,
+      practicesActivated,
+      milestones: milestones.map((m) => ({
+        sk: m.SK,
+        type: m.type,
+        threshold: m.threshold,
+        practiceId: m.practiceId,
+        title: m.title,
+        description: m.description,
+        achievedAt: m.achievedAt,
+      })),
+    })
+  })
+}

--- a/app/api/return/route.ts
+++ b/app/api/return/route.ts
@@ -11,6 +11,12 @@ import {
   applyDelta,
   type ReturnItem,
 } from '@/lib/returns/returns'
+import {
+  checkNewMilestones,
+  getMilestoneDef,
+  makeMilestoneSK,
+  type NewMilestone,
+} from '@/lib/milestones/milestones'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -73,7 +79,7 @@ export async function POST(req: Request) {
 
     // No-op if value unchanged
     if (existing && delta === 0) {
-      return NextResponse.json({ ok: true, noop: true, didIt, date: returnDate }, { status: 200 })
+      return NextResponse.json({ ok: true, noop: true, didIt, date: returnDate, newMilestones: [] }, { status: 200 })
     }
 
     const now = new Date().toISOString()
@@ -87,7 +93,9 @@ export async function POST(req: Request) {
       updatedAt: now,
     })
 
-    // Update returnCounters in PROFILE if delta != 0
+    let newMilestones: NewMilestone[] = []
+
+    // Update returnCounters and check milestones if delta != 0
     if (delta !== 0) {
       const raw = profile?.returnCounters
       const counters: Record<string, number> =
@@ -100,8 +108,36 @@ export async function POST(req: Request) {
         UpdateExpression: 'SET returnCounters = :counters',
         ExpressionAttributeValues: { ':counters': updated },
       })
+
+      // Check and persist milestones triggered by this check-in
+      if (delta > 0) {
+        const crossed = checkNewMilestones(updated, practiceId, delta)
+        const results = await Promise.all(
+          crossed.map(async (hit) => {
+            const def = getMilestoneDef(hit.type, hit.threshold)
+            if (!def) return null
+            const sk = makeMilestoneSK(hit.type, hit.threshold, hit.practiceId)
+            const item = {
+              PK: pk,
+              SK: sk,
+              type: hit.type,
+              ...(hit.practiceId ? { practiceId: hit.practiceId } : {}),
+              threshold: hit.threshold,
+              title: def.title,
+              description: def.description,
+              achievedAt: now,
+            }
+            const isNew = await mainClient.putItemIfNotExists(item)
+            if (!isNew) return null
+            const m: NewMilestone = { type: def.type, threshold: def.threshold, title: def.title, description: def.description }
+            if (hit.practiceId) m.practiceId = hit.practiceId
+            return m
+          })
+        )
+        newMilestones = results.filter((m): m is NewMilestone => m !== null)
+      }
     }
 
-    return NextResponse.json({ ok: true, didIt, date: returnDate, delta }, { status: 200 })
+    return NextResponse.json({ ok: true, didIt, date: returnDate, delta, newMilestones }, { status: 200 })
   })
 }

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -1,59 +1,90 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { DashboardPage } from '@/components/layout';
-import { StatCard, EmptyState, Card, Button } from '@/components/ui';
-import { MOCK_COUNTERS, MOCK_MILESTONES } from '@/lib/mockState';
+import { StatCard, EmptyState, Card, Button, Loading, ErrorState } from '@/components/ui';
+
+type Milestone = {
+  sk: string
+  type: string
+  threshold: number
+  practiceId?: string
+  title: string
+  description: string
+  achievedAt: string
+}
+
+type ProgressData = {
+  totalReturns: number
+  practicesActivated: number
+  milestones: Milestone[]
+}
 
 export default function ProgressPage() {
+  const [data, setData] = useState<ProgressData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/progress')
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed')
+        return res.json() as Promise<ProgressData>
+      })
+      .then(setData)
+      .catch(() => setError(true))
+      .finally(() => setLoading(false))
+  }, [])
+
   return (
     <DashboardPage
       title="Progress"
       description="Your growth at a glance."
       metaLabel="INSIGHTS"
       summary={
-        <div className="space-y-4">
-          <StatCard
-            label="Total check-ins"
-            value={MOCK_COUNTERS.totalReturns}
-            helper="across all practices"
-          />
-          <StatCard
-            label="Current streak"
-            value={`${MOCK_COUNTERS.currentStreak}d`}
-            helper="days in a row"
-          />
-          <StatCard
-            label="Longest streak"
-            value={`${MOCK_COUNTERS.longestStreak}d`}
-            helper="personal best"
-          />
-          <StatCard
-            label="Practices started"
-            value={MOCK_COUNTERS.practicesActivated}
-            helper="total over all time"
-          />
-        </div>
+        loading ? (
+          <Loading text="Loading stats…" />
+        ) : error ? (
+          <ErrorState message="Couldn't load stats." onRetry={() => window.location.reload()} />
+        ) : (
+          <div className="space-y-4">
+            <StatCard
+              label="Total check-ins"
+              value={data?.totalReturns ?? 0}
+              helper="across all practices"
+            />
+            <StatCard
+              label="Practices started"
+              value={data?.practicesActivated ?? 0}
+              helper="total over all time"
+            />
+          </div>
+        )
       }
       main={
         <div className="space-y-6">
           <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Milestones</p>
-          {MOCK_MILESTONES.length === 0 ? (
+          {loading ? (
+            <Loading text="Loading milestones…" />
+          ) : error ? null : !data || data.milestones.length === 0 ? (
             <EmptyState
               title="No milestones yet"
               text="Keep checking in — your first milestone is closer than you think."
             />
           ) : (
             <div className="space-y-3">
-              {MOCK_MILESTONES.map((m) => (
-                <Card key={m.id} variant="subtle" className="flex items-start gap-4">
+              {data.milestones.map((m) => (
+                <Card key={m.sk} variant="subtle" className="flex items-start gap-4">
                   <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
                     ★
                   </div>
                   <div>
                     <p className="font-semibold text-foreground">{m.title}</p>
                     <p className="text-sm text-muted-foreground">{m.description}</p>
-                    <p className="text-xs text-muted-foreground mt-1">{m.achievedAt}</p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {new Date(m.achievedAt).toLocaleDateString()}
+                    </p>
                   </div>
                 </Card>
               ))}

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -10,6 +10,7 @@ import { practicesById } from '@/lib/practices/library';
 import { todayUTC } from '@/lib/returns/returns';
 import type { Practice } from '@/lib/practices/library';
 import type { DotEntry } from '@/lib/returns/returns';
+import type { NewMilestone } from '@/lib/milestones/milestones';
 
 type ActiveData = {
   todayFocusPracticeId: string | null
@@ -17,6 +18,15 @@ type ActiveData = {
 
 type ReturnsData = {
   returns: DotEntry[]
+}
+
+type ReturnResponse = {
+  ok: boolean
+  noop?: boolean
+  didIt: boolean
+  date: string
+  delta?: number
+  newMilestones?: NewMilestone[]
 }
 
 export default function TodayPage() {
@@ -27,6 +37,7 @@ export default function TodayPage() {
   const [error, setError] = useState(false)
   const [logging, setLogging] = useState(false)
   const [logError, setLogError] = useState('')
+  const [newMilestones, setNewMilestones] = useState<NewMilestone[]>([])
 
   const loadReturns = useCallback(async (practiceId: string) => {
     const res = await fetch(`/api/returns?practiceId=${practiceId}&days=14`)
@@ -69,7 +80,11 @@ export default function TodayPage() {
         body: JSON.stringify({ practiceId: focusPractice.id, didIt: newValue }),
       })
       if (!res.ok) throw new Error('Failed to log return')
+      const data: ReturnResponse = await res.json()
       setTodayDidIt(newValue)
+      if (data.newMilestones && data.newMilestones.length > 0) {
+        setNewMilestones(data.newMilestones)
+      }
       await loadReturns(focusPractice.id)
     } catch {
       setLogError('Could not save. Please try again.')
@@ -81,6 +96,26 @@ export default function TodayPage() {
   return (
     <NarrowFormPage title="Today" description="Your daily check-in." metaLabel="OVERVIEW">
       <div className="space-y-6">
+
+        {newMilestones.length > 0 && (
+          <Card className="border-primary/40 bg-primary/5">
+            <div className="space-y-2">
+              <p className="text-sm font-semibold text-primary">Milestone unlocked!</p>
+              {newMilestones.map((m) => (
+                <div key={`${m.type}-${m.threshold}`}>
+                  <p className="text-sm font-medium text-foreground">{m.title}</p>
+                  <p className="text-xs text-muted-foreground">{m.description}</p>
+                </div>
+              ))}
+              <button
+                onClick={() => setNewMilestones([])}
+                className="text-xs text-muted-foreground underline underline-offset-2 mt-1"
+              >
+                Dismiss
+              </button>
+            </div>
+          </Card>
+        )}
 
         {loading && <Loading text="Loading today's practice…" />}
         {!loading && error && (

--- a/lib/milestones/milestones.ts
+++ b/lib/milestones/milestones.ts
@@ -1,0 +1,79 @@
+export type MilestoneType = 'total' | 'practice'
+
+export type MilestoneDef = {
+  type: MilestoneType
+  threshold: number
+  title: string
+  description: string
+}
+
+export type MilestoneItem = {
+  PK: string
+  SK: string
+  type: MilestoneType
+  practiceId?: string
+  threshold: number
+  title: string
+  description: string
+  achievedAt: string
+}
+
+export type NewMilestone = Pick<MilestoneItem, 'type' | 'threshold' | 'title' | 'description'> & {
+  practiceId?: string
+}
+
+export const TOTAL_MILESTONES: MilestoneDef[] = [
+  { type: 'total', threshold: 1,   title: 'First check-in',  description: 'Logged your very first practice.' },
+  { type: 'total', threshold: 7,   title: 'One week in',     description: 'Seven check-ins logged.' },
+  { type: 'total', threshold: 30,  title: 'Monthly habit',   description: '30 check-ins across your practices.' },
+  { type: 'total', threshold: 100, title: 'Century',         description: '100 total check-ins. Remarkable.' },
+]
+
+export const PRACTICE_MILESTONES: MilestoneDef[] = [
+  { type: 'practice', threshold: 7,  title: '7-day practice',  description: '7 check-ins for a single practice.' },
+  { type: 'practice', threshold: 30, title: 'Practice master', description: '30 check-ins for a single practice.' },
+]
+
+export const ALL_MILESTONE_DEFS = [...TOTAL_MILESTONES, ...PRACTICE_MILESTONES]
+
+export function makeMilestoneSK(type: MilestoneType, threshold: number, practiceId?: string): string {
+  if (type === 'total') return `MILESTONE#total#${threshold}`
+  return `MILESTONE#practice#${practiceId}#${threshold}`
+}
+
+export function getMilestoneDef(type: MilestoneType, threshold: number): MilestoneDef | undefined {
+  return ALL_MILESTONE_DEFS.find((d) => d.type === type && d.threshold === threshold)
+}
+
+/**
+ * Returns milestone thresholds newly crossed after applying delta to updatedCounters.
+ * Only triggers for positive delta (check-ins increasing).
+ */
+export function checkNewMilestones(
+  updatedCounters: Record<string, number>,
+  practiceId: string,
+  delta: number,
+): Array<{ type: MilestoneType; threshold: number; practiceId?: string }> {
+  if (delta <= 0) return []
+
+  const newTotal = Object.values(updatedCounters).reduce((sum, v) => sum + v, 0)
+  const oldTotal = newTotal - delta
+  const newPracticeCount = updatedCounters[practiceId] ?? 0
+  const oldPracticeCount = newPracticeCount - delta
+
+  const hits: Array<{ type: MilestoneType; threshold: number; practiceId?: string }> = []
+
+  for (const def of TOTAL_MILESTONES) {
+    if (newTotal >= def.threshold && oldTotal < def.threshold) {
+      hits.push({ type: 'total', threshold: def.threshold })
+    }
+  }
+
+  for (const def of PRACTICE_MILESTONES) {
+    if (newPracticeCount >= def.threshold && oldPracticeCount < def.threshold) {
+      hits.push({ type: 'practice', threshold: def.threshold, practiceId })
+    }
+  }
+
+  return hits
+}

--- a/tests/unit/api/progress.get.test.ts
+++ b/tests/unit/api/progress.get.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GET } from '@/app/api/progress/route'
+
+const mainQueryMock = vi.fn()
+const mainGetItemMock = vi.fn()
+
+vi.mock('@/utils/dynamoClient', () => ({
+  createDynamoClient: () => ({
+    getItem: mainGetItemMock,
+    query: mainQueryMock,
+  }),
+}))
+
+const getCurrentUserMock = vi.fn()
+vi.mock('aws-amplify/auth/server', () => ({
+  getCurrentUser: () => getCurrentUserMock(),
+}))
+vi.mock('@/utils/amplifyServerUtils', () => ({
+  runWithAmplifyServerContext: ({
+    operation,
+  }: {
+    operation: (ctx: unknown) => Promise<unknown>
+  }) => operation({}),
+}))
+
+const makeReq = () => new Request('http://localhost/api/progress')
+
+beforeEach(() => {
+  getCurrentUserMock.mockResolvedValue({ userId: 'u1', username: 'user' })
+  mainGetItemMock.mockReset()
+  mainQueryMock.mockReset()
+  mainGetItemMock.mockResolvedValue(undefined)
+  mainQueryMock.mockResolvedValue([])
+})
+
+describe('GET /api/progress', () => {
+  it('returns 200 with zeroed stats when profile is empty', async () => {
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.ok).toBe(true)
+    expect(json.totalReturns).toBe(0)
+    expect(json.practicesActivated).toBe(0)
+    expect(json.milestones).toEqual([])
+  })
+
+  it('sums returnCounters for totalReturns', async () => {
+    mainGetItemMock.mockResolvedValue({
+      returnCounters: { 'sleep-consistent-bedtime': 5, 'sleep-screen-off': 3 },
+    })
+    const res = await GET(makeReq())
+    const json = await res.json()
+    expect(json.totalReturns).toBe(8)
+  })
+
+  it('counts UPRACTICE items for practicesActivated', async () => {
+    mainQueryMock.mockImplementation(({ ExpressionAttributeValues }: { ExpressionAttributeValues: Record<string, string> }) => {
+      const prefix = ExpressionAttributeValues[':prefix']
+      if (prefix === 'UPRACTICE#') return Promise.resolve([{ SK: 'UPRACTICE#a' }, { SK: 'UPRACTICE#b' }])
+      return Promise.resolve([])
+    })
+    const res = await GET(makeReq())
+    const json = await res.json()
+    expect(json.practicesActivated).toBe(2)
+  })
+
+  it('returns milestones from query', async () => {
+    mainQueryMock.mockImplementation(({ ExpressionAttributeValues }: { ExpressionAttributeValues: Record<string, string> }) => {
+      const prefix = ExpressionAttributeValues[':prefix']
+      if (prefix === 'MILESTONE#') return Promise.resolve([{
+        PK: 'USER#u1',
+        SK: 'MILESTONE#total#1',
+        type: 'total',
+        threshold: 1,
+        title: 'First check-in',
+        description: 'Logged your very first practice.',
+        achievedAt: '2026-01-01T00:00:00.000Z',
+      }])
+      return Promise.resolve([])
+    })
+    const res = await GET(makeReq())
+    const json = await res.json()
+    expect(json.milestones).toHaveLength(1)
+    expect(json.milestones[0].sk).toBe('MILESTONE#total#1')
+    expect(json.milestones[0].title).toBe('First check-in')
+  })
+
+  it('handles returnCounters as JSON string', async () => {
+    mainGetItemMock.mockResolvedValue({
+      returnCounters: JSON.stringify({ 'sleep-consistent-bedtime': 10 }),
+    })
+    const res = await GET(makeReq())
+    const json = await res.json()
+    expect(json.totalReturns).toBe(10)
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    getCurrentUserMock.mockRejectedValue(new Error('Unauthorized'))
+    const res = await GET(makeReq())
+    expect(res.status).toBe(401)
+  })
+})

--- a/tests/unit/api/return.post.test.ts
+++ b/tests/unit/api/return.post.test.ts
@@ -4,6 +4,7 @@ import { POST } from '@/app/api/return/route'
 const mainGetItemMock = vi.fn()
 const mainQueryMock = vi.fn()
 const mainUpdateItemMock = vi.fn()
+const mainPutItemIfNotExistsMock = vi.fn()
 const returnsGetItemMock = vi.fn()
 const returnsPutItemMock = vi.fn()
 
@@ -12,6 +13,7 @@ vi.mock('@/utils/dynamoClient', () => ({
     getItem: mainGetItemMock,
     query: mainQueryMock,
     updateItem: mainUpdateItemMock,
+    putItemIfNotExists: mainPutItemIfNotExistsMock,
   }),
   createReturnsClient: () => ({
     getItem: returnsGetItemMock,
@@ -44,9 +46,11 @@ beforeEach(() => {
   mainGetItemMock.mockReset()
   mainQueryMock.mockReset()
   mainUpdateItemMock.mockReset()
+  mainPutItemIfNotExistsMock.mockReset()
   returnsGetItemMock.mockReset()
   returnsPutItemMock.mockReset()
   mainUpdateItemMock.mockResolvedValue(undefined)
+  mainPutItemIfNotExistsMock.mockResolvedValue(false)
   returnsPutItemMock.mockResolvedValue(undefined)
   mainQueryMock.mockResolvedValue([])
 })
@@ -143,5 +147,48 @@ describe('POST /api/return', () => {
   it('returns 400 for missing fields', async () => {
     const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime' }))
     expect(res.status).toBe(400)
+  })
+
+  it('returns newMilestones=[] when no milestone crossed', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], returnCounters: { 'sleep-consistent-bedtime': 5 } })
+    returnsGetItemMock.mockResolvedValue(undefined)
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: true }))
+    const json = await res.json()
+    expect(json.newMilestones).toEqual([])
+  })
+
+  it('returns newMilestones with first-checkin milestone when counter crosses 1', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], returnCounters: {} })
+    returnsGetItemMock.mockResolvedValue(undefined)
+    mainPutItemIfNotExistsMock.mockResolvedValue(true)
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: true }))
+    const json = await res.json()
+    // counter goes 0→1: crosses total#1 only (practice milestones are at 7 and 30)
+    expect(json.newMilestones).toHaveLength(1)
+    expect(json.newMilestones[0].type).toBe('total')
+    expect(json.newMilestones[0].threshold).toBe(1)
+    expect(json.newMilestones[0].title).toBe('First check-in')
+  })
+
+  it('does not return milestone when putItemIfNotExists returns false (already earned)', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], returnCounters: {} })
+    returnsGetItemMock.mockResolvedValue(undefined)
+    mainPutItemIfNotExistsMock.mockResolvedValue(false) // already exists
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: true }))
+    const json = await res.json()
+    expect(json.newMilestones).toEqual([])
+  })
+
+  it('returns newMilestones=[] on noop', async () => {
+    mainGetItemMock.mockResolvedValue({ activePracticeIds: ['sleep-consistent-bedtime'], returnCounters: {} })
+    returnsGetItemMock.mockResolvedValue({ didIt: true, createdAt: 'x', updatedAt: 'x' })
+
+    const res = await POST(makeReq({ practiceId: 'sleep-consistent-bedtime', didIt: true }))
+    const json = await res.json()
+    expect(json.noop).toBe(true)
+    expect(json.newMilestones).toEqual([])
   })
 })

--- a/tests/unit/milestones/milestones.test.ts
+++ b/tests/unit/milestones/milestones.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { checkNewMilestones } from '@/lib/milestones/milestones'
+
+describe('checkNewMilestones', () => {
+  it('returns empty array when delta is 0', () => {
+    expect(checkNewMilestones({ 'sleep-consistent-bedtime': 5 }, 'sleep-consistent-bedtime', 0)).toEqual([])
+  })
+
+  it('returns empty array when delta is negative', () => {
+    expect(checkNewMilestones({ 'sleep-consistent-bedtime': 4 }, 'sleep-consistent-bedtime', -1)).toEqual([])
+  })
+
+  it('triggers total milestone at 1', () => {
+    const counters = { 'sleep-consistent-bedtime': 1 }
+    const hits = checkNewMilestones(counters, 'sleep-consistent-bedtime', 1)
+    expect(hits).toContainEqual({ type: 'total', threshold: 1 })
+  })
+
+  it('triggers total milestone at 7', () => {
+    const counters = { 'sleep-consistent-bedtime': 7 }
+    const hits = checkNewMilestones(counters, 'sleep-consistent-bedtime', 1)
+    expect(hits).toContainEqual({ type: 'total', threshold: 7 })
+  })
+
+  it('does not re-trigger total milestone at 7 when total was already 8', () => {
+    const counters = { 'sleep-consistent-bedtime': 5, 'sleep-screen-off': 4 }
+    // total=9, delta=1, oldTotal=8 — doesn't cross 7
+    const hits = checkNewMilestones(counters, 'sleep-consistent-bedtime', 1)
+    expect(hits).not.toContainEqual({ type: 'total', threshold: 7 })
+  })
+
+  it('triggers total milestone at 30', () => {
+    const counters = { 'sleep-consistent-bedtime': 30 }
+    const hits = checkNewMilestones(counters, 'sleep-consistent-bedtime', 1)
+    expect(hits).toContainEqual({ type: 'total', threshold: 30 })
+  })
+
+  it('triggers total milestone at 100', () => {
+    const counters = { 'sleep-consistent-bedtime': 100 }
+    const hits = checkNewMilestones(counters, 'sleep-consistent-bedtime', 1)
+    expect(hits).toContainEqual({ type: 'total', threshold: 100 })
+  })
+
+  it('triggers practice milestone at 7 for the specific practice', () => {
+    const counters = { 'sleep-consistent-bedtime': 7 }
+    const hits = checkNewMilestones(counters, 'sleep-consistent-bedtime', 1)
+    expect(hits).toContainEqual({ type: 'practice', threshold: 7, practiceId: 'sleep-consistent-bedtime' })
+  })
+
+  it('triggers practice milestone at 30', () => {
+    const counters = { 'sleep-consistent-bedtime': 30 }
+    const hits = checkNewMilestones(counters, 'sleep-consistent-bedtime', 1)
+    expect(hits).toContainEqual({ type: 'practice', threshold: 30, practiceId: 'sleep-consistent-bedtime' })
+  })
+
+  it('does not trigger practice milestone for a different practice', () => {
+    const counters = { 'sleep-consistent-bedtime': 5, 'sleep-screen-off': 7 }
+    // logging sleep-consistent-bedtime, oldCount=4, newCount=5
+    const hits = checkNewMilestones(counters, 'sleep-consistent-bedtime', 1)
+    expect(hits).not.toContainEqual({ type: 'practice', threshold: 7, practiceId: 'sleep-screen-off' })
+  })
+
+  it('can trigger both total and practice milestones simultaneously', () => {
+    const counters = { 'sleep-consistent-bedtime': 7 }
+    const hits = checkNewMilestones(counters, 'sleep-consistent-bedtime', 1)
+    expect(hits).toContainEqual({ type: 'total', threshold: 7 })
+    expect(hits).toContainEqual({ type: 'practice', threshold: 7, practiceId: 'sleep-consistent-bedtime' })
+  })
+
+  it('triggers total milestone using combined counters across practices', () => {
+    const counters = { 'sleep-consistent-bedtime': 4, 'sleep-screen-off': 3 }
+    // total=7, delta=1, oldTotal=6 → crosses 7
+    const hits = checkNewMilestones(counters, 'sleep-consistent-bedtime', 1)
+    expect(hits).toContainEqual({ type: 'total', threshold: 7 })
+  })
+})

--- a/utils/dynamoClient.ts
+++ b/utils/dynamoClient.ts
@@ -1,4 +1,4 @@
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient, ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
   GetCommand,
@@ -52,6 +52,21 @@ export class DynamoClient {
       Item: item,
     };
     await this.client.send(new PutCommand(input));
+  }
+
+  async putItemIfNotExists(item: Record<string, unknown>): Promise<boolean> {
+    try {
+      const input: PutCommandInput = {
+        TableName: this.tableName,
+        Item: item,
+        ConditionExpression: 'attribute_not_exists(PK)',
+      }
+      await this.client.send(new PutCommand(input))
+      return true
+    } catch (error) {
+      if (error instanceof ConditionalCheckFailedException) return false
+      throw error
+    }
   }
 
   async updateItem(input: Omit<UpdateCommandInput, "TableName">) {


### PR DESCRIPTION
## Summary
- Milestone catalog with total (1/7/30/100 check-ins) and per-practice (7/30) thresholds
- `POST /api/return` now triggers milestone checks on each positive delta, writing idempotent milestone items to DynamoDB via conditional put
- `GET /api/progress` returns live `totalReturns`, `practicesActivated`, and earned milestones
- Progress page replaced mock data with real API; Today page shows dismissible celebration banner on milestone unlock

## Test plan
- [ ] Log first check-in on Today page → celebration banner appears with "First check-in" milestone
- [ ] Dismiss banner → it disappears
- [ ] Navigate to Progress → milestone appears in the feed with date
- [ ] Log same value again (noop) → no banner
- [ ] Toggle back to false → no milestone banner (decrements never trigger)
- [ ] Progress stats show real totalReturns and practicesActivated counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)