### PR TITLE
feat: design polish, plan labels, custom radar chart, post check-in moment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Science-based wellbeing assessment + coaching product using the Friends Intellig
 - Run a 7-pillar assessment (35 yes/no questions)
 - Compute pillar scores + choose focus pillar
 - Suggest small “practices” based on results
-- Let users activate practices (free vs paid caps)
+- Let users activate practices (Free plan vs Plus plan caps)
 - Track daily returns (did it / not today)
 - Show progress via counters + milestones
 

--- a/_docs/canon/api-contract.md
+++ b/_docs/canon/api-contract.md
@@ -110,8 +110,8 @@ This endpoint is the **only** way to modify active/trial/paused/focus state.
 **Server rules**
 - Enforce caps based on `subscriptionStatus`:
   - FREE cap=1
-  - PAID cap=10
-- Warning thresholds on paid:
+  - PAID cap=10 (displayed as Plus plan)
+- Warning thresholds on Plus plan / internal `PAID`:
   - at 5 → include warning
   - at 7 → strong warning
 - At 10 → hard stop (error)
@@ -150,7 +150,7 @@ or
 **Server rules (Option 2)**
 - Pausing removes from `activePracticeIds` but preserves a pointer to the UPRACTICE record:
   - keep mapping in `activePracticeSkById` (or equivalent) to locate SK for resume/history
-- Resume re-adds to `activePracticeIds` subject to caps (free/paid)
+- Resume re-adds to `activePracticeIds` subject to caps (Free plan / Plus plan)
 - Resume should behave like `add` with cap checks + warnings
 
 **Returns**
@@ -255,7 +255,7 @@ or
 
 ## 7) Cap warnings & confirm flow (canonical intent)
 
-- Paid users:
+- Plus plan users (internal `PAID`):
   - warn at 5
   - strong warn at 7
   - hard stop at 10

--- a/_docs/canon/db-schema.md
+++ b/_docs/canon/db-schema.md
@@ -122,7 +122,7 @@ Stores daily completion signal per practice per day.
 
 ### 3.1 Caps
 - Free: **1 active practice**
-- Paid: **10 active practices hard cap**
+- Plus plan (internal `PAID`): **10 active practices hard cap**
 - Warning thresholds: **5 (soft), 7 (strong), 10 (hard stop)**
 
 ### 3.2 Trials policy

--- a/_docs/canon/practice-caps-and-trials.md
+++ b/_docs/canon/practice-caps-and-trials.md
@@ -13,7 +13,7 @@
 - Hard stop: cannot add more
 - Replacement is allowed (count remains 1)
 
-### Paid users
+### Plus plan users (internal `PAID`)
 - Maximum **10** active practices
 - Hard stop at 10 (cannot exceed under any circumstance)
 
@@ -21,7 +21,7 @@ Caps are enforced **server-side only**.
 
 ---
 
-## 2. Progressive Warnings (Paid Users)
+## 2. Progressive Warnings (Plus Plan Users)
 
 Warnings are **non-blocking** but intentional:
 

--- a/_docs/canon/state-machine.md
+++ b/_docs/canon/state-machine.md
@@ -84,7 +84,7 @@ This single screen replaces the “selector” + “manage” split.
 - Pause / resume (Option 2 pause logic)
 - Set focus practice
 - View trials (start/promote/discard)
-- Show cap warnings at 5/7 and hard stop at 10 (paid)
+- Show cap warnings at 5/7 and hard stop at 10 (Plus plan / internal `PAID`)
 - Navigate to Today + Progress
 
 > **Invariant:** Any action that changes practice state calls `POST /api/practice`.
@@ -93,7 +93,7 @@ This single screen replaces the “selector” + “manage” split.
 
 ## 6) Cap & Confirm UX (canonical behavior)
 
-### Paid users
+### Plus plan users (internal `PAID`)
 - At 5 active: show warning (non-blocking)
 - At 7 active: show strong warning (non-blocking but prominent)
 - At 10 active: hard stop (cannot add more)

--- a/_docs/canon/testing-checklist.md
+++ b/_docs/canon/testing-checklist.md
@@ -73,9 +73,9 @@
   - returns hard error or requiresReplace response (whatever your contract defines)
 - [ ] Free user can `replace` at cap successfully (count stays 1)
 
-### 3.2 Paid cap = 10 (hard stop)
-- [ ] Paid user can add up to 10 active practices
-- [ ] Paid user adding 11th is rejected (hard stop)
+### 3.2 Plus plan cap = 10 (hard stop; internal `PAID`)
+- [ ] Plus plan user can add up to 10 active practices
+- [ ] Plus plan user adding 11th is rejected (hard stop)
   - ensure no data mutation occurred
 
 ### 3.3 Warnings at 5 and 7
@@ -98,14 +98,14 @@
 ### 4.2 Resume is cap-checked and warning-aware
 - [ ] Resume adds it back if under cap
 - [ ] Resume triggers warning at 5 / 7 when applicable
-- [ ] Resume is rejected if at hard cap (paid 10, free 1)
+- [ ] Resume is rejected if at hard cap (Plus plan 10, Free plan 1)
 
 ---
 
 ## 5) Trial lifecycle (LOCKED distinctions)
 
 ### 5.1 Trials don’t consume cap
-- [ ] With paid user at cap=10 active, `startTrial` still succeeds
+- [ ] With Plus plan user at cap=10 active, `startTrial` still succeeds
 - [ ] Active count remains unchanged after `startTrial`
 
 ### 5.2 Promote trial consumes cap
@@ -163,7 +163,7 @@ Use Playwright/Cypress (or similar). Keep these short and stable.
 - [ ] If assessment exists but no practices, Today redirects to Results (or Active Practices per your guard) and cannot log returns
 
 ### 8.3 Cap cannot be bypassed
-- [ ] Paid user at 10 active cannot add 11th via any UI path
+- [ ] Plus plan user at 10 active cannot add 11th via any UI path
 - [ ] Free user cannot exceed 1 active
 
 ---

--- a/_docs/plans/epic2-dev-subscription-toggle.md
+++ b/_docs/plans/epic2-dev-subscription-toggle.md
@@ -2,7 +2,7 @@
 
 **Status:** Implemented
 
-**Purpose:** Allow testing paid flows without payment integration.
+**Purpose:** Allow testing Plus plan flows without payment integration.
 
 **Success criteria:**
 - Dev can toggle subscriptionStatus ✓
@@ -17,7 +17,7 @@ Add to `.env.local`:
 ```
 NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true
 ```
-Restart dev server. The "Free | Paid" toggle appears in the header. Click to switch; UI updates immediately.
+Restart dev server. The "Free | Plus" toggle appears in the header. Click to switch; UI updates immediately.
 
 ---
 
@@ -60,7 +60,7 @@ Add `NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true` so the client can gate the dev con
 
 - Client component
 - Renders only when `process.env.NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION === "true"`
-- Shows Free | Premium toggle (or two buttons: "Set Free" / "Set Paid")
+- Shows Free | Plus toggle (or two buttons: "Set Free" / "Set Plus")
 - On click:
   1. `POST /api/dev/subscription` with `{ subscriptionStatus: "FREE" | "PAID" }`
   2. On success: call `refetch()` from `useProfile()`
@@ -87,12 +87,12 @@ Add `NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true` so the client can gate the dev con
 - DevSubscriptionToggle will call `refetch()` after a successful POST
 
 **Flow:**
-1. User clicks "Set Paid" in DevSubscriptionToggle
+1. User clicks "Set Plus" in DevSubscriptionToggle
 2. POST /api/dev/subscription with `{ subscriptionStatus: "PAID" }`
 3. API updates PROFILE.subscriptionStatus via setMySubscriptionStatus
 4. On success, DevSubscriptionToggle calls `refetch()`
 5. ProfileContext fetches `/api/me` and updates state
-6. PlanBadge and UpgradeButton re-render with new status (Premium, no Upgrade button)
+6. PlanBadge and UpgradeButton re-render with new status (Plus plan, no Upgrade button)
 
 ---
 
@@ -101,8 +101,8 @@ Add `NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true` so the client can gate the dev con
 1. Set `NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true` in `.env.local`
 2. Restart dev server (env vars need rebuild)
 3. Sign in → dev toggle appears in header
-4. Click "Set Paid" → PlanBadge shows Premium, Upgrade button hides
-5. Click "Set Free" → PlanBadge shows Free, Upgrade button appears
+4. Click "Set Plus" → PlanBadge shows Plus plan, Upgrade button hides
+5. Click "Set Free" → PlanBadge shows Free plan, Upgrade button appears
 6. No full page refresh required
 
 ---

--- a/_docs/plans/epic2-subscription-display.md
+++ b/_docs/plans/epic2-subscription-display.md
@@ -2,7 +2,7 @@
 
 **Status:** Implemented
 
-**Purpose:** Enable free vs paid gating and UI behavior.
+**Purpose:** Enable Free plan vs Plus plan gating and UI behavior.
 
 **Success criteria:**
 - PROFILE contains subscriptionStatus ✓ (from profile-defaults)
@@ -18,15 +18,20 @@
 ### Backend (already done)
 - `createMyProfile` sets `subscriptionStatus: "FREE"`
 - `/api/me` returns full profile including `subscriptionStatus`
-- `POST /api/dev/subscription` allows dev override to PAID
+- `POST /api/dev/subscription` allows dev override to internal `PAID` status
 
 ### Front-end
-- **PlanBadge** (`components/PlanBadge.tsx`): shows "Free" or "Premium" pill in header (from profile context)
-- **UpgradeButton** (`components/UpgradeButton.tsx`): stubbed Upgrade CTA, shown only when `subscriptionStatus === "FREE"`; click → toast "Upgrade coming soon"
+- **PlanBadge** (`components/PlanBadge.tsx`): shows "Free plan" or "Plus plan" pill in header (from profile context)
+- **UpgradeButton** (`components/UpgradeButton.tsx`): stubbed Upgrade CTA, shown only when `subscriptionStatus === "FREE"`; click → toast "Plus plan is coming soon"
 - **AppShell**: renders PlanBadge + UpgradeButton in header
-- Free = muted pill, Paid = primary-tinted pill; no Upgrade button for Premium
+- Free plan = muted pill, Plus plan = primary-tinted pill; no Upgrade button for Plus plan
+
+### Naming rule
+- Internal/database values remain `FREE | PAID`.
+- User-facing labels are **Free plan** and **Plus plan**.
+- `PAID` means "Plus plan capabilities" in code and tests.
 
 ### Manual test
-1. Sign in → header shows "Free" badge + Upgrade button
-2. Click Upgrade → toast "Upgrade coming soon"
-3. `POST /api/dev/subscription` with `{ subscriptionStatus: "PAID" }` → refresh → header shows "Premium", Upgrade button hidden
+1. Sign in → header shows "Free plan" badge + "Upgrade to Plus" button
+2. Click Upgrade → toast "Plus plan is coming soon"
+3. `POST /api/dev/subscription` with `{ subscriptionStatus: "PAID" }` → refresh → header shows "Plus plan", Upgrade button hidden

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -5,13 +5,14 @@ import { useAuthenticator } from '@aws-amplify/ui-react';
 import { NarrowFormPage } from '@/components/layout';
 import { Card, Button } from '@/components/ui';
 import { useProfile } from '@/contexts/ProfileContext';
+import { getPlanLabel } from '@/lib/plans';
 
 export default function AccountPage() {
   const { user, signOut } = useAuthenticator((ctx) => [ctx.user, ctx.signOut])
   const { profile } = useProfile()
 
   const email = user?.signInDetails?.loginId ?? user?.username ?? '—'
-  const plan = profile?.subscriptionStatus === 'PAID' ? 'Premium' : 'Free'
+  const plan = getPlanLabel(profile?.subscriptionStatus)
 
   return (
     <NarrowFormPage title="Account" description="Your profile and settings.">

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -23,16 +23,26 @@ async function getActiveTrialCount(userId: string): Promise<number> {
   return trials.filter(isTrialActive).length;
 }
 
+async function getActiveTrialCountOrDefault(userId: string): Promise<number> {
+  try {
+    return await getActiveTrialCount(userId);
+  } catch (error) {
+    console.error("[GET /api/me] failed to read active trials:", error);
+    return 0;
+  }
+}
+
 export async function GET(req: Request) {
   return withAuth(req, async (user) => {
     const client = getDataClient();
 
     const [profileResult, activeTrialCount] = await Promise.all([
       client.queries.getMyProfile(),
-      getActiveTrialCount(user.userId),
+      getActiveTrialCountOrDefault(user.userId),
     ]);
 
     if (profileResult.errors?.length) {
+      console.error("[GET /api/me] getMyProfile errors:", profileResult.errors);
       return jsonWithNoStore(
         { ok: false, error: { code: "INTERNAL_ERROR", message: "Failed to read profile" } },
         500
@@ -49,9 +59,14 @@ export async function GET(req: Request) {
     // Profile missing — create default (idempotent)
     const created = await client.mutations.createMyProfile();
     if (created.errors?.length) {
+      console.error("[GET /api/me] createMyProfile errors:", created.errors);
       // Race: re-read
       const read2 = await client.queries.getMyProfile();
       if (read2.errors?.length || !read2.data) {
+        console.error("[GET /api/me] profile reread after create failed:", {
+          errors: read2.errors,
+          hasData: Boolean(read2.data),
+        });
         return jsonWithNoStore(
           { ok: false, error: { code: "INTERNAL_ERROR", message: "Failed to create or read profile" } },
           500

--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -139,8 +139,8 @@ export default function AssessmentPage() {
             <span
               className={
                 pillarColor
-                  ? "inline-flex items-center gap-2 rounded-full border px-2.5 py-0.5 text-[11px] font-semibold"
-                  : "inline-flex items-center gap-2 rounded-full border border-border bg-muted/40 px-2.5 py-0.5 text-[11px] font-semibold text-foreground"
+                  ? "inline-flex items-center gap-2 rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+                  : "inline-flex items-center gap-2 rounded-full border border-border bg-muted/40 px-2.5 py-0.5 text-xs font-semibold text-foreground"
               }
               style={
                 pillarColor && pillarTextColor

--- a/app/globals.css
+++ b/app/globals.css
@@ -59,7 +59,7 @@
   --card-foreground: oklch(0.16 0.02 265);
   --popover: oklch(0.99 0.001 0);
   --popover-foreground: oklch(0.16 0.02 265);
-  /* Primary: clearer, more saturated teal - intentional & premium */
+  /* Primary: clearer, more saturated teal - intentional and polished */
   --primary: oklch(0.55 0.22 260);
   --primary-foreground: oklch(0.985 0 0);
   /* Secondary: soft teal/emerald for highlights & positive feedback */
@@ -134,7 +134,28 @@
   }
   body {
     @apply bg-background text-foreground;
+    overflow-x: clip;
   }
+}
+
+@keyframes dot-pop {
+  0%   { transform: scale(1); }
+  45%  { transform: scale(1.55); }
+  100% { transform: scale(1); }
+}
+
+@keyframes button-confirm {
+  0%   { transform: scale(1); }
+  35%  { transform: scale(1.08); }
+  100% { transform: scale(1); }
+}
+
+.animate-dot-pop {
+  animation: dot-pop 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.animate-button-confirm {
+  animation: button-confirm 0.3s ease-out;
 }
 
 /* Amplify Authenticator: full custom skin inside FIApp card */

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -42,7 +42,7 @@ type ActiveData = {
 function PillarBadge({ pillar }: { pillar: Pillar }) {
   return (
     <span
-      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
+      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold text-white"
       style={{ backgroundColor: pillarColors[pillar] }}
     >
       {pillarLabels[pillar]}
@@ -52,7 +52,7 @@ function PillarBadge({ pillar }: { pillar: Pillar }) {
 
 function TrialBadge() {
   return (
-    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-amber-100 text-amber-800 border border-amber-300">
+    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-amber-100 text-amber-800 border border-amber-300">
       Trying
     </span>
   );
@@ -60,7 +60,7 @@ function TrialBadge() {
 
 function PausedBadge() {
   return (
-    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-muted text-muted-foreground border border-border">
+    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-muted text-muted-foreground border border-border">
       Paused
     </span>
   );
@@ -68,7 +68,7 @@ function PausedBadge() {
 
 function FocusBadge() {
   return (
-    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-primary/10 text-primary border border-primary/30">
+    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-primary/10 text-primary border border-primary/30">
       Today&apos;s focus
     </span>
   );
@@ -318,7 +318,10 @@ export default function PracticesPage() {
                                     disabled={!!actionLoading[p.id]}
                                   >
                                     <span className="font-medium">{c.title}</span>
-                                    <span className="text-muted-foreground"> · {pillarLabels[c.pillar]}</span>
+                                    <span className="inline-flex items-center gap-1 ml-1.5">
+                                      <span className="h-2 w-2 rounded-full shrink-0 inline-block" style={{ backgroundColor: pillarColors[c.pillar] }} />
+                                      <span className="text-muted-foreground text-xs">{pillarLabels[c.pillar]}</span>
+                                    </span>
                                   </button>
                                 ))}
                               </div>

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -188,31 +188,32 @@ export default function ResultsPage() {
                 <div className="space-y-4">
                   {suggestions.map((practice) => (
                     <Card key={practice.id} variant="interactive">
-                      <div className="flex items-start justify-between gap-4">
-                        <div className="space-y-2 min-w-0">
+                      <div className="space-y-4">
+                        <div className="space-y-2">
                           <span
-                            className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
+                            className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold text-white"
                             style={{ backgroundColor: pillarColors[practice.pillar] }}
                           >
                             {pillarLabels[practice.pillar]}
                           </span>
                           <p className="font-semibold text-foreground">{practice.title}</p>
                           <p className="text-sm text-muted-foreground">{practice.description}</p>
-                          <p className="text-xs text-muted-foreground italic">
-                            Why: {practice.rationale}
-                          </p>
+                          {practice.rationale && (
+                            <p className="text-xs text-muted-foreground border-l-2 border-border pl-3">
+                              {practice.rationale}
+                            </p>
+                          )}
                         </div>
-                        <div className="flex flex-col items-end gap-1 shrink-0">
+                        <div>
                           <Button
-                            size="sm"
                             variant="outline"
                             disabled={!!trialLoading[practice.id]}
                             onClick={() => handleTryThis(practice.id)}
                           >
-                            {trialLoading[practice.id] ? '…' : 'Try this'}
+                            {trialLoading[practice.id] ? '…' : 'Try this practice'}
                           </Button>
                           {trialError[practice.id] && (
-                            <p className="text-[11px] text-destructive text-right max-w-[140px]">
+                            <p className="text-xs text-destructive mt-1">
                               {trialError[practice.id]}
                             </p>
                           )}

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -53,6 +53,7 @@ export default function TodayPage() {
   const [logError, setLogError] = useState('')
   const [trialLogError, setTrialLogError] = useState<Record<string, string>>({})
   const [newMilestones, setNewMilestones] = useState<NewMilestone[]>([])
+  const [justLogged, setJustLogged] = useState(false)
 
   const loadReturns = useCallback(async (practiceId: string) => {
     const res = await fetch(`/api/returns?practiceId=${practiceId}&days=14`)
@@ -110,6 +111,10 @@ export default function TodayPage() {
         setNewMilestones(data.newMilestones)
       }
       await loadReturns(focusPractice.id)
+      if (newValue === true) {
+        setJustLogged(true)
+        setTimeout(() => setJustLogged(false), 700)
+      }
     } catch {
       setLogError('Could not save. Please try again.')
     } finally {
@@ -143,7 +148,7 @@ export default function TodayPage() {
 
   return (
     <NarrowFormPage title="Today" description="Your daily check-in.">
-      <div className="space-y-6">
+      <div className="space-y-8">
 
         {newMilestones.length > 0 && (
           <Card className="border-primary/40 bg-primary/5">
@@ -184,16 +189,17 @@ export default function TodayPage() {
         {!loading && !error && focusPractice && (
           <>
             <Card>
-              <div className="space-y-4">
+              <div className="space-y-5">
+                {/* Context */}
                 <div>
                   <div className="flex items-center gap-2 flex-wrap">
                     <span
-                      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
+                      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold text-white"
                       style={{ backgroundColor: pillarColors[focusPractice.pillar] }}
                     >
                       {pillarLabels[focusPractice.pillar]}
                     </span>
-                    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-primary/10 text-primary border border-primary/30">
+                    <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-primary/10 text-primary border border-primary/30">
                       Today&apos;s focus
                     </span>
                   </div>
@@ -201,18 +207,23 @@ export default function TodayPage() {
                   <p className="mt-1 text-sm text-muted-foreground">{focusPractice.description}</p>
                 </div>
 
-                <div className="grid grid-cols-2 gap-3 pt-2">
+                {/* Primary action */}
+                <div className="space-y-2 pt-1">
                   <Button
+                    size="lg"
                     variant={todayDidIt === true ? 'default' : 'outline'}
                     disabled={logging}
                     onClick={() => handleLog(true)}
+                    className={`w-full font-semibold ${todayDidIt !== true ? 'border-primary/40 text-primary hover:bg-primary/5' : ''} ${justLogged ? 'animate-button-confirm' : ''}`}
                   >
                     {logging && todayDidIt !== true ? '…' : '✓ Did it'}
                   </Button>
                   <Button
-                    variant={todayDidIt === false ? 'secondary' : 'outline'}
+                    size="sm"
+                    variant="ghost"
                     disabled={logging}
                     onClick={() => handleLog(false)}
+                    className="w-full text-muted-foreground hover:text-foreground"
                   >
                     {logging && todayDidIt !== false ? '…' : 'Not today'}
                   </Button>
@@ -220,7 +231,10 @@ export default function TodayPage() {
 
                 {todayDidIt === true && !logging && (
                   <p className="text-sm text-center text-muted-foreground">
-                    Nice work. Keep it up tomorrow.
+                    {(() => {
+                      const doneCount = dots.filter(d => d.didIt === true).length
+                      return `You've done this ${doneCount} ${doneCount === 1 ? 'time' : 'times'}.`
+                    })()}
                   </p>
                 )}
                 {todayDidIt === false && !logging && (
@@ -238,70 +252,81 @@ export default function TodayPage() {
             {dots.some((d) => d.didIt !== null) && <Card variant="subtle">
               <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Last 14 days</p>
               <div className="flex flex-wrap gap-2">
-                {dots.map((dot) => (
-                  <span
-                    key={dot.date}
-                    title={dot.date}
-                    className={`h-6 w-6 rounded-full border transition-colors ${
-                      dot.didIt === true
-                        ? 'bg-primary border-primary'
-                        : dot.didIt === false
-                        ? 'bg-muted border-border'
-                        : 'bg-transparent border-border/40'
-                    }`}
-                  />
-                ))}
+                {dots.map((dot) => {
+                  const d = new Date(dot.date + 'T00:00:00Z')
+                  const label = d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' })
+                  const tooltip = dot.didIt === true ? `${label} · Did it` : dot.didIt === false ? `${label} · Skipped` : label
+                  return (
+                    <span
+                      key={dot.date}
+                      title={tooltip}
+                      className={`h-6 w-6 rounded-full border transition-colors ${
+                        dot.didIt === true
+                          ? 'bg-primary border-primary'
+                          : dot.didIt === false
+                          ? 'bg-foreground/20 border-foreground/35'
+                          : 'bg-muted/70 border-border/50'
+                      } ${justLogged && dot.date === todayUTC() ? 'animate-dot-pop' : ''}`}
+                    />
+                  )
+                })}
               </div>
             </Card>}
           </>
         )}
 
         {!loading && !error && activeTrials.length > 0 && (
-          <div className="space-y-3">
-            {activeTrials.map((trial) => {
-              const didIt = trialDidIt[trial.id] ?? null
-              const busy = !!trialLogging[trial.id]
-              return (
-                <Card key={trial.id} variant="subtle">
-                  <div className="space-y-4">
-                    <div>
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span
-                          className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold text-white"
-                          style={{ backgroundColor: pillarColors[trial.pillar] }}
-                        >
-                          {pillarLabels[trial.pillar]}
-                        </span>
-                        <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold bg-amber-100 text-amber-800 border border-amber-300">
-                          Trying · {trial.daysRemaining}d left to decide
-                        </span>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-3">Trying out</p>
+            <div className="space-y-3">
+              {activeTrials.map((trial) => {
+                const didIt = trialDidIt[trial.id] ?? null
+                const busy = !!trialLogging[trial.id]
+                return (
+                  <Card key={trial.id} variant="subtle">
+                    <div className="space-y-4">
+                      <div>
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span
+                            className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold text-white"
+                            style={{ backgroundColor: pillarColors[trial.pillar] }}
+                          >
+                            {pillarLabels[trial.pillar]}
+                          </span>
+                          <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-amber-100 text-amber-800 border border-amber-300">
+                            {trial.daysRemaining}d left to decide
+                          </span>
+                        </div>
+                        <p className="mt-3 font-semibold text-foreground">{trial.title}</p>
+                        <p className="mt-1 text-sm text-muted-foreground">{trial.description}</p>
                       </div>
-                      <p className="mt-3 font-semibold text-foreground">{trial.title}</p>
-                      <p className="mt-1 text-sm text-muted-foreground">{trial.description}</p>
+                      <div className="space-y-1.5">
+                        <Button
+                          variant={didIt === true ? 'default' : 'outline'}
+                          disabled={busy}
+                          onClick={() => handleTrialLog(trial.id, true)}
+                          className={`w-full ${didIt !== true ? 'border-border/60' : ''}`}
+                        >
+                          {busy ? '…' : '✓ Did it'}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          disabled={busy}
+                          onClick={() => handleTrialLog(trial.id, false)}
+                          className="w-full text-muted-foreground hover:text-foreground"
+                        >
+                          {busy ? '…' : 'Not today'}
+                        </Button>
+                      </div>
+                      {trialLogError[trial.id] && (
+                        <p className="text-xs text-destructive">{trialLogError[trial.id]}</p>
+                      )}
                     </div>
-                    <div className="grid grid-cols-2 gap-3">
-                      <Button
-                        variant={didIt === true ? 'default' : 'outline'}
-                        disabled={busy}
-                        onClick={() => handleTrialLog(trial.id, true)}
-                      >
-                        {busy ? '…' : '✓ Did it'}
-                      </Button>
-                      <Button
-                        variant={didIt === false ? 'secondary' : 'outline'}
-                        disabled={busy}
-                        onClick={() => handleTrialLog(trial.id, false)}
-                      >
-                        {busy ? '…' : 'Not today'}
-                      </Button>
-                    </div>
-                    {trialLogError[trial.id] && (
-                      <p className="text-xs text-destructive">{trialLogError[trial.id]}</p>
-                    )}
-                  </div>
-                </Card>
-              )
-            })}
+                  </Card>
+                )
+              })}
+            </div>
           </div>
         )}
 

--- a/components/AuthenticatorWrapper.tsx
+++ b/components/AuthenticatorWrapper.tsx
@@ -1,9 +1,27 @@
 "use client";
 
 import { useEffect } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react";
 import { ensureAmplifyConfigured } from "@/lib/amplifyClient";
+
+const passwordSettings = {
+  minLength: 8,
+  requireLowercase: true,
+  requireUppercase: true,
+  requireNumbers: true,
+  requireSpecialCharacters: true,
+};
+
+function PasswordRequirements() {
+  return (
+    <p className="mt-2 text-xs leading-5 text-muted-foreground">
+      Passwords need 8+ characters with uppercase, lowercase, a number, and a
+      symbol.
+    </p>
+  );
+}
 
 function SignInFooter() {
   const { toForgotPassword } = useAuthenticator();
@@ -20,6 +38,15 @@ function SignInFooter() {
         We&apos;ll never share your data.
       </p>
     </div>
+  );
+}
+
+function SignUpFormFields() {
+  return (
+    <>
+      <Authenticator.SignUp.FormFields />
+      <PasswordRequirements />
+    </>
   );
 }
 
@@ -57,6 +84,7 @@ export default function AuthenticatorWrapper() {
         <div className="fiapp-auth-shell">
           <Authenticator
             className="fiapp-auth"
+            passwordSettings={passwordSettings}
             formFields={{
               signIn: {
                 username: {
@@ -85,6 +113,9 @@ export default function AuthenticatorWrapper() {
               SignIn: {
                 Footer: SignInFooter,
               },
+              SignUp: {
+                FormFields: SignUpFormFields,
+              },
             }}
           >
             {({ user }) => (user ? <AuthRedirect /> : <></>)}
@@ -92,9 +123,9 @@ export default function AuthenticatorWrapper() {
         </div>
 
         <div className="mt-6 text-center text-xs text-muted-foreground">
-          <a href="/" className="text-muted-foreground hover:text-foreground">
+          <Link href="/" className="text-muted-foreground hover:text-foreground">
             ← Back to home
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/components/DevSubscriptionToggle.tsx
+++ b/components/DevSubscriptionToggle.tsx
@@ -4,9 +4,10 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { useProfile } from "@/contexts/ProfileContext";
 import { Button } from "@/components/ui";
+import { getPlanLabel, getPlanShortLabel, type SubscriptionStatus } from "@/lib/plans";
 
 /**
- * Dev-only control to toggle subscriptionStatus for testing paid flows.
+ * Dev-only control to toggle subscriptionStatus for testing Plus plan flows.
  * Renders only when NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true (e.g. in .env.local).
  */
 export function DevSubscriptionToggle() {
@@ -15,7 +16,7 @@ export function DevSubscriptionToggle() {
 
   if (process.env.NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION !== "true") return null;
 
-  async function setStatus(status: "FREE" | "PAID") {
+  async function setStatus(status: SubscriptionStatus) {
     setLoading(true);
     try {
       const res = await fetch("/api/dev/subscription", {
@@ -34,7 +35,7 @@ export function DevSubscriptionToggle() {
       }
 
       await refetch();
-      toast.success(`Set to ${status === "PAID" ? "Premium" : "Free"}`);
+      toast.success(`Set to ${getPlanLabel(status)}`);
     } catch (err) {
       toast.error("Failed to update", {
         description: err instanceof Error ? err.message : "Network error",
@@ -45,7 +46,7 @@ export function DevSubscriptionToggle() {
   }
 
   return (
-    <div className="flex items-center gap-1" title="Dev: toggle subscription">
+    <div className="flex items-center gap-1" title="Dev: set plan">
       <Button
         variant="ghost"
         size="sm"
@@ -53,7 +54,7 @@ export function DevSubscriptionToggle() {
         disabled={loading}
         className="text-xs text-muted-foreground hover:text-foreground h-7 px-2"
       >
-        Free
+        {getPlanShortLabel("FREE")}
       </Button>
       <span className="text-muted-foreground/60 text-xs">|</span>
       <Button
@@ -63,7 +64,7 @@ export function DevSubscriptionToggle() {
         disabled={loading}
         className="text-xs text-muted-foreground hover:text-foreground h-7 px-2"
       >
-        Paid
+        {getPlanShortLabel("PAID")}
       </Button>
     </div>
   );

--- a/components/PlanBadge.tsx
+++ b/components/PlanBadge.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useProfile } from "@/contexts/ProfileContext";
+import { getPlanLabel, isPlusPlan } from "@/lib/plans";
 
 export function PlanBadge() {
   const { profile, loading } = useProfile();
@@ -8,8 +9,8 @@ export function PlanBadge() {
   if (loading || !profile?.subscriptionStatus) return null;
 
   const plan = profile.subscriptionStatus;
-  const label = plan === "PAID" ? "Premium" : "Free";
-  const variant = plan === "PAID" ? "primary" : "muted";
+  const label = getPlanLabel(plan);
+  const variant = isPlusPlan(plan) ? "primary" : "muted";
 
   return (
     <span

--- a/components/UpgradeButton.tsx
+++ b/components/UpgradeButton.tsx
@@ -14,8 +14,8 @@ export function UpgradeButton() {
   if (loading || profile?.subscriptionStatus !== "FREE") return null;
 
   function handleClick() {
-    toast.info("Upgrade coming soon", {
-      description: "Premium features are in development.",
+    toast.info("Plus plan is coming soon", {
+      description: "Plus lets you keep up to 10 active practices.",
     });
   }
 
@@ -26,7 +26,7 @@ export function UpgradeButton() {
       onClick={handleClick}
       className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary/50"
     >
-      Upgrade
+      Upgrade to Plus
     </Button>
   );
 }

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -4,11 +4,12 @@ import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useAuthenticator } from '@aws-amplify/ui-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui'
 import { PlanBadge } from '@/components/PlanBadge'
-import { UpgradeButton } from '@/components/UpgradeButton'
 import { DevSubscriptionToggle } from '@/components/DevSubscriptionToggle'
 import { useProfile } from '@/contexts/ProfileContext'
+import { getPlanLabel, isPlusPlan } from '@/lib/plans'
 
 interface AppShellProps {
   children: React.ReactNode
@@ -35,7 +36,7 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
   const { profile } = useProfile()
 
   const email = user?.signInDetails?.loginId ?? user?.username ?? ''
-  const plan = profile?.subscriptionStatus === 'PAID' ? 'Premium' : 'Free'
+  const planLabel = getPlanLabel(profile?.subscriptionStatus)
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -81,7 +82,6 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
           <div className="flex items-center gap-2">
             <PlanBadge />
             <DevSubscriptionToggle />
-            <UpgradeButton />
             <div ref={accountRef} className="relative hidden sm:block">
               <Button
                 variant="ghost"
@@ -94,7 +94,15 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
                 <div className="absolute right-0 top-full mt-1 w-56 rounded-xl border border-border bg-card shadow-md z-50 overflow-hidden">
                   <div className="px-4 py-3 border-b border-border/60">
                     <p className="text-xs text-muted-foreground truncate">{email}</p>
-                    <p className="text-xs font-medium text-foreground mt-0.5">{plan} plan</p>
+                    <p className="text-xs font-medium text-foreground mt-0.5">{planLabel}</p>
+                    {!isPlusPlan(profile?.subscriptionStatus) && (
+                      <button
+                        onClick={() => { setAccountOpen(false); toast.info('Plus plan is coming soon', { description: 'Plus lets you keep up to 10 active practices.' }) }}
+                        className="mt-2 w-full rounded-md bg-primary/10 border border-primary/25 px-2 py-1 text-xs font-semibold text-primary hover:bg-primary/20 transition-colors text-center"
+                      >
+                        Upgrade to Plus
+                      </button>
+                    )}
                   </div>
                   <Link
                     href="/account"

--- a/components/ui/PillarRadarChart.tsx
+++ b/components/ui/PillarRadarChart.tsx
@@ -1,61 +1,171 @@
 'use client'
 
-import {
-  RadarChart,
-  Radar,
-  PolarGrid,
-  PolarAngleAxis,
-  ResponsiveContainer,
-  Tooltip,
-} from 'recharts'
+import { useMemo, useState } from 'react'
+import { pillarOrder, pillarLabels } from '@/lib/assessment/pillars'
+import { pillarColors } from '@/lib/design/pillarColors'
 import type { Pillar } from '@/lib/assessment/pillars'
-import { pillarOrder } from '@/lib/assessment/pillars'
-import { pillarLabels } from '@/lib/assessment/pillars'
 
 const MAX_SCORE = 5
+const N = pillarOrder.length // 7
+const W = 500
+const H = 420
+const CX = W / 2       // 250
+const CY = H / 2 - 8  // 202 — a touch high to balance label space below
+const R = 138          // outermost ring radius
+const LABEL_R = R + 32 // label anchor distance from center
+
+function angle(i: number) {
+  // start at top (-90°), go clockwise
+  return (2 * Math.PI * i / N) - Math.PI / 2
+}
+
+function pt(r: number, i: number): [number, number] {
+  const a = angle(i)
+  return [CX + r * Math.cos(a), CY + r * Math.sin(a)]
+}
+
+function scorePoints(scores: Record<Pillar, number>): string {
+  return pillarOrder
+    .map((p, i) => pt(((scores[p] ?? 0) / MAX_SCORE) * R, i).join(','))
+    .join(' ')
+}
+
+function textAnchor(i: number): 'start' | 'middle' | 'end' {
+  const c = Math.cos(angle(i))
+  return c > 0.15 ? 'start' : c < -0.15 ? 'end' : 'middle'
+}
 
 type Props = {
   scores: Record<Pillar, number>
   focusPillar: Pillar
 }
 
-export function PillarRadarChart({ scores }: Props) {
-  const data = pillarOrder.map((pillar) => ({
-    pillar: pillarLabels[pillar],
-    score: scores[pillar] ?? 0,
-    fullMark: MAX_SCORE,
-  }))
+export function PillarRadarChart({ scores, focusPillar }: Props) {
+  const [hovered, setHovered] = useState<Pillar | null>(null)
 
-  const focusColor = `hsl(var(--primary))`
+  const polygon = useMemo(() => scorePoints(scores), [scores])
 
   return (
-    <ResponsiveContainer width="100%" height={300}>
-      <RadarChart data={data} margin={{ top: 10, right: 30, bottom: 10, left: 30 }}>
-        <PolarGrid stroke="hsl(var(--border))" />
-        <PolarAngleAxis
-          dataKey="pillar"
-          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 12 }}
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      className="w-full select-none"
+      style={{ maxHeight: 360, fontFamily: 'inherit' }}
+    >
+      {/* Concentric circular grid rings */}
+      {[1, 2, 3, 4, 5].map((lvl) => (
+        <circle
+          key={lvl}
+          cx={CX} cy={CY}
+          r={(lvl / MAX_SCORE) * R}
+          fill="none"
+          style={{ stroke: 'var(--border)' }}
+          strokeOpacity={lvl === 5 ? 0.5 : 0.22}
+          strokeWidth={lvl === 5 ? 1.5 : 1}
         />
-        <Radar
-          name="Score"
-          dataKey="score"
-          stroke={focusColor}
-          fill={focusColor}
-          fillOpacity={0.25}
-          strokeWidth={2}
-          dot={{ r: 3, fill: focusColor, strokeWidth: 0 }}
-        />
-        <Tooltip
-          formatter={(value) => [`${value} / ${MAX_SCORE}`, 'Score']}
-          contentStyle={{
-            backgroundColor: 'hsl(var(--card))',
-            border: '1px solid hsl(var(--border))',
-            borderRadius: '8px',
-            fontSize: '12px',
-            color: 'hsl(var(--foreground))',
-          }}
-        />
-      </RadarChart>
-    </ResponsiveContainer>
+      ))}
+
+      {/* Outermost ring — subtle background tint */}
+      <circle
+        cx={CX} cy={CY} r={R}
+        style={{ fill: 'var(--muted)' }}
+        fillOpacity={0.12}
+        stroke="none"
+      />
+
+      {/* Axis spokes */}
+      {pillarOrder.map((_, i) => {
+        const [x, y] = pt(R, i)
+        return (
+          <line
+            key={i}
+            x1={CX} y1={CY} x2={x} y2={y}
+            style={{ stroke: 'var(--border)' }}
+            strokeOpacity={0.25}
+            strokeWidth={1}
+          />
+        )
+      })}
+
+      {/* Score polygon — fill */}
+      <polygon
+        points={polygon}
+        style={{ fill: 'var(--primary)' }}
+        fillOpacity={0.1}
+        stroke="none"
+      />
+
+      {/* Score polygon — stroke (separate so fill opacity doesn't affect it) */}
+      <polygon
+        points={polygon}
+        fill="none"
+        style={{ stroke: 'var(--primary)' }}
+        strokeOpacity={0.85}
+        strokeWidth={2}
+        strokeLinejoin="round"
+      />
+
+      {/* Vertex dots */}
+      {pillarOrder.map((pillar, i) => {
+        const score = scores[pillar] ?? 0
+        const r = (score / MAX_SCORE) * R
+        const [x, y] = pt(r, i)
+        const isFocus = pillar === focusPillar
+        const isHov = pillar === hovered
+        const color = pillarColors[pillar]
+
+        return (
+          <g
+            key={pillar}
+            onMouseEnter={() => setHovered(pillar)}
+            onMouseLeave={() => setHovered(null)}
+            style={{ cursor: 'default' }}
+          >
+            {/* Halo for focus pillar or hover */}
+            {(isFocus || isHov) && (
+              <circle
+                cx={x} cy={y}
+                r={isHov ? 13 : 11}
+                fill={color}
+                fillOpacity={isHov ? 0.2 : 0.14}
+                stroke="none"
+              />
+            )}
+            {/* Dot */}
+            <circle
+              cx={x} cy={y}
+              r={isFocus ? 6 : 5}
+              fill={color}
+              stroke="white"
+              strokeWidth={1.5}
+            />
+          </g>
+        )
+      })}
+
+      {/* Labels */}
+      {pillarOrder.map((pillar, i) => {
+        const [lx, ly] = pt(LABEL_R, i)
+        const anchor = textAnchor(i)
+        const isFocus = pillar === focusPillar
+
+        return (
+          <text
+            key={pillar}
+            x={lx}
+            y={ly}
+            textAnchor={anchor}
+            dominantBaseline="middle"
+            fontSize={14}
+            fontWeight={isFocus ? 600 : 400}
+            style={{
+              fill: isFocus ? pillarColors[pillar] : 'var(--foreground)',
+              fillOpacity: isFocus ? 0.9 : 0.6,
+            }}
+          >
+            {pillarLabels[pillar]}
+          </text>
+        )
+      })}
+    </svg>
   )
 }

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -1,0 +1,13 @@
+export type SubscriptionStatus = "FREE" | "PAID";
+
+export function isPlusPlan(status?: string | null): boolean {
+  return status?.toUpperCase() === "PAID";
+}
+
+export function getPlanLabel(status?: string | null): string {
+  return isPlusPlan(status) ? "Plus plan" : "Free plan";
+}
+
+export function getPlanShortLabel(status?: string | null): string {
+  return isPlusPlan(status) ? "Plus" : "Free";
+}

--- a/lib/practices/trial.ts
+++ b/lib/practices/trial.ts
@@ -50,9 +50,9 @@ export function checkActiveCap(
   subscriptionStatus: string | undefined,
   activeCount: number
 ): CapCheckResult {
-  const isPaid = subscriptionStatus?.toUpperCase() === 'PAID'
+  const hasPlusPlan = subscriptionStatus?.toUpperCase() === 'PAID'
 
-  if (!isPaid) {
+  if (!hasPlusPlan) {
     if (activeCount >= FREE_CAP) return { allowed: false, reason: 'CAP_REACHED', cap: FREE_CAP }
     return { allowed: true }
   }

--- a/tests/dynamo-client.test.ts
+++ b/tests/dynamo-client.test.ts
@@ -1,13 +1,17 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mockClient } from "aws-sdk-client-mock";
 import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
-import { createDynamoClient } from "@/utils/dynamoClient";
+import { createDynamoClient, createReturnsClient } from "@/utils/dynamoClient";
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 
 describe("DynamoClient wrapper", () => {
   beforeEach(() => {
     ddbMock.reset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("uses the wrapper to put and get items", async () => {
@@ -24,5 +28,26 @@ describe("DynamoClient wrapper", () => {
     expect(item).toEqual({ PK: "USER#1", SK: "PROFILE" });
     expect(ddbMock.commandCalls(PutCommand).length).toBe(1);
     expect(ddbMock.commandCalls(GetCommand).length).toBe(1);
+  });
+
+  it("defaults to the Amplify main table name when env is absent", async () => {
+    vi.stubEnv("FIAPP_MAIN_TABLE", "");
+    ddbMock.on(GetCommand).resolves({ Item: { PK: "USER#1", SK: "PROFILE" } });
+
+    const client = createDynamoClient();
+    await client.getItem({ PK: "USER#1", SK: "PROFILE" });
+
+    expect(ddbMock.commandCalls(GetCommand)[0].firstArg.input.TableName).toBe("FIAPP_MAIN");
+  });
+
+  it("defaults returns reads to the Amplify returns table name when env is absent", async () => {
+    vi.stubEnv("FIAPP_MAIN_TABLE", "");
+    vi.stubEnv("FIAPP_RETURNS_TABLE", "");
+    ddbMock.on(GetCommand).resolves({ Item: { PK: "USER#1", SK: "DATE#2026-05-04" } });
+
+    const client = createReturnsClient();
+    await client.getItem({ PK: "USER#1", SK: "DATE#2026-05-04" });
+
+    expect(ddbMock.commandCalls(GetCommand)[0].firstArg.input.TableName).toBe("FIAPP_RETURNS");
   });
 });

--- a/tests/unit/api/me.test.ts
+++ b/tests/unit/api/me.test.ts
@@ -83,6 +83,34 @@ describe("GET /api/me", () => {
     expect(json.data.activeTrialCount).toBe(1);
   });
 
+  it("returns profile with activeTrialCount=0 when trial count lookup fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const existingProfile = {
+      userId: "usr-1",
+      subscriptionStatus: "FREE",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+      activePracticeIds: [],
+      latestAssessmentId: "a1",
+    };
+    getMyProfileMock.mockResolvedValue({ data: existingProfile, errors: undefined });
+    dynamoQueryMock.mockRejectedValue(new Error("Access denied"));
+
+    const req = new Request("http://localhost/api/me");
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.data.activeTrialCount).toBe(0);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[GET /api/me] failed to read active trials:",
+      expect.any(Error)
+    );
+
+    consoleError.mockRestore();
+  });
+
   it("does not count expired trials", async () => {
     const existingProfile = {
       userId: "usr-1",
@@ -135,6 +163,27 @@ describe("GET /api/me", () => {
     expect(json.data.activeTrialCount).toBe(0);
     expect(getMyProfileMock).toHaveBeenCalledTimes(1);
     expect(createMyProfileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and returns 500 when profile read returns AppSync errors", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    getMyProfileMock.mockResolvedValue({
+      data: null,
+      errors: [{ message: "Resolver failed" }],
+    });
+
+    const req = new Request("http://localhost/api/me");
+    const res = await GET(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error?.message).toBe("Failed to read profile");
+    expect(consoleError).toHaveBeenCalledWith(
+      "[GET /api/me] getMyProfile errors:",
+      [{ message: "Resolver failed" }]
+    );
+
+    consoleError.mockRestore();
   });
 
   it("returns same profile on second call (idempotent, no overwrite)", async () => {

--- a/tests/unit/components/DevSubscriptionToggle.test.tsx
+++ b/tests/unit/components/DevSubscriptionToggle.test.tsx
@@ -48,14 +48,14 @@ describe("DevSubscriptionToggle", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders Free and Paid buttons when flag is true", () => {
+  it("renders Free and Plus buttons when flag is true", () => {
     render(<DevSubscriptionToggle />);
 
     expect(screen.getByRole("button", { name: "Free" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Paid" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Plus" })).toBeInTheDocument();
   });
 
-  it("calls fetch and refetch when Paid is clicked", async () => {
+  it("calls fetch and refetch when Plus is clicked", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({}),
@@ -63,7 +63,7 @@ describe("DevSubscriptionToggle", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<DevSubscriptionToggle />);
-    fireEvent.click(screen.getByRole("button", { name: "Paid" }));
+    fireEvent.click(screen.getByRole("button", { name: "Plus" }));
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/dev/subscription", {
@@ -78,7 +78,7 @@ describe("DevSubscriptionToggle", () => {
       expect(refetchMock).toHaveBeenCalled();
     });
 
-    expect(toastSuccessMock).toHaveBeenCalledWith("Set to Premium");
+    expect(toastSuccessMock).toHaveBeenCalledWith("Set to Plus plan");
   });
 
   it("calls fetch and refetch when Free is clicked", async () => {
@@ -104,7 +104,7 @@ describe("DevSubscriptionToggle", () => {
       expect(refetchMock).toHaveBeenCalled();
     });
 
-    expect(toastSuccessMock).toHaveBeenCalledWith("Set to Free");
+    expect(toastSuccessMock).toHaveBeenCalledWith("Set to Free plan");
   });
 
   it("shows error toast when fetch fails", async () => {
@@ -116,7 +116,7 @@ describe("DevSubscriptionToggle", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(<DevSubscriptionToggle />);
-    fireEvent.click(screen.getByRole("button", { name: "Paid" }));
+    fireEvent.click(screen.getByRole("button", { name: "Plus" }));
 
     await waitFor(() => {
       expect(toastErrorMock).toHaveBeenCalledWith("Failed to update", {

--- a/tests/unit/components/PlanBadge.test.tsx
+++ b/tests/unit/components/PlanBadge.test.tsx
@@ -49,7 +49,7 @@ describe("PlanBadge", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders Free when subscriptionStatus is FREE", () => {
+  it("renders Free plan when subscriptionStatus is FREE", () => {
     useProfileMock.mockReturnValue({
       profile: { subscriptionStatus: "FREE" },
       loading: false,
@@ -58,11 +58,11 @@ describe("PlanBadge", () => {
     });
 
     render(<PlanBadge />);
-    expect(screen.getByText("Free")).toBeInTheDocument();
-    expect(screen.getByLabelText("Plan: Free")).toBeInTheDocument();
+    expect(screen.getByText("Free plan")).toBeInTheDocument();
+    expect(screen.getByLabelText("Plan: Free plan")).toBeInTheDocument();
   });
 
-  it("renders Premium when subscriptionStatus is PAID", () => {
+  it("renders Plus plan when subscriptionStatus is PAID", () => {
     useProfileMock.mockReturnValue({
       profile: { subscriptionStatus: "PAID" },
       loading: false,
@@ -71,7 +71,7 @@ describe("PlanBadge", () => {
     });
 
     render(<PlanBadge />);
-    expect(screen.getByText("Premium")).toBeInTheDocument();
-    expect(screen.getByLabelText("Plan: Premium")).toBeInTheDocument();
+    expect(screen.getByText("Plus plan")).toBeInTheDocument();
+    expect(screen.getByLabelText("Plan: Plus plan")).toBeInTheDocument();
   });
 });

--- a/tests/unit/components/UpgradeButton.test.tsx
+++ b/tests/unit/components/UpgradeButton.test.tsx
@@ -45,7 +45,7 @@ describe("UpgradeButton", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders Upgrade button when subscriptionStatus is FREE", () => {
+  it("renders Upgrade to Plus button when subscriptionStatus is FREE", () => {
     useProfileMock.mockReturnValue({
       profile: { subscriptionStatus: "FREE" },
       loading: false,
@@ -54,7 +54,7 @@ describe("UpgradeButton", () => {
     });
 
     render(<UpgradeButton />);
-    expect(screen.getByRole("button", { name: "Upgrade" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upgrade to Plus" })).toBeInTheDocument();
   });
 
   it("calls toast.info on click when FREE", () => {
@@ -66,10 +66,10 @@ describe("UpgradeButton", () => {
     });
 
     render(<UpgradeButton />);
-    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Plus" }));
 
-    expect(toastMock).toHaveBeenCalledWith("Upgrade coming soon", {
-      description: "Premium features are in development.",
+    expect(toastMock).toHaveBeenCalledWith("Plus plan is coming soon", {
+      description: "Plus lets you keep up to 10 active practices.",
     });
   });
 });

--- a/tests/unit/plans.test.ts
+++ b/tests/unit/plans.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getPlanLabel, getPlanShortLabel, isPlusPlan } from "@/lib/plans";
+
+describe("plan display helpers", () => {
+  it("maps internal FREE status to Free plan labels", () => {
+    expect(getPlanLabel("FREE")).toBe("Free plan");
+    expect(getPlanShortLabel("FREE")).toBe("Free");
+    expect(isPlusPlan("FREE")).toBe(false);
+  });
+
+  it("maps internal PAID status to Plus plan labels", () => {
+    expect(getPlanLabel("PAID")).toBe("Plus plan");
+    expect(getPlanShortLabel("PAID")).toBe("Plus");
+    expect(isPlusPlan("PAID")).toBe(true);
+  });
+});

--- a/utils/dynamoClient.ts
+++ b/utils/dynamoClient.ts
@@ -11,6 +11,16 @@ import {
   type QueryCommandInput,
 } from "@aws-sdk/lib-dynamodb";
 
+const DEFAULT_MAIN_TABLE = "FIAPP_MAIN";
+const DEFAULT_RETURNS_TABLE = "FIAPP_RETURNS";
+
+function firstConfiguredValue(
+  fallback: string,
+  ...values: Array<string | undefined>
+) {
+  return values.find((value) => value?.trim()) ?? fallback;
+}
+
 export interface DynamoClientOptions {
   tableName?: string;
   region?: string;
@@ -22,10 +32,11 @@ export class DynamoClient {
   private client: DynamoDBDocumentClient;
 
   constructor(options: DynamoClientOptions = {}) {
-    const tableName = options.tableName ?? process.env.FIAPP_MAIN_TABLE;
-    if (!tableName) {
-      throw new Error("FIAPP_MAIN_TABLE is not set");
-    }
+    const tableName = firstConfiguredValue(
+      DEFAULT_MAIN_TABLE,
+      options.tableName,
+      process.env.FIAPP_MAIN_TABLE
+    );
 
     this.tableName = tableName;
     this.client =
@@ -94,6 +105,10 @@ export function createDynamoClient(options: DynamoClientOptions = {}) {
 }
 
 export function createReturnsClient(options: Omit<DynamoClientOptions, 'tableName'> = {}) {
-  const tableName = process.env.FIAPP_RETURNS_TABLE ?? process.env.FIAPP_MAIN_TABLE;
+  const tableName = firstConfiguredValue(
+    DEFAULT_RETURNS_TABLE,
+    process.env.FIAPP_RETURNS_TABLE,
+    process.env.FIAPP_MAIN_TABLE
+  );
   return new DynamoClient({ ...options, tableName });
 }


### PR DESCRIPTION
## Summary

- **Plan label centralisation** — new `lib/plans.ts` with `getPlanLabel()` / `isPlusPlan()`. All "Premium/Paid" strings replaced with "Plus plan / Free plan" consistently across components and tests.
- **DynamoDB client fix** — `FIAPP_MAIN_TABLE` env var no longer throws on startup; falls back to `"FIAPP_MAIN"` so local dev and test environments don't need it set.
- **Custom SVG radar chart** — replaced Recharts `RadarChart` with a hand-rolled SVG: concentric grid rings, pillar-coloured vertex dots, focus-pillar halo, hover halo, labels using design-system CSS variables.
- **Today page improvements** — full-width primary-tinted "Did it" button, ghost "Not today", 14-day dot visibility fix (skipped = `bg-foreground/20`, unlogged = `bg-muted/70`), formatted hover tooltips, post check-in `dot-pop` + `button-confirm` animations, "You've done this N times" confirmation text.
- **Results / Insights page** — suggested practice cards: rationale as left-border blockquote, button below text, removed custom className override.
- **AppShell** — UpgradeButton removed from header bar; inline upgrade CTA in account dropdown for non-Plus users only.
- **Global cleanup** — `overflow-x: clip` on body fixes trackpad scroll shake; `text-[11px]` replaced with `text-xs` across all pages; all pillar labels use `pillarColors` consistently.

## Test plan

- [ ] Log "Did it" on Today page — button pulses, today's dot pops, confirmation shows correct count
- [ ] Log "Not today" — no animation, compassionate copy shown
- [ ] Insights page — radar chart renders with correct pillar colours, focus halo visible, hover works
- [ ] Account dropdown — Free users see upgrade CTA; Plus users do not
- [ ] Plan labels — PlanBadge, UpgradeButton, DevSubscriptionToggle all show "Plus plan" / "Free plan"
- [ ] No horizontal scroll shake on trackpad left/right swipe
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)