### PR TITLE
feat: spec gaps — nav, milestones, account page, practices UX

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link from 'next/link';
+import { useAuthenticator } from '@aws-amplify/ui-react';
+import { NarrowFormPage } from '@/components/layout';
+import { Card, Button } from '@/components/ui';
+import { useProfile } from '@/contexts/ProfileContext';
+
+export default function AccountPage() {
+  const { user, signOut } = useAuthenticator((ctx) => [ctx.user, ctx.signOut])
+  const { profile } = useProfile()
+
+  const email = user?.signInDetails?.loginId ?? user?.username ?? '—'
+  const plan = profile?.subscriptionStatus === 'PAID' ? 'Premium' : 'Free'
+
+  return (
+    <NarrowFormPage title="Account" description="Your profile and settings." metaLabel="ACCOUNT">
+      <div className="space-y-4">
+
+        {/* Identity */}
+        <Card>
+          <div className="space-y-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Profile</p>
+            <div className="space-y-3">
+              <div>
+                <p className="text-xs text-muted-foreground mb-0.5">Email</p>
+                <p className="text-sm font-medium text-foreground">{email}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground mb-0.5">Plan</p>
+                <p className="text-sm font-medium text-foreground">{plan}</p>
+              </div>
+            </div>
+          </div>
+        </Card>
+
+        {/* Assessment */}
+        <Card>
+          <div className="space-y-3">
+            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Assessment</p>
+            <p className="text-sm text-muted-foreground">
+              Retake the assessment to update your focus pillar and get fresh practice suggestions.
+            </p>
+            <Button variant="outline" asChild>
+              <Link href="/assessment">Retake assessment →</Link>
+            </Button>
+          </div>
+        </Card>
+
+        {/* Sign out */}
+        <Card>
+          <div className="space-y-3">
+            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Session</p>
+            <Button variant="outline" onClick={signOut} className="w-full">
+              Sign out
+            </Button>
+          </div>
+        </Card>
+
+      </div>
+    </NarrowFormPage>
+  );
+}

--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -11,6 +11,11 @@ import {
   computeStreaks,
   type ReturnItem,
 } from '@/lib/returns/returns'
+import {
+  TOTAL_MILESTONES,
+  PRACTICE_MILESTONES,
+  makeMilestoneSK,
+} from '@/lib/milestones/milestones'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -74,12 +79,49 @@ export async function GET(req: Request) {
 
     const { currentStreak, longestStreak } = computeStreaks(activeDates, today, STREAK_LOOKBACK_DAYS)
 
+    // Compute next-up milestones
+    const achievedSKs = new Set(milestones.map((m) => m.SK))
+
+    type NextMilestone = {
+      type: string; threshold: number; practiceId?: string
+      title: string; description: string; progress: number; remaining: number
+    }
+    const nextMilestones: NextMilestone[] = []
+
+    // Next total milestone
+    for (const def of TOTAL_MILESTONES) {
+      if (!achievedSKs.has(makeMilestoneSK('total', def.threshold))) {
+        nextMilestones.push({
+          type: 'total', threshold: def.threshold,
+          title: def.title, description: def.description,
+          progress: totalReturns, remaining: def.threshold - totalReturns,
+        })
+        break
+      }
+    }
+
+    // Next practice milestone per active practice
+    for (const practiceId of activePracticeIds) {
+      const practiceCount = counters[practiceId] ?? 0
+      for (const def of PRACTICE_MILESTONES) {
+        if (!achievedSKs.has(makeMilestoneSK('practice', def.threshold, practiceId))) {
+          nextMilestones.push({
+            type: 'practice', threshold: def.threshold, practiceId,
+            title: def.title, description: def.description,
+            progress: practiceCount, remaining: def.threshold - practiceCount,
+          })
+          break
+        }
+      }
+    }
+
     return NextResponse.json({
       ok: true,
       totalReturns,
       practicesActivated,
       currentStreak,
       longestStreak,
+      nextMilestones,
       milestones: milestones.map((m) => ({
         sk: m.SK,
         type: m.type,

--- a/app/globals.css
+++ b/app/globals.css
@@ -278,8 +278,8 @@
   width: 100% !important;
 }
 
-.fiapp-auth span.amplify-alert__body {
-  display: block !important;
-  flex: 1 !important;
-  min-width: 0 !important;
+.fiapp-auth .amplify-alert__dismiss {
+  width: auto !important;
+  padding: 0.25rem !important;
+  flex-shrink: 0 !important;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -272,4 +272,13 @@
   border-radius: 10px !important;
   border: 1px solid var(--border) !important;
   background: color-mix(in oklch, var(--muted) 30%, transparent) !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 0.5rem !important;
+  width: 100% !important;
+}
+
+.fiapp-auth .amplify-alert__body {
+  flex: 1 !important;
+  min-width: 0 !important;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -278,7 +278,8 @@
   width: 100% !important;
 }
 
-.fiapp-auth .amplify-alert__body {
+.fiapp-auth span.amplify-alert__body {
+  display: block !important;
   flex: 1 !important;
   min-width: 0 !important;
 }

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -53,7 +53,15 @@ function PillarBadge({ pillar }: { pillar: Pillar }) {
 function TrialBadge() {
   return (
     <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-amber-100 text-amber-800 border border-amber-300">
-      Trial
+      Trying
+    </span>
+  );
+}
+
+function PausedBadge() {
+  return (
+    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-muted text-muted-foreground border border-border">
+      Paused
     </span>
   );
 }
@@ -243,8 +251,8 @@ export default function PracticesPage() {
 
   return (
     <StandardPage
-      title="Active Practices"
-      description="Manage your practices and trials."
+      title="My Practices"
+      description="Your committed practices and what you're testing."
       metaLabel="PRACTICES"
       actions={
         <Button variant="outline" size="sm" asChild>
@@ -258,168 +266,143 @@ export default function PracticesPage() {
 
         {!loading && !error && data && (
           <>
-            {/* Active practices */}
-            <section>
-              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Active</p>
-              {data.activePractices.length === 0 ? (
-                <EmptyState
-                  title="No active practices"
-                  text="Promote a trial or pick one from your results."
-                  action={<Button variant="outline" asChild><Link href="/results">Browse suggestions</Link></Button>}
-                />
-              ) : (
-                <div className="space-y-3">
-                  {data.activePractices.map((p) => {
-                    const isFocus = data.todayFocusPracticeId === p.id
-                    const isReplacing = replacingId === p.id
-                    const confirmed = isReplacing && !!replaceToken
-                    return (
-                      <Card key={p.id} variant="interactive">
-                        <div className="flex items-start justify-between gap-4">
-                          <div className="space-y-2 min-w-0 flex-1">
-                            <div className="flex items-center gap-2 flex-wrap">
-                              <PillarBadge pillar={p.pillar} />
-                              {isFocus && <FocusBadge />}
-                            </div>
-                            <p className="font-semibold text-foreground">{p.title}</p>
-                            <p className="text-sm text-muted-foreground">{p.description}</p>
-                            {inlineError[p.id] && (
-                              <p className="text-xs text-destructive">{inlineError[p.id]}</p>
-                            )}
-                            {inlineWarning[p.id] && (
-                              <p className="text-xs text-amber-700">{inlineWarning[p.id]}</p>
-                            )}
+            {(data.activePractices.length + data.trials.length + data.pausedPractices.length) === 0 ? (
+              <EmptyState
+                title="No practices yet"
+                text="Pick practices from your results to start building your routine."
+                action={<Button variant="outline" asChild><Link href="/results">Browse suggestions</Link></Button>}
+              />
+            ) : (
+              <div className="space-y-3">
+                {data.activePractices.map((p) => {
+                  const isFocus = data.todayFocusPracticeId === p.id
+                  const isReplacing = replacingId === p.id
+                  const confirmed = isReplacing && !!replaceToken
+                  return (
+                    <Card key={p.id} variant="interactive">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="space-y-2 min-w-0 flex-1">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <PillarBadge pillar={p.pillar} />
+                            {isFocus && <FocusBadge />}
+                          </div>
+                          <p className="font-semibold text-foreground">{p.title}</p>
+                          <p className="text-sm text-muted-foreground">{p.description}</p>
+                          {inlineError[p.id] && (
+                            <p className="text-xs text-destructive">{inlineError[p.id]}</p>
+                          )}
+                          {inlineWarning[p.id] && (
+                            <p className="text-xs text-amber-700">{inlineWarning[p.id]}</p>
+                          )}
 
-                            {/* Replace picker */}
-                            {isReplacing && !confirmed && (
-                              <div className="mt-3 space-y-2">
-                                <p className="text-xs font-medium text-muted-foreground">Pick a replacement:</p>
-                                <div className="flex flex-col gap-1 max-h-48 overflow-y-auto pr-1">
-                                  {replaceCandidates.map((c) => (
-                                    <button
-                                      key={c.id}
-                                      className="text-left text-sm px-3 py-2 rounded-lg border border-border hover:bg-muted transition-colors"
-                                      onClick={() => handleReplaceSelect(p.id, c.id)}
-                                      disabled={!!actionLoading[p.id]}
-                                    >
-                                      <span className="font-medium">{c.title}</span>
-                                      <span className="text-muted-foreground"> · {pillarLabels[c.pillar]}</span>
-                                    </button>
-                                  ))}
-                                </div>
+                          {isReplacing && !confirmed && (
+                            <div className="mt-3 space-y-2">
+                              <p className="text-xs font-medium text-muted-foreground">Pick a replacement:</p>
+                              <div className="flex flex-col gap-1 max-h-48 overflow-y-auto pr-1">
+                                {replaceCandidates.map((c) => (
+                                  <button
+                                    key={c.id}
+                                    className="text-left text-sm px-3 py-2 rounded-lg border border-border hover:bg-muted transition-colors"
+                                    onClick={() => handleReplaceSelect(p.id, c.id)}
+                                    disabled={!!actionLoading[p.id]}
+                                  >
+                                    <span className="font-medium">{c.title}</span>
+                                    <span className="text-muted-foreground"> · {pillarLabels[c.pillar]}</span>
+                                  </button>
+                                ))}
+                              </div>
+                              <Button size="sm" variant="ghost" onClick={() => { setReplacingId(null); setReplaceToken(null); setReplaceTarget(null) }}>
+                                Cancel
+                              </Button>
+                            </div>
+                          )}
+
+                          {isReplacing && confirmed && replaceTarget && (
+                            <div className="mt-3 p-3 rounded-lg bg-amber-50 border border-amber-200 space-y-2">
+                              <p className="text-sm font-medium text-amber-900">
+                                Replace with &ldquo;{practicesById(replaceTarget)}&rdquo;?
+                              </p>
+                              <div className="flex gap-2">
+                                <Button size="sm" variant="default" disabled={!!actionLoading[p.id]} onClick={() => handleReplaceConfirm(p.id)}>
+                                  {actionLoading[p.id] ? '…' : 'Confirm'}
+                                </Button>
                                 <Button size="sm" variant="ghost" onClick={() => { setReplacingId(null); setReplaceToken(null); setReplaceTarget(null) }}>
                                   Cancel
                                 </Button>
                               </div>
-                            )}
-
-                            {/* Replace confirm step */}
-                            {isReplacing && confirmed && replaceTarget && (
-                              <div className="mt-3 p-3 rounded-lg bg-amber-50 border border-amber-200 space-y-2">
-                                <p className="text-sm font-medium text-amber-900">
-                                  Replace with &ldquo;{practicesById(replaceTarget)}&rdquo;?
-                                </p>
-                                <div className="flex gap-2">
-                                  <Button size="sm" variant="default" disabled={!!actionLoading[p.id]} onClick={() => handleReplaceConfirm(p.id)}>
-                                    {actionLoading[p.id] ? '…' : 'Confirm'}
-                                  </Button>
-                                  <Button size="sm" variant="ghost" onClick={() => { setReplacingId(null); setReplaceToken(null); setReplaceTarget(null) }}>
-                                    Cancel
-                                  </Button>
-                                </div>
-                              </div>
-                            )}
-                          </div>
-
-                          {!isReplacing && (
-                            <div className="flex flex-col gap-2 shrink-0">
-                              {!isFocus && (
-                                <Button size="sm" variant="outline" disabled={!!actionLoading[p.id]} onClick={() => handleSetFocus(p.id)}>
-                                  {actionLoading[p.id] ? '…' : 'Set focus'}
-                                </Button>
-                              )}
-                              <Button size="sm" variant="ghost" disabled={!!actionLoading[p.id]} onClick={() => handlePause(p.id)}>
-                                Pause
-                              </Button>
-                              <Button size="sm" variant="ghost" disabled={!!actionLoading[p.id]} onClick={() => { setReplacingId(p.id); setReplaceToken(null); setReplaceTarget(null) }}>
-                                Replace
-                              </Button>
                             </div>
                           )}
                         </div>
-                      </Card>
-                    )
-                  })}
-                </div>
-              )}
-            </section>
 
-            {/* Paused practices */}
-            {data.pausedPractices.length > 0 && (
-              <section>
-                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Paused</p>
-                <div className="space-y-3">
-                  {data.pausedPractices.map((p) => (
-                    <Card key={p.id} variant="interactive" className="flex items-start justify-between gap-4 opacity-70">
-                      <div className="space-y-2 min-w-0">
-                        <PillarBadge pillar={p.pillar} />
-                        <p className="font-semibold text-foreground">{p.title}</p>
-                        <p className="text-sm text-muted-foreground">{p.description}</p>
-                        {inlineError[p.id] && <p className="text-xs text-destructive">{inlineError[p.id]}</p>}
-                        {inlineWarning[p.id] && <p className="text-xs text-amber-700">{inlineWarning[p.id]}</p>}
-                      </div>
-                      <Button size="sm" variant="outline" disabled={!!actionLoading[p.id]} onClick={() => handleResume(p.id)}>
-                        {actionLoading[p.id] ? '…' : 'Resume'}
-                      </Button>
-                    </Card>
-                  ))}
-                </div>
-              </section>
-            )}
-
-            {/* Trials */}
-            <section>
-              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Trials</p>
-              {data.trials.length === 0 ? (
-                <EmptyState
-                  title="No active trials"
-                  text="Try a practice for 7 days before committing."
-                  action={<Button variant="outline" asChild><Link href="/results">Find a practice</Link></Button>}
-                />
-              ) : (
-                <div className="space-y-3">
-                  {data.trials.map((t) => (
-                    <Card key={t.id} variant="interactive" className="flex items-start justify-between gap-4">
-                      <div className="space-y-2 min-w-0">
-                        <div className="flex items-center gap-2 flex-wrap">
-                          <PillarBadge pillar={t.pillar} />
-                          <TrialBadge />
-                        </div>
-                        <p className="font-semibold text-foreground">{t.title}</p>
-                        <p className="text-sm text-muted-foreground">{t.description}</p>
-                        {t.active && (
-                          <p className="text-xs text-amber-700 font-medium">
-                            {t.daysRemaining === 0 ? 'Expires today' : `${t.daysRemaining} day${t.daysRemaining === 1 ? '' : 's'} remaining`}
-                          </p>
+                        {!isReplacing && (
+                          <div className="flex flex-col gap-2 shrink-0">
+                            {!isFocus && (
+                              <Button size="sm" variant="outline" disabled={!!actionLoading[p.id]} onClick={() => handleSetFocus(p.id)}>
+                                {actionLoading[p.id] ? '…' : 'Set focus'}
+                              </Button>
+                            )}
+                            <Button size="sm" variant="ghost" disabled={!!actionLoading[p.id]} onClick={() => handlePause(p.id)}>
+                              Pause
+                            </Button>
+                            <Button size="sm" variant="ghost" disabled={!!actionLoading[p.id]} onClick={() => { setReplacingId(p.id); setReplaceToken(null); setReplaceTarget(null) }}>
+                              Replace
+                            </Button>
+                          </div>
                         )}
-                        {!t.active && <p className="text-xs text-muted-foreground">Trial expired</p>}
-                        {inlineError[t.id] && <p className="text-xs text-destructive">{inlineError[t.id]}</p>}
                       </div>
-                      {t.active && (
-                        <div className="flex flex-col gap-2 shrink-0">
-                          <Button size="sm" variant="default" disabled={!!actionLoading[t.id]} onClick={() => handleTrialAction('promoteTrial', t.id)}>
-                            {actionLoading[t.id] ? '…' : 'Promote'}
-                          </Button>
-                          <Button size="sm" variant="ghost" disabled={!!actionLoading[t.id]} onClick={() => handleTrialAction('discardTrial', t.id)}>
-                            Discard
-                          </Button>
-                        </div>
-                      )}
                     </Card>
-                  ))}
-                </div>
-              )}
-            </section>
+                  )
+                })}
+
+                {data.trials.map((t) => (
+                  <Card key={t.id} variant="interactive" className="flex items-start justify-between gap-4">
+                    <div className="space-y-2 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <PillarBadge pillar={t.pillar} />
+                        <TrialBadge />
+                      </div>
+                      <p className="font-semibold text-foreground">{t.title}</p>
+                      <p className="text-sm text-muted-foreground">{t.description}</p>
+                      {t.active && (
+                        <p className="text-xs text-amber-700 font-medium">
+                          {t.daysRemaining === 0 ? 'Expires today' : `${t.daysRemaining} day${t.daysRemaining === 1 ? '' : 's'} left to decide`}
+                        </p>
+                      )}
+                      {!t.active && <p className="text-xs text-muted-foreground">Trial expired</p>}
+                      {inlineError[t.id] && <p className="text-xs text-destructive">{inlineError[t.id]}</p>}
+                    </div>
+                    {t.active && (
+                      <div className="flex flex-col gap-2 shrink-0">
+                        <Button size="sm" variant="default" disabled={!!actionLoading[t.id]} onClick={() => handleTrialAction('promoteTrial', t.id)}>
+                          {actionLoading[t.id] ? '…' : 'Keep it'}
+                        </Button>
+                        <Button size="sm" variant="ghost" disabled={!!actionLoading[t.id]} onClick={() => handleTrialAction('discardTrial', t.id)}>
+                          Not for me
+                        </Button>
+                      </div>
+                    )}
+                  </Card>
+                ))}
+
+                {data.pausedPractices.map((p) => (
+                  <Card key={p.id} variant="interactive" className="flex items-start justify-between gap-4 opacity-70">
+                    <div className="space-y-2 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <PillarBadge pillar={p.pillar} />
+                        <PausedBadge />
+                      </div>
+                      <p className="font-semibold text-foreground">{p.title}</p>
+                      <p className="text-sm text-muted-foreground">{p.description}</p>
+                      {inlineError[p.id] && <p className="text-xs text-destructive">{inlineError[p.id]}</p>}
+                      {inlineWarning[p.id] && <p className="text-xs text-amber-700">{inlineWarning[p.id]}</p>}
+                    </div>
+                    <Button size="sm" variant="outline" disabled={!!actionLoading[p.id]} onClick={() => handleResume(p.id)}>
+                      {actionLoading[p.id] ? '…' : 'Resume'}
+                    </Button>
+                  </Card>
+                ))}
+              </div>
+            )}
           </>
         )}
 

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -15,11 +15,22 @@ type Milestone = {
   achievedAt: string
 }
 
+type NextMilestone = {
+  type: string
+  threshold: number
+  practiceId?: string
+  title: string
+  description: string
+  progress: number
+  remaining: number
+}
+
 type ProgressData = {
   totalReturns: number
   practicesActivated: number
   currentStreak: number
   longestStreak: number
+  nextMilestones: NextMilestone[]
   milestones: Milestone[]
 }
 
@@ -76,6 +87,34 @@ export default function ProgressPage() {
       }
       main={
         <div className="space-y-6">
+          {/* Next-up milestones */}
+          {!loading && !error && data && data.nextMilestones.length > 0 && (
+            <div className="space-y-3">
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Coming up</p>
+              {data.nextMilestones.map((m) => {
+                const pct = Math.min(100, Math.round((m.progress / m.threshold) * 100))
+                return (
+                  <Card key={`${m.type}-${m.threshold}-${m.practiceId ?? ''}`} variant="subtle">
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <p className="font-semibold text-foreground text-sm">{m.title}</p>
+                        <p className="text-xs text-muted-foreground">{m.progress}/{m.threshold}</p>
+                      </div>
+                      <p className="text-xs text-muted-foreground">{m.description}</p>
+                      <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                        <div
+                          className="h-1.5 rounded-full bg-primary transition-all"
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                      <p className="text-xs text-muted-foreground">{m.remaining} more to go</p>
+                    </div>
+                  </Card>
+                )
+              })}
+            </div>
+          )}
+
           <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Milestones</p>
           {loading ? (
             <Loading text="Loading milestones…" />

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -50,7 +50,7 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
 
   return (
     <div className="min-h-screen bg-background">
-      <header className="sticky top-0 z-50 border-b border-border/60 bg-card/95 backdrop-blur relative overflow-hidden">
+      <header className="sticky top-0 z-50 border-b border-border/60 bg-card/95 backdrop-blur relative">
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute -top-20 right-[-10%] h-40 w-72 rounded-full bg-primary/10 blur-3xl" />
         </div>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -18,6 +18,7 @@ const NAV_ITEMS = [
   { href: '/practices', label: 'Practices' },
   { href: '/results', label: 'Results' },
   { href: '/progress', label: 'Progress' },
+  { href: '/assessment', label: 'Assessment' },
 ]
 
 function isActive(href: string, pathname: string | null) {

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -93,10 +93,17 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
                     <p className="text-xs text-muted-foreground truncate">{email}</p>
                     <p className="text-xs font-medium text-foreground mt-0.5">{plan} plan</p>
                   </div>
+                  <Link
+                    href="/account"
+                    onClick={() => setAccountOpen(false)}
+                    className="block px-4 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                  >
+                    View account
+                  </Link>
                   {onSignOut && (
                     <button
                       onClick={() => { setAccountOpen(false); onSignOut() }}
-                      className="w-full text-left px-4 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                      className="w-full text-left px-4 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors border-t border-border/60"
                     >
                       Sign out
                     </button>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { useAuthenticator } from '@aws-amplify/ui-react'
 import { Button } from '@/components/ui'
 import { PlanBadge } from '@/components/PlanBadge'
 import { UpgradeButton } from '@/components/UpgradeButton'
 import { DevSubscriptionToggle } from '@/components/DevSubscriptionToggle'
+import { useProfile } from '@/contexts/ProfileContext'
 
 interface AppShellProps {
   children: React.ReactNode
@@ -28,6 +30,23 @@ function isActive(href: string, pathname: string | null) {
 export function AppShell({ children, onSignOut }: AppShellProps) {
   const pathname = usePathname()
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [accountOpen, setAccountOpen] = useState(false)
+  const accountRef = useRef<HTMLDivElement>(null)
+  const { user } = useAuthenticator((ctx) => [ctx.user])
+  const { profile } = useProfile()
+
+  const email = user?.signInDetails?.loginId ?? user?.username ?? ''
+  const plan = profile?.subscriptionStatus === 'PAID' ? 'Premium' : 'Free'
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (accountRef.current && !accountRef.current.contains(e.target as Node)) {
+        setAccountOpen(false)
+      }
+    }
+    if (accountOpen) document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [accountOpen])
 
   return (
     <div className="min-h-screen bg-background">
@@ -60,14 +79,31 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
             <PlanBadge />
             <DevSubscriptionToggle />
             <UpgradeButton />
-            <Button variant="ghost" size="sm" className="hidden sm:inline-flex">
-              Account
-            </Button>
-            {onSignOut && (
-              <Button variant="ghost" size="sm" onClick={onSignOut} className="hidden sm:inline-flex">
-                Sign out
+            <div ref={accountRef} className="relative hidden sm:block">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setAccountOpen((v) => !v)}
+              >
+                Account
               </Button>
-            )}
+              {accountOpen && (
+                <div className="absolute right-0 top-full mt-1 w-56 rounded-xl border border-border bg-card shadow-md z-50 overflow-hidden">
+                  <div className="px-4 py-3 border-b border-border/60">
+                    <p className="text-xs text-muted-foreground truncate">{email}</p>
+                    <p className="text-xs font-medium text-foreground mt-0.5">{plan} plan</p>
+                  </div>
+                  {onSignOut && (
+                    <button
+                      onClick={() => { setAccountOpen(false); onSignOut() }}
+                      className="w-full text-left px-4 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                    >
+                      Sign out
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
             {/* Mobile hamburger */}
             <button
               className="md:hidden flex items-center justify-center w-9 h-9 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,6 +8,7 @@ const PROTECTED_PREFIXES = [
   '/results',
   '/assessment',
   '/progress',
+  '/account',
   '/decideRoute',
 ]
 


### PR DESCRIPTION
## Summary

- **Gap 2**: Add Assessment back to primary nav (spec requires Today / Practices / Progress / Assessment)
- **Gap 4**: Show next-up milestones on Progress page with progress bar and "X more to go"
- **Auth alert fix**: Text was squished to left side — fixed by scoping `width:100%` away from the alert dismiss button
- **Account button**: Wire Account dropdown in header (email, plan badge, View account link, Sign out)
- **`/account` page**: Simple page showing email, plan, retake assessment link, and sign out
- **Practices page refactor**: Flatten Active/Trials/Paused sections into a unified list; rename badge copy to "Trying" / "Paused"; rename trial actions to "Keep it" / "Not for me"

## Test plan

- [ ] Nav shows Today, Practices, Results, Progress, Assessment links
- [ ] Progress page shows "Coming up" section with progress bars for next unachieved milestones
- [ ] Auth error alert displays with text properly aligned
- [ ] Account button opens dropdown with email and plan; "View account" navigates to `/account`
- [ ] `/account` page shows email and plan; "Sign out" works; "Retake assessment" links to `/assessment`
- [ ] Practices page shows active, trial, and paused cards in a unified list with correct badge labels and button text
- [ ] Navigating to `/account` without auth redirects to `/auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)