### PR TITLE
fix: correct ampx pipeline-deploy flag (--app-id)

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,7 @@ backend:
     build:
       commands:
         - npm ci --cache .npm --prefer-offline
-        - npx ampx pipeline-deploy --branch $AWS_BRANCH --appId $AWS_APP_ID
+        - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:
     preBuild:


### PR DESCRIPTION
## Summary
- Fixes typo in `amplify.yml`: `--appId` → `--app-id`
- Previous build failed because the flag name was wrong, causing `ampx pipeline-deploy` to print help text instead of running
- This allows the CDK backend phase to run and create the FIAPP_RETURNS DynamoDB table

## Test plan
- [ ] Build backend phase completes without error
- [ ] FIAPP_RETURNS table appears in DynamoDB (ap-southeast-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)