### PR TITLE
chore: add amplify.yml to wire CDK backend deployment in CI/CD

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,23 @@
+version: 1
+backend:
+  phases:
+    build:
+      commands:
+        - npm ci --cache .npm --prefer-offline
+        - npx ampx pipeline-deploy --branch $AWS_BRANCH --appId $AWS_APP_ID
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm ci --cache .npm --prefer-offline
+    build:
+      commands:
+        - npm run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - .next/cache/**/*
+      - .npm/**/*


### PR DESCRIPTION
## Summary
- Adds `amplify.yml` so Amplify Console runs the CDK backend deployment phase (`ampx pipeline-deploy`) on every push to main, in addition to the Next.js frontend build
- Fixes the root cause of FIAPP_RETURNS not being created — previously Amplify only ran `next build` with no backend phase

## Test plan
- [ ] Merge triggers a build in Amplify Console
- [ ] Build logs show a backend phase running `ampx pipeline-deploy`
- [ ] FIAPP_RETURNS table appears in DynamoDB console (ap-southeast-2) after build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)