### PR TITLE
Epic 10: Production readiness

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/components/ui';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[GlobalError]', error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-muted/40 px-4">
+      <div className="rounded-xl border border-border bg-card p-8 text-center shadow-sm max-w-sm w-full">
+        <p className="text-base font-semibold text-foreground">Something went wrong</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          An unexpected error occurred. Please try again.
+        </p>
+        <div className="mt-6">
+          <Button onClick={reset}>Try again</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-muted/40 px-4">
+      <div className="rounded-xl border border-border bg-card p-8 text-center shadow-sm max-w-sm w-full">
+        <p className="text-base font-semibold text-foreground">Page not found</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This page doesn&apos;t exist or has moved.
+        </p>
+        <div className="mt-6">
+          <Button asChild>
+            <Link href="/">Go home</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { StandardPage } from '@/components/layout';
 import { Card, Button, EmptyState, Loading, ErrorState } from '@/components/ui';
 import { pillarColors } from '@/lib/design/pillarColors';
-import { MOCK_PILLAR_LABELS } from '@/lib/mockState';
+import { pillarLabels } from '@/lib/assessment/pillars';
 import { practices } from '@/lib/practices/library';
 import type { Pillar } from '@/lib/assessment/pillars';
 
@@ -45,7 +45,7 @@ function PillarBadge({ pillar }: { pillar: Pillar }) {
       className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
       style={{ backgroundColor: pillarColors[pillar] }}
     >
-      {MOCK_PILLAR_LABELS[pillar]}
+      {pillarLabels[pillar]}
     </span>
   );
 }
@@ -303,7 +303,7 @@ export default function PracticesPage() {
                                       disabled={!!actionLoading[p.id]}
                                     >
                                       <span className="font-medium">{c.title}</span>
-                                      <span className="text-muted-foreground"> · {MOCK_PILLAR_LABELS[c.pillar]}</span>
+                                      <span className="text-muted-foreground"> · {pillarLabels[c.pillar]}</span>
                                     </button>
                                   ))}
                                 </div>

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -7,14 +7,9 @@ import { StandardPage } from '@/components/layout';
 import { Card, Button, Loading, ErrorState } from '@/components/ui';
 import { PillarRadarChart } from '@/components/ui/PillarRadarChart';
 import { pillarColors } from '@/lib/design/pillarColors';
-import { pillarOrder } from '@/lib/assessment/pillars';
+import { pillarOrder, pillarLabels } from '@/lib/assessment/pillars';
 import type { Pillar } from '@/lib/assessment/pillars';
 import type { Practice } from '@/lib/practices/library';
-import {
-  MOCK_PILLAR_SCORES,
-  MOCK_FOCUS_PILLAR,
-  MOCK_PILLAR_LABELS,
-} from '@/lib/mockState';
 
 const MAX_SCORE = 5;
 
@@ -82,7 +77,7 @@ export default function ResultsPage() {
           const data = await assessRes.json() as AssessmentData
           setAssessment(data)
         }
-        // 404 = no assessment yet — fall through to mock scores
+        // 404 = no assessment yet — assessment stays null
 
         if (!sugRes.ok) throw new Error('Failed to load suggestions')
         const sugData = await sugRes.json() as SuggestionsData
@@ -96,8 +91,8 @@ export default function ResultsPage() {
     load()
   }, [])
 
