### PR TITLE
fix: remove redundant page eyebrow labels, fix Friends branding

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -14,7 +14,7 @@ export default function AccountPage() {
   const plan = profile?.subscriptionStatus === 'PAID' ? 'Premium' : 'Free'
 
   return (
-    <NarrowFormPage title="Account" description="Your profile and settings." metaLabel="ACCOUNT">
+    <NarrowFormPage title="Account" description="Your profile and settings.">
       <div className="space-y-4">
 
         {/* Identity */}

--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -106,7 +106,7 @@ export default function AssessmentPage() {
       title=""
     >
       <div className="space-y-3">
-        <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
+        <p className="text-xs tracking-[0.12em] text-muted-foreground">
           Friends Intelligence · Assessment
         </p>
         <Card>

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -253,7 +253,6 @@ export default function PracticesPage() {
     <StandardPage
       title="My Practices"
       description="Your committed practices and what you're testing."
-      metaLabel="PRACTICES"
       actions={
         <Button variant="outline" size="sm" asChild>
           <Link href="/results">+ Add practice</Link>

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -54,7 +54,6 @@ export default function ProgressPage() {
     <DashboardPage
       title="Progress"
       description="Your growth at a glance."
-      metaLabel="INSIGHTS"
       summary={
         loading ? (
           <Loading text="Loading stats…" />

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -98,7 +98,6 @@ export default function ResultsPage() {
     <StandardPage
       title="Your Insights"
       description="Where you stand across the 7 Friends pillars — and what to work on next."
-      metaLabel="INSIGHTS"
       actions={assessment ? (
         <Button variant="ghost" size="sm" asChild>
           <Link href="/assessment">Retake assessment</Link>

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -142,7 +142,7 @@ export default function TodayPage() {
   }
 
   return (
-    <NarrowFormPage title="Today" description="Your daily check-in." metaLabel="OVERVIEW">
+    <NarrowFormPage title="Today" description="Your daily check-in.">
       <div className="space-y-6">
 
         {newMilestones.length > 0 && (

--- a/components/layout/PageLayouts.tsx
+++ b/components/layout/PageLayouts.tsx
@@ -15,7 +15,7 @@ interface BasePageProps {
 export function StandardPage({
   title,
   description,
-  metaLabel = 'PAGE',
+  metaLabel,
   actions,
   children,
 }: BasePageProps) {
@@ -38,7 +38,7 @@ export function StandardPage({
 export function NarrowFormPage({
   title,
   description,
-  metaLabel = 'FORM',
+  metaLabel,
   actions,
   children,
 }: BasePageProps) {
@@ -74,7 +74,7 @@ interface DashboardPageProps {
 export function DashboardPage({
   title,
   description,
-  metaLabel = 'DASHBOARD',
+  metaLabel,
   summary,
   main,
   actions,
@@ -110,7 +110,7 @@ interface ListDetailPageProps {
 export function ListDetailPage({
   title,
   description,
-  metaLabel = 'LIBRARY',
+  metaLabel,
   list,
   detail,
   actions,

--- a/components/ui/content-primitives.tsx
+++ b/components/ui/content-primitives.tsx
@@ -21,15 +21,17 @@ interface PageHeaderProps {
   actions?: React.ReactNode
 }
 
-export function PageHeader({ eyebrow = 'PAGE', title, description, actions }: PageHeaderProps) {
+export function PageHeader({ eyebrow, title, description, actions }: PageHeaderProps) {
   return (
     <div className="border-b border-border/60 pb-8 mb-10">
       <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div>
-          <span className="inline-flex items-center rounded-full bg-muted/60 px-3 py-1 text-xs uppercase tracking-[0.22em] text-muted-foreground">
-            {eyebrow}
-          </span>
-          <h1 className="mt-3 text-4xl sm:text-5xl font-bold text-foreground">{title}</h1>
+          {eyebrow && (
+            <span className="inline-flex items-center rounded-full bg-muted/60 px-3 py-1 text-xs uppercase tracking-[0.22em] text-muted-foreground">
+              {eyebrow}
+            </span>
+          )}
+          <h1 className={`text-4xl sm:text-5xl font-bold text-foreground${eyebrow ? ' mt-3' : ''}`}>{title}</h1>
           {description && (
             <p className="mt-3 text-lg text-muted-foreground max-w-2xl">{description}</p>
           )}


### PR DESCRIPTION
## Summary

- **Eyebrow labels removed**: `PageHeader` now only renders the eyebrow pill when an explicit `eyebrow` prop is passed — no more hardcoded fallbacks like `PAGE`, `FORM`, `DASHBOARD`. Stripped `metaLabel` from Today, Practices, Insights, Progress, and Account pages where it just echoed the nav item (e.g. "PRACTICES" above "My Practices")
- **Assessment eyebrow**: kept "Friends Intelligence · Assessment" as useful context on a 35-question form, but removed `uppercase` CSS so it renders in normal case instead of all-caps
- **Friends branding audit**: confirmed zero remaining instances of `F.R.I.E.N.D.S` or `FRIENDS` across all app, component, test, and doc files

## Test plan

- [ ] All product pages (Today, Practices, Insights, Progress, Account) show no eyebrow label above the title
- [ ] Assessment page shows "Friends Intelligence · Assessment" in normal case (not all-caps)
- [ ] Branding consistent as "Friends Intelligence" on auth screen, nav, and assessment

🤖 Generated with [Claude Code](https://claude.com/claude-code)