### PR TITLE
Epic 9: Routing state machine hardening

### DIFF
--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,52 +1,65 @@
 import { NextResponse } from "next/server";
 
 import { getDataClient } from "@/utils/dataServerClient";
+import { createDynamoClient } from "@/utils/dynamoClient";
 import { withAuth } from "@/utils/authServer";
+import { isTrialActive, type TrialItem } from "@/lib/practices/trial";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+function jsonWithNoStore(body: unknown, status: number) {
+  const res = NextResponse.json(body, { status });
+  res.headers.set("Cache-Control", "no-store");
+  return res;
+}
+
+async function getActiveTrialCount(userId: string): Promise<number> {
+  const client = createDynamoClient();
+  const trials = await client.query<TrialItem>({
+    KeyConditionExpression: "PK = :pk AND begins_with(SK, :prefix)",
+    ExpressionAttributeValues: { ":pk": `USER#${userId}`, ":prefix": "TRIAL#" },
+  });
+  return trials.filter(isTrialActive).length;
+}
+
 export async function GET(req: Request) {
-  return withAuth(req, async () => {
+  return withAuth(req, async (user) => {
     const client = getDataClient();
 
-    // 1) Read PROFILE (PK=USER#id, SK=PROFILE)
-    const read1 = await client.queries.getMyProfile();
-    if (read1.errors?.length) {
-      const res = NextResponse.json(
+    const [profileResult, activeTrialCount] = await Promise.all([
+      client.queries.getMyProfile(),
+      getActiveTrialCount(user.userId),
+    ]);
+
+    if (profileResult.errors?.length) {
+      return jsonWithNoStore(
         { ok: false, error: { code: "INTERNAL_ERROR", message: "Failed to read profile" } },
-        { status: 500 }
+        500
       );
-      res.headers.set("Cache-Control", "no-store");
-      return res;
     }
 
-    if (read1.data) {
-      const res = NextResponse.json({ ok: true, data: read1.data }, { status: 200 });
-      res.headers.set("Cache-Control", "no-store");
-      return res;
+    if (profileResult.data) {
+      return jsonWithNoStore(
+        { ok: true, data: { ...profileResult.data, activeTrialCount } },
+        200
+      );
     }
 
-    // 2) If missing, create default PROFILE (idempotent; does not overwrite)
+    // Profile missing — create default (idempotent)
     const created = await client.mutations.createMyProfile();
     if (created.errors?.length) {
-      // Race: another request created it; re-read
+      // Race: re-read
       const read2 = await client.queries.getMyProfile();
       if (read2.errors?.length || !read2.data) {
-        const res = NextResponse.json(
+        return jsonWithNoStore(
           { ok: false, error: { code: "INTERNAL_ERROR", message: "Failed to create or read profile" } },
-          { status: 500 }
+          500
         );
-        res.headers.set("Cache-Control", "no-store");
-        return res;
       }
-      const res = NextResponse.json({ ok: true, data: read2.data }, { status: 200 });
-      res.headers.set("Cache-Control", "no-store");
-      return res;
+      return jsonWithNoStore({ ok: true, data: { ...read2.data, activeTrialCount } }, 200);
     }
 
-    const res = NextResponse.json({ ok: true, data: created.data }, { status: 200 });
-    res.headers.set("Cache-Control", "no-store");
-    return res;
+    return jsonWithNoStore({ ok: true, data: { ...created.data, activeTrialCount } }, 200);
   });
 }

--- a/contexts/ProfileContext.tsx
+++ b/contexts/ProfileContext.tsx
@@ -16,6 +16,7 @@ export type Profile = {
   subscriptionStatus?: "FREE" | "PAID";
   latestAssessmentId?: string | null;
   activePracticeIds?: string[] | null;
+  activeTrialCount?: number | null;
   todayFocusPracticeId?: string | null;
   [key: string]: unknown;
 };

--- a/lib/decideRoute.ts
+++ b/lib/decideRoute.ts
@@ -1,6 +1,7 @@
 export type ProfileForRouting = {
   latestAssessmentId: string | null;
   activePracticeIds?: string[] | null;
+  activeTrialCount?: number | null;
   todayFocusPracticeId?: string | null;
 };
 
@@ -11,7 +12,10 @@ export function decideRoute(
     return "/assessment";
   }
 
-  if (!profile.activePracticeIds || profile.activePracticeIds.length === 0) {
+  const hasActivePractices = (profile.activePracticeIds?.length ?? 0) > 0;
+  const hasActiveTrials = (profile.activeTrialCount ?? 0) > 0;
+
+  if (!hasActivePractices && !hasActiveTrials) {
     return "/results";
   }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,16 +2,37 @@ import { NextRequest, NextResponse } from 'next/server'
 import { fetchAuthSession } from 'aws-amplify/auth/server'
 import { runWithAmplifyServerContext } from '@/utils/amplifyServerUtils'
 
+const PROTECTED_PREFIXES = [
+  '/today',
+  '/practices',
+  '/results',
+  '/assessment',
+  '/progress',
+  '/decideRoute',
+]
+
+function isProtectedPage(pathname: string): boolean {
+  return PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix))
+}
+
 export async function middleware(request: NextRequest) {
   const response = NextResponse.next()
+  const { pathname } = request.nextUrl
 
   try {
-    await runWithAmplifyServerContext({
+    const session = await runWithAmplifyServerContext({
       nextServerContext: { request, response },
       operation: (contextSpec) => fetchAuthSession(contextSpec),
     })
+
+    // Redirect to /auth if tokens are missing on a protected page
+    if (!session.tokens && isProtectedPage(pathname)) {
+      return NextResponse.redirect(new URL('/auth', request.url))
+    }
   } catch {
-    // Not authenticated — let the app handle redirects
+    if (isProtectedPage(pathname)) {
+      return NextResponse.redirect(new URL('/auth', request.url))
+    }
   }
 
   return response

--- a/tests/unit/api/me.test.ts
+++ b/tests/unit/api/me.test.ts
@@ -11,6 +11,11 @@ vi.mock("@/utils/dataServerClient", () => ({
   }),
 }));
 
+const dynamoQueryMock = vi.fn();
+vi.mock("@/utils/dynamoClient", () => ({
+  createDynamoClient: () => ({ query: dynamoQueryMock }),
+}));
+
 const runWithAmplifyMock = vi.fn();
 vi.mock("@/utils/amplifyServerUtils", () => ({
   runWithAmplifyServerContext: (opts: {
@@ -22,12 +27,14 @@ describe("GET /api/me", () => {
   beforeEach(() => {
     getMyProfileMock.mockReset();
     createMyProfileMock.mockReset();
+    dynamoQueryMock.mockReset();
+    dynamoQueryMock.mockResolvedValue([]); // no active trials by default
     runWithAmplifyMock.mockResolvedValue({
       user: { userId: "usr-test", username: "test@example.com" },
     });
   });
 
-  it("returns existing profile without calling createMyProfile", async () => {
+  it("returns existing profile with activeTrialCount=0 when no trials", async () => {
     const existingProfile = {
       userId: "usr-1",
       subscriptionStatus: "FREE",
@@ -44,12 +51,64 @@ describe("GET /api/me", () => {
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json).toEqual({ ok: true, data: existingProfile });
+    expect(json.ok).toBe(true);
+    expect(json.data.userId).toBe("usr-1");
+    expect(json.data.activeTrialCount).toBe(0);
     expect(getMyProfileMock).toHaveBeenCalledTimes(1);
     expect(createMyProfileMock).not.toHaveBeenCalled();
   });
 
-  it("creates profile when missing, returns it", async () => {
+  it("returns activeTrialCount=1 when one active trial exists", async () => {
+    const existingProfile = {
+      userId: "usr-1",
+      subscriptionStatus: "FREE",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+      activePracticeIds: [],
+      latestAssessmentId: "a1",
+    };
+    getMyProfileMock.mockResolvedValue({ data: existingProfile, errors: undefined });
+    dynamoQueryMock.mockResolvedValue([{
+      practiceId: "sleep-consistent-bedtime",
+      status: "trial",
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+      SK: "TRIAL#x#sleep-consistent-bedtime",
+    }]);
+
+    const req = new Request("http://localhost/api/me");
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.activeTrialCount).toBe(1);
+  });
+
+  it("does not count expired trials", async () => {
+    const existingProfile = {
+      userId: "usr-1",
+      subscriptionStatus: "FREE",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+      activePracticeIds: [],
+      latestAssessmentId: "a1",
+    };
+    getMyProfileMock.mockResolvedValue({ data: existingProfile, errors: undefined });
+    dynamoQueryMock.mockResolvedValue([{
+      practiceId: "sleep-consistent-bedtime",
+      status: "trial",
+      expiresAt: new Date(Date.now() - 1000).toISOString(), // expired
+      SK: "TRIAL#x#sleep-consistent-bedtime",
+    }]);
+
+    const req = new Request("http://localhost/api/me");
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.activeTrialCount).toBe(0);
+  });
+
+  it("creates profile when missing, returns it with activeTrialCount", async () => {
     getMyProfileMock.mockResolvedValue({ data: null, errors: undefined });
 
     const newProfile = {
@@ -71,8 +130,9 @@ describe("GET /api/me", () => {
     const json = await res.json();
 
     expect(res.status).toBe(200);
-    expect(json).toEqual({ ok: true, data: newProfile });
+    expect(json.ok).toBe(true);
     expect(json.data.subscriptionStatus).toBe("FREE");
+    expect(json.data.activeTrialCount).toBe(0);
     expect(getMyProfileMock).toHaveBeenCalledTimes(1);
     expect(createMyProfileMock).toHaveBeenCalledTimes(1);
   });
@@ -97,9 +157,9 @@ describe("GET /api/me", () => {
 
     expect(res1.status).toBe(200);
     expect(res2.status).toBe(200);
-    expect(json1.data).toEqual(json2.data);
-    expect(json1.data.userId).toBe("usr-3");
+    expect(json1.data.userId).toBe(json2.data.userId);
     expect(json1.data.subscriptionStatus).toBe("FREE");
+    expect(json1.data.activeTrialCount).toBe(0);
     expect(createMyProfileMock).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/decideRoute.test.ts
+++ b/tests/unit/decideRoute.test.ts
@@ -12,14 +12,37 @@ describe("decideRoute", () => {
     expect(decideRoute(profile)).toBe("/assessment");
   });
 
-  it("routes to /results when no active practices", () => {
+  it("routes to /results when no active practices and no active trials", () => {
     const profile: ProfileForRouting = {
       latestAssessmentId: "a1",
       activePracticeIds: [],
+      activeTrialCount: 0,
       todayFocusPracticeId: "p1",
     };
 
     expect(decideRoute(profile)).toBe("/results");
+  });
+
+  it("routes to /practices when no active practices but has active trial and no focus", () => {
+    const profile: ProfileForRouting = {
+      latestAssessmentId: "a1",
+      activePracticeIds: [],
+      activeTrialCount: 1,
+      todayFocusPracticeId: null,
+    };
+
+    expect(decideRoute(profile)).toBe("/practices");
+  });
+
+  it("routes to /today when has active trial and focus practice set", () => {
+    const profile: ProfileForRouting = {
+      latestAssessmentId: "a1",
+      activePracticeIds: [],
+      activeTrialCount: 1,
+      todayFocusPracticeId: "sleep-consistent-bedtime",
+    };
+
+    expect(decideRoute(profile)).toBe("/today");
   });
 
   it("routes to /practices when no focus practice", () => {
@@ -42,20 +65,32 @@ describe("decideRoute", () => {
     expect(decideRoute(profile)).toBe("/today");
   });
 
-  it("treats undefined activePracticeIds as empty", () => {
+  it("treats undefined activePracticeIds as empty (no trials → /results)", () => {
     const profile: ProfileForRouting = {
       latestAssessmentId: "a1",
       activePracticeIds: undefined,
+      activeTrialCount: 0,
       todayFocusPracticeId: "p1",
     };
 
     expect(decideRoute(profile)).toBe("/results");
   });
 
-  it("treats null activePracticeIds as empty", () => {
+  it("treats null activePracticeIds as empty (no trials → /results)", () => {
     const profile: ProfileForRouting = {
       latestAssessmentId: "a1",
       activePracticeIds: null,
+      activeTrialCount: null,
+      todayFocusPracticeId: "p1",
+    };
+
+    expect(decideRoute(profile)).toBe("/results");
+  });
+
+  it("treats omitted activeTrialCount as zero", () => {
+    const profile: ProfileForRouting = {
+      latestAssessmentId: "a1",
+      activePracticeIds: [],
       todayFocusPracticeId: "p1",
     };
 


### PR DESCRIPTION
## Summary
- **Trial routing fix**: `decideRoute` now checks `activeTrialCount` — a user with an active trial but no promoted practice correctly routes to `/practices` instead of looping back to `/results`
- **`/api/me` extended**: fetches active trial count in parallel with profile and includes `activeTrialCount` in the response payload
- **Middleware auth guard**: unauthenticated users hitting protected page routes (`/today`, `/practices`, `/results`, `/assessment`, `/progress`, `/decideRoute`) are now redirected to `/auth` at the edge before any page rendering

## Test plan
- [ ] Start a trial from results page → navigates to `/practices` (not stuck at `/results`)
- [ ] Navigate directly to `/today` without auth → redirected to `/auth`
- [ ] Navigate directly to `/practices` without auth → redirected to `/auth`
- [ ] Authenticated user with trial and focus practice set → routes to `/today`
- [ ] Profile with expired trial and no practices → routes to `/results`

🤖 Generated with [Claude Code](https://claude.com/claude-code)