-  const scores = assessment?.scoresByPillar ?? MOCK_PILLAR_SCORES
-  const focusPillar = assessment?.focusPillar ?? MOCK_FOCUS_PILLAR
+  const scores = assessment?.scoresByPillar
+  const focusPillar = assessment?.focusPillar
 
   return (
     <StandardPage
@@ -106,65 +101,70 @@ export default function ResultsPage() {
       metaLabel="RESULTS"
     >
       <div className="space-y-10">
-        {/* Focus pillar highlight */}
-        <Card className="border-primary/30 bg-primary/5">
-          <p className="text-xs uppercase tracking-[0.2em] text-primary mb-2">Focus Pillar</p>
-          <div className="flex items-center gap-3">
-            <span
-              className="h-4 w-4 rounded-full shrink-0"
-              style={{ backgroundColor: pillarColors[focusPillar] }}
-            />
-            <h2 className="text-2xl font-bold text-foreground">
-              {MOCK_PILLAR_LABELS[focusPillar]} Intelligence
-            </h2>
-          </div>
-          <p className="mt-2 text-sm text-muted-foreground">
-            This is your lowest-scoring area. Starting here gives you the most room to grow.
-          </p>
-        </Card>
 
-        {/* Radar chart */}
-        <Card>
-          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">
-            Pillar Strengths
-          </p>
-          <PillarRadarChart scores={scores} focusPillar={focusPillar} />
-        </Card>
+        {assessment && (
+          <>
+            {/* Focus pillar highlight */}
+            <Card className="border-primary/30 bg-primary/5">
+              <p className="text-xs uppercase tracking-[0.2em] text-primary mb-2">Focus Pillar</p>
+              <div className="flex items-center gap-3">
+                <span
+                  className="h-4 w-4 rounded-full shrink-0"
+                  style={{ backgroundColor: pillarColors[focusPillar!] }}
+                />
+                <h2 className="text-2xl font-bold text-foreground">
+                  {pillarLabels[focusPillar!]} Intelligence
+                </h2>
+              </div>
+              <p className="mt-2 text-sm text-muted-foreground">
+                This is your lowest-scoring area. Starting here gives you the most room to grow.
+              </p>
+            </Card>
 
-        {/* All pillar scores */}
-        <div>
-          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">All Pillars</p>
-          <div className="space-y-3">
-            {pillarOrder.map((pillar) => {
-              const score = scores[pillar] ?? 0;
-              const pct = Math.round((score / MAX_SCORE) * 100);
-              const isFocus = pillar === focusPillar;
-              const color = pillarColors[pillar];
-              return (
-                <div
-                  key={pillar}
-                  className={`flex items-center gap-4 rounded-xl p-4 border ${
-                    isFocus ? 'border-primary/30 bg-primary/5' : 'border-border/60 bg-card'
-                  }`}
-                >
-                  <span className="h-3 w-3 rounded-full shrink-0" style={{ backgroundColor: color }} />
-                  <span className="w-28 text-sm font-medium text-foreground shrink-0">
-                    {MOCK_PILLAR_LABELS[pillar]}
-                  </span>
-                  <div className="flex-1 h-2 rounded-full bg-muted/60">
-                    <div className="h-2 rounded-full" style={{ width: `${pct}%`, backgroundColor: color }} />
-                  </div>
-                  <span className="w-10 text-right text-sm text-muted-foreground shrink-0">
-                    {score}/{MAX_SCORE}
-                  </span>
-                  {isFocus && (
-                    <span className="text-xs font-semibold text-primary shrink-0">focus</span>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
+            {/* Radar chart */}
+            <Card>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">
+                Pillar Strengths
+              </p>
+              <PillarRadarChart scores={scores!} focusPillar={focusPillar!} />
+            </Card>
+
+            {/* All pillar scores */}
+            <div>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">All Pillars</p>
+              <div className="space-y-3">
+                {pillarOrder.map((pillar) => {
+                  const score = scores![pillar] ?? 0;
+                  const pct = Math.round((score / MAX_SCORE) * 100);
+                  const isFocus = pillar === focusPillar;
+                  const color = pillarColors[pillar];
+                  return (
+                    <div
+                      key={pillar}
+                      className={`flex items-center gap-4 rounded-xl p-4 border ${
+                        isFocus ? 'border-primary/30 bg-primary/5' : 'border-border/60 bg-card'
+                      }`}
+                    >
+                      <span className="h-3 w-3 rounded-full shrink-0" style={{ backgroundColor: color }} />
+                      <span className="w-28 text-sm font-medium text-foreground shrink-0">
+                        {pillarLabels[pillar]}
+                      </span>
+                      <div className="flex-1 h-2 rounded-full bg-muted/60">
+                        <div className="h-2 rounded-full" style={{ width: `${pct}%`, backgroundColor: color }} />
+                      </div>
+                      <span className="w-10 text-right text-sm text-muted-foreground shrink-0">
+                        {score}/{MAX_SCORE}
+                      </span>
+                      {isFocus && (
+                        <span className="text-xs font-semibold text-primary shrink-0">focus</span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </>
+        )}
 
         {/* Suggested practices */}
         <div>
@@ -191,7 +191,7 @@ export default function ResultsPage() {
                         className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
                         style={{ backgroundColor: pillarColors[practice.pillar] }}
                       >
-                        {MOCK_PILLAR_LABELS[practice.pillar]}
+                        {pillarLabels[practice.pillar]}
                       </span>
                       <p className="font-semibold text-foreground">{practice.title}</p>
                       <p className="text-sm text-muted-foreground">{practice.description}</p>

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { NarrowFormPage } from '@/components/layout';
 import { Card, Button, Loading, ErrorState } from '@/components/ui';
 import { pillarColors } from '@/lib/design/pillarColors';
-import { MOCK_PILLAR_LABELS } from '@/lib/mockState';
+import { pillarLabels } from '@/lib/assessment/pillars';
 import { practicesById } from '@/lib/practices/library';
 import { todayUTC } from '@/lib/returns/returns';
 import type { Practice } from '@/lib/practices/library';
@@ -142,7 +142,7 @@ export default function TodayPage() {
                     className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
                     style={{ backgroundColor: pillarColors[focusPractice.pillar] }}
                   >
-                    {MOCK_PILLAR_LABELS[focusPractice.pillar]}
+                    {pillarLabels[focusPractice.pillar]}
                   </span>
                   <p className="mt-3 text-xl font-semibold text-foreground">{focusPractice.title}</p>
                   <p className="mt-1 text-sm text-muted-foreground">{focusPractice.description}</p>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -16,8 +16,8 @@ interface AppShellProps {
 const NAV_ITEMS = [
   { href: '/today', label: 'Today' },
   { href: '/practices', label: 'Practices' },
+  { href: '/results', label: 'Results' },
   { href: '/progress', label: 'Progress' },
-  { href: '/assessment', label: 'Assessment' },
 ]
 
 function isActive(href: string, pathname: string | null) {

--- a/components/ui/PillarRadarChart.tsx
+++ b/components/ui/PillarRadarChart.tsx
@@ -10,7 +10,7 @@ import {
 } from 'recharts'
 import type { Pillar } from '@/lib/assessment/pillars'
 import { pillarOrder } from '@/lib/assessment/pillars'
-import { MOCK_PILLAR_LABELS } from '@/lib/mockState'
+import { pillarLabels } from '@/lib/assessment/pillars'
 
 const MAX_SCORE = 5
 
@@ -21,7 +21,7 @@ type Props = {
 
 export function PillarRadarChart({ scores }: Props) {
   const data = pillarOrder.map((pillar) => ({
-    pillar: MOCK_PILLAR_LABELS[pillar],
+    pillar: pillarLabels[pillar],
     score: scores[pillar] ?? 0,
     fullMark: MAX_SCORE,
   }))

--- a/lib/assessment/pillars.ts
+++ b/lib/assessment/pillars.ts
@@ -9,3 +9,13 @@ export const pillarOrder = [
 ] as const;
 
 export type Pillar = (typeof pillarOrder)[number];
+
+export const pillarLabels: Record<Pillar, string> = {
+  financial: "Financial",
+  relationship: "Relationship",
+  information: "Information",
+  emotional: "Emotional",
+  nutrition: "Nutrition",
+  dynamic: "Dynamic",
+  sleep: "Sleep",
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- **Pillar labels de-mocked**: moved `pillarLabels` into `lib/assessment/pillars` — all 3 pages and the radar chart now import the real constant; `MOCK_PILLAR_LABELS` no longer used in any UI
- **Results page hardened**: score/radar/focus-pillar sections only render when real assessment data is available (no mock fallback scores)
- **Error boundary**: `app/error.tsx` catches unexpected rendering errors with a retry button
- **404 page**: `app/not-found.tsx` for unknown routes
- **Security headers**: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy` added via `next.config.ts`

## Test plan
- [ ] Navigate to a non-existent URL (e.g. `/xyz`) → custom 404 page
- [ ] Results page with real assessment data → scores/radar visible
- [ ] Security headers present in Network tab response headers
- [ ] 235 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)