### PR TITLE
UX polish: unified practice/trial UI, Insights page, Friends branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# FIApp v1 — FRIENDS Intelligence App
+# FIApp v1 — Friends Intelligence App
 
-Science-based wellbeing assessment + coaching product using the F.R.I.E.N.D.S Intelligence framework.
+Science-based wellbeing assessment + coaching product using the Friends Intelligence framework.
 
 **Frontend + Backend:** Next.js (App Router)  
 **Hosting:** AWS Amplify  

--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -107,7 +107,7 @@ export default function AssessmentPage() {
     >
       <div className="space-y-3">
         <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
-          FRIENDS INTELLIGENCE · ASSESSMENT
+          Friends Intelligence · Assessment
         </p>
         <Card>
           <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,16 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- Red — top (12 o'clock) -->
+  <path d="M 38.6 13.8 A 38 38 0 0 1 61.4 13.8" stroke="#E53935" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Orange — upper right -->
+  <path d="M 71.2 18.4 A 38 38 0 0 1 85.5 36.3" stroke="#F47920" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Yellow — right -->
+  <path d="M 87.9 46.9 A 38 38 0 0 1 82.8 69.2" stroke="#FFC20E" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Green — lower right -->
+  <path d="M 75.9 77.8 A 38 38 0 0 1 55.5 87.6" stroke="#39B54A" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Teal — lower left -->
+  <path d="M 44.6 87.6 A 38 38 0 0 1 24.1 77.8" stroke="#00A99D" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Blue — left -->
+  <path d="M 17.3 69.3 A 38 38 0 0 1 12.1 47.0" stroke="#1C75BC" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Purple — upper left -->
+  <path d="M 14.5 36.4 A 38 38 0 0 1 28.7 18.5" stroke="#7B2D8B" stroke-width="9" fill="none" stroke-linecap="round"/>
+</svg>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ import AppChrome from "@/components/AppChrome";
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
 export const metadata: Metadata = {
-  title: "FIApp - Wellbeing & Growth",
+  title: "Friends Intelligence",
   description: "Your personal wellbeing and growth platform",
 };
 

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -264,14 +264,26 @@ export default function PracticesPage() {
         {loading && <Loading text="Loading your practices…" />}
         {!loading && error && <ErrorState message="Couldn't load practices." onRetry={load} />}
 
-        {!loading && !error && data && (
+        {!loading && !error && data && (() => {
+          const activeTrials = data.trials.filter((t) => t.active)
+          const expiredTrials = data.trials.filter((t) => !t.active)
+          const visibleCount = data.activePractices.length + activeTrials.length + data.pausedPractices.length
+          return (
           <>
-            {(data.activePractices.length + data.trials.length + data.pausedPractices.length) === 0 ? (
-              <EmptyState
-                title="No practices yet"
-                text="Pick practices from your results to start building your routine."
-                action={<Button variant="outline" asChild><Link href="/results">Browse suggestions</Link></Button>}
-              />
+            {visibleCount === 0 ? (
+              expiredTrials.length > 0 ? (
+                <EmptyState
+                  title={expiredTrials.length === 1 ? `Your trial of "${expiredTrials[0].title}" ended` : 'Your trials ended'}
+                  text="Ready to commit to something? Browse your results and pick a practice."
+                  action={<Button variant="outline" asChild><Link href="/results">Browse suggestions</Link></Button>}
+                />
+              ) : (
+                <EmptyState
+                  title="No practices yet"
+                  text="Pick practices from your results to start building your routine."
+                  action={<Button variant="outline" asChild><Link href="/results">Browse suggestions</Link></Button>}
+                />
+              )
             ) : (
               <div className="space-y-3">
                 {data.activePractices.map((p) => {
@@ -354,7 +366,7 @@ export default function PracticesPage() {
                   )
                 })}
 
-                {data.trials.map((t) => (
+                {activeTrials.map((t) => (
                   <Card key={t.id} variant="interactive" className="flex items-start justify-between gap-4">
                     <div className="space-y-2 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
@@ -404,7 +416,8 @@ export default function PracticesPage() {
               </div>
             )}
           </>
-        )}
+          )
+        })()}
 
         <div className="pt-2">
           <Button asChild>

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { StandardPage } from '@/components/layout';
-import { Card, Button, Loading, ErrorState } from '@/components/ui';
+import { Card, Button, Loading, ErrorState, EmptyState } from '@/components/ui';
 import { PillarRadarChart } from '@/components/ui/PillarRadarChart';
 import { pillarColors } from '@/lib/design/pillarColors';
 import { pillarOrder, pillarLabels } from '@/lib/assessment/pillars';
@@ -96,11 +96,27 @@ export default function ResultsPage() {
 
   return (
     <StandardPage
-      title="Your Results"
-      description="Here's where you stand across the 7 F.R.I.E.N.D.S pillars."
-      metaLabel="RESULTS"
+      title="Your Insights"
+      description="Where you stand across the 7 Friends pillars — and what to work on next."
+      metaLabel="INSIGHTS"
+      actions={assessment ? (
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/assessment">Retake assessment</Link>
+        </Button>
+      ) : undefined}
     >
       <div className="space-y-10">
+
+        {loading && <Loading text="Loading your insights…" />}
+        {!loading && error && <ErrorState message="Couldn't load your insights." onRetry={() => window.location.reload()} />}
+
+        {!loading && !error && !assessment && (
+          <EmptyState
+            title="No insights yet"
+            text="Take the assessment to see your pillar scores and get personalized practice suggestions."
+            action={<Button asChild><Link href="/assessment">Start assessment →</Link></Button>}
+          />
+        )}
 
         {assessment && (
           <>
@@ -163,70 +179,60 @@ export default function ResultsPage() {
                 })}
               </div>
             </div>
+            {/* Suggested practices */}
+            <div>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">
+                Suggested Practices
+              </p>
+              {!suggestions && <Loading text="Finding the right practices for you…" />}
+              {suggestions && (
+                <div className="space-y-4">
+                  {suggestions.map((practice) => (
+                    <Card key={practice.id} variant="interactive">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="space-y-2 min-w-0">
+                          <span
+                            className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
+                            style={{ backgroundColor: pillarColors[practice.pillar] }}
+                          >
+                            {pillarLabels[practice.pillar]}
+                          </span>
+                          <p className="font-semibold text-foreground">{practice.title}</p>
+                          <p className="text-sm text-muted-foreground">{practice.description}</p>
+                          <p className="text-xs text-muted-foreground italic">
+                            Why: {practice.rationale}
+                          </p>
+                        </div>
+                        <div className="flex flex-col items-end gap-1 shrink-0">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={!!trialLoading[practice.id]}
+                            onClick={() => handleTryThis(practice.id)}
+                          >
+                            {trialLoading[practice.id] ? '…' : 'Try this'}
+                          </Button>
+                          {trialError[practice.id] && (
+                            <p className="text-[11px] text-destructive text-right max-w-[140px]">
+                              {trialError[practice.id]}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </Card>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* CTA */}
+            <div className="pt-2">
+              <Button asChild size="lg">
+                <Link href="/practices">Go to My Practices →</Link>
+              </Button>
+            </div>
           </>
         )}
-
-        {/* Suggested practices */}
-        <div>
-          <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">
-            Suggested Practices
-          </p>
-
-          {loading && <Loading text="Finding the right practices for you…" />}
-
-          {!loading && error && (
-            <ErrorState
-              message="Couldn't load suggestions."
-              onRetry={() => window.location.reload()}
-            />
-          )}
-
-          {!loading && !error && suggestions && (
-            <div className="space-y-4">
-              {suggestions.map((practice) => (
-                <Card key={practice.id} variant="interactive">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="space-y-2 min-w-0">
-                      <span
-                        className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
-                        style={{ backgroundColor: pillarColors[practice.pillar] }}
-                      >
-                        {pillarLabels[practice.pillar]}
-                      </span>
-                      <p className="font-semibold text-foreground">{practice.title}</p>
-                      <p className="text-sm text-muted-foreground">{practice.description}</p>
-                      <p className="text-xs text-muted-foreground italic">
-                        Why: {practice.rationale}
-                      </p>
-                    </div>
-                    <div className="flex flex-col items-end gap-1 shrink-0">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        disabled={!!trialLoading[practice.id]}
-                        onClick={() => handleTryThis(practice.id)}
-                      >
-                        {trialLoading[practice.id] ? '…' : 'Try this'}
-                      </Button>
-                      {trialError[practice.id] && (
-                        <p className="text-[11px] text-destructive text-right max-w-[140px]">
-                          {trialError[practice.id]}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                </Card>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* CTA */}
-        <div className="pt-2">
-          <Button asChild size="lg">
-            <Link href="/practices">Go to Active Practices →</Link>
-          </Button>
-        </div>
       </div>
     </StandardPage>
   );

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -17,6 +17,7 @@ type Trial = {
   id: string
   pillar: Pillar
   title: string
+  description: string
   daysRemaining: number
   active: boolean
 }
@@ -185,12 +186,17 @@ export default function TodayPage() {
             <Card>
               <div className="space-y-4">
                 <div>
-                  <span
-                    className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
-                    style={{ backgroundColor: pillarColors[focusPractice.pillar] }}
-                  >
-                    {pillarLabels[focusPractice.pillar]}
-                  </span>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span
+                      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
+                      style={{ backgroundColor: pillarColors[focusPractice.pillar] }}
+                    >
+                      {pillarLabels[focusPractice.pillar]}
+                    </span>
+                    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-primary/10 text-primary border border-primary/30">
+                      Today&apos;s focus
+                    </span>
+                  </div>
                   <p className="mt-3 text-xl font-semibold text-foreground">{focusPractice.title}</p>
                   <p className="mt-1 text-sm text-muted-foreground">{focusPractice.description}</p>
                 </div>
@@ -228,8 +234,8 @@ export default function TodayPage() {
               </div>
             </Card>
 
-            {/* 14-day dots */}
-            <Card variant="subtle">
+            {/* 14-day dots — only shown after first check-in */}
+            {dots.some((d) => d.didIt !== null) && <Card variant="subtle">
               <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Last 14 days</p>
               <div className="flex flex-wrap gap-2">
                 {dots.map((dot) => (
@@ -246,35 +252,35 @@ export default function TodayPage() {
                   />
                 ))}
               </div>
-            </Card>
+            </Card>}
           </>
         )}
 
-        {/* Trial check-ins */}
         {!loading && !error && activeTrials.length > 0 && (
           <div className="space-y-3">
-            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Trials</p>
             {activeTrials.map((trial) => {
               const didIt = trialDidIt[trial.id] ?? null
               const busy = !!trialLogging[trial.id]
               return (
                 <Card key={trial.id} variant="subtle">
-                  <div className="space-y-3">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span
-                        className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
-                        style={{ backgroundColor: pillarColors[trial.pillar] }}
-                      >
-                        {pillarLabels[trial.pillar]}
-                      </span>
-                      <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-amber-100 text-amber-800 border border-amber-300">
-                        Trial · {trial.daysRemaining}d left
-                      </span>
+                  <div className="space-y-4">
+                    <div>
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span
+                          className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
+                          style={{ backgroundColor: pillarColors[trial.pillar] }}
+                        >
+                          {pillarLabels[trial.pillar]}
+                        </span>
+                        <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-amber-100 text-amber-800 border border-amber-300">
+                          Trying · {trial.daysRemaining}d left to decide
+                        </span>
+                      </div>
+                      <p className="mt-3 font-semibold text-foreground">{trial.title}</p>
+                      <p className="mt-1 text-sm text-muted-foreground">{trial.description}</p>
                     </div>
-                    <p className="font-medium text-foreground">{trial.title}</p>
-                    <div className="grid grid-cols-2 gap-2">
+                    <div className="grid grid-cols-2 gap-3">
                       <Button
-                        size="sm"
                         variant={didIt === true ? 'default' : 'outline'}
                         disabled={busy}
                         onClick={() => handleTrialLog(trial.id, true)}
@@ -282,7 +288,6 @@ export default function TodayPage() {
                         {busy ? '…' : '✓ Did it'}
                       </Button>
                       <Button
-                        size="sm"
                         variant={didIt === false ? 'secondary' : 'outline'}
                         disabled={busy}
                         onClick={() => handleTrialLog(trial.id, false)}

--- a/components/AuthenticatorWrapper.tsx
+++ b/components/AuthenticatorWrapper.tsx
@@ -47,7 +47,7 @@ export default function AuthenticatorWrapper() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src="/logo-mark.svg" alt="Friends Intelligence" className="h-16 w-16 mx-auto mb-4" />
           <h1 className="text-3xl font-semibold text-foreground">
-            FRIENDS Intelligence
+            Friends Intelligence
           </h1>
           <p className="text-sm text-muted-foreground mt-2">
             Sign in to continue your journey

--- a/components/AuthenticatorWrapper.tsx
+++ b/components/AuthenticatorWrapper.tsx
@@ -44,6 +44,8 @@ export default function AuthenticatorWrapper() {
     <div className="min-h-screen bg-muted/40 flex items-center justify-center px-4 py-10">
       <div className="w-full max-w-2xl rounded-2xl border border-border bg-card shadow-xl p-12">
         <div className="text-center mb-8">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/logo-mark.svg" alt="Friends Intelligence" className="h-16 w-16 mx-auto mb-4" />
           <h1 className="text-3xl font-semibold text-foreground">
             FRIENDS Intelligence
           </h1>

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -18,9 +18,8 @@ interface AppShellProps {
 const NAV_ITEMS = [
   { href: '/today', label: 'Today' },
   { href: '/practices', label: 'Practices' },
-  { href: '/results', label: 'Results' },
+  { href: '/results', label: 'Insights' },
   { href: '/progress', label: 'Progress' },
-  { href: '/assessment', label: 'Assessment' },
 ]
 
 function isActive(href: string, pathname: string | null) {
@@ -56,8 +55,12 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
         </div>
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-14 flex items-center justify-between">
           <div className="flex items-center gap-6">
-            <Link href="/today" className="font-semibold tracking-tight text-foreground hover:text-primary transition-colors">
-              FIApp
+            <Link href="/today" className="flex items-center gap-2 group">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="/logo-mark.svg" alt="Friends Intelligence" className="h-7 w-7 shrink-0" />
+              <span className="hidden sm:inline font-semibold tracking-tight text-foreground group-hover:text-primary transition-colors text-sm">
+                Friends Intelligence
+              </span>
             </Link>
             <nav className="hidden md:flex items-center gap-4 text-sm">
               {NAV_ITEMS.map(({ href, label }) => (

--- a/components/ui/content-primitives.tsx
+++ b/components/ui/content-primitives.tsx
@@ -107,9 +107,11 @@ interface EmptyStateProps {
 export function EmptyState({ icon, title, text, action }: EmptyStateProps) {
   return (
     <Card variant="subtle" className="text-center">
-      <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted/60 text-muted-foreground">
-        {icon || <span className="text-lg">○</span>}
-      </div>
+      {icon && (
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted/60 text-muted-foreground">
+          {icon}
+        </div>
+      )}
       <h3 className="text-lg font-semibold text-foreground">{title}</h3>
       {text && <p className="mt-2 text-sm text-muted-foreground">{text}</p>}
       {action && <div className="mt-4 flex justify-center">{action}</div>}

--- a/public/logo-mark.svg
+++ b/public/logo-mark.svg
@@ -1,0 +1,16 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <!-- Red — top (12 o'clock) -->
+  <path d="M 38.6 13.8 A 38 38 0 0 1 61.4 13.8" stroke="#E53935" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Orange — upper right -->
+  <path d="M 71.2 18.4 A 38 38 0 0 1 85.5 36.3" stroke="#F47920" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Yellow — right -->
+  <path d="M 87.9 46.9 A 38 38 0 0 1 82.8 69.2" stroke="#FFC20E" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Green — lower right -->
+  <path d="M 75.9 77.8 A 38 38 0 0 1 55.5 87.6" stroke="#39B54A" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Teal — lower left -->
+  <path d="M 44.6 87.6 A 38 38 0 0 1 24.1 77.8" stroke="#00A99D" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Blue — left -->
+  <path d="M 17.3 69.3 A 38 38 0 0 1 12.1 47.0" stroke="#1C75BC" stroke-width="9" fill="none" stroke-linecap="round"/>
+  <!-- Purple — upper left -->
+  <path d="M 14.5 36.4 A 38 38 0 0 1 28.7 18.5" stroke="#7B2D8B" stroke-width="9" fill="none" stroke-linecap="round"/>
+</svg>

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -8,7 +8,7 @@ test.describe("/auth", () => {
 
     await page.goto("/auth");
 
-    await expect(page.getByText("FRIENDS Intelligence")).toBeVisible();
+    await expect(page.getByText("Friends Intelligence")).toBeVisible();
     await expect(page.getByRole("tab", { name: /sign in/i })).toBeVisible();
     await expect(page.getByLabel(/email/i)).toBeVisible();
   });
@@ -20,7 +20,7 @@ test.describe("/auth", () => {
 
     await page.goto("/auth");
     await expect(page).toHaveURL(/\/decideRoute$/);
-    await expect(page.getByText("FRIENDS Intelligence")).toHaveCount(0);
+    await expect(page.getByText("Friends Intelligence")).toHaveCount(0);
     await expect(page.getByLabel(/email/i)).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

- **Practices page**: merged Active / Trial / Paused into one flat list; expired trials hidden silently with a contextual empty state (e.g. *"Your trial of X ended"*); renamed Promote → Keep it, Discard → Not for me, Trial badge → Trying
- **Today page**: removed "Trials" section header; added "Today's focus" badge to focus card; trial cards now show description and full-size buttons; 14-day dots hidden until first check-in
- **Insights page** (was Results): renamed in nav and page; "Retake assessment" moved from bottom to page header; proper empty state for users who haven't taken the assessment yet
- **Friends branding**: replaced all `F.R.I.E.N.D.S` and `FRIENDS` with `Friends` across UI, README, and e2e tests
- **EmptyState component**: removed default `○` placeholder — icon container only renders when an icon prop is passed

## Test plan

- [ ] Practices page: active, trial, and paused cards all appear in one list with correct badges and actions
- [ ] Expired trial: card disappears from list; contextual empty state appears if it was the only item
- [ ] Today page: focus card shows "Today's focus" badge; trial card shows description and full-size buttons; dots hidden on day one
- [ ] Insights page: "Retake assessment" button visible in header when assessment exists; empty state shown when no assessment taken
- [ ] Auth page: displays "Friends Intelligence" (e2e test updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)