### PR TITLE
fix: read DynamoDB credentials from FIAPP_AWS_* env vars

### DIFF
--- a/utils/dynamoClient.ts
+++ b/utils/dynamoClient.ts
@@ -39,11 +39,21 @@ export class DynamoClient {
     );
 
     this.tableName = tableName;
+    const accessKeyId = process.env.FIAPP_AWS_ACCESS_KEY_ID
+    const secretAccessKey = process.env.FIAPP_AWS_SECRET_ACCESS_KEY
+    const region = options.region
+      ?? process.env.FIAPP_AWS_REGION
+      ?? process.env.AWS_REGION
+      ?? "ap-southeast-2"
+
     this.client =
       options.client ??
       DynamoDBDocumentClient.from(
         new DynamoDBClient({
-          region: options.region ?? process.env.AWS_REGION ?? "ap-southeast-2",
+          region,
+          ...(accessKeyId && secretAccessKey
+            ? { credentials: { accessKeyId, secretAccessKey } }
+            : {}),
         })
       );
   }


### PR DESCRIPTION
## Summary

- Amplify reserves the `AWS_` prefix for environment variables, preventing us from setting `AWS_ACCESS_KEY_ID` etc. directly
- Updated `utils/dynamoClient.ts` to read from `FIAPP_AWS_ACCESS_KEY_ID`, `FIAPP_AWS_SECRET_ACCESS_KEY`, `FIAPP_AWS_REGION`
- Falls back to the default AWS credential chain (IAM role) when the custom vars are not set — no regression for local dev or future IAM role setups

## Required: set these in Amplify Console → Environment variables
| Variable | Value |
|---|---|
| `FIAPP_AWS_ACCESS_KEY_ID` | IAM access key for `fiapp-server` user |
| `FIAPP_AWS_SECRET_ACCESS_KEY` | IAM secret key |
| `FIAPP_AWS_REGION` | `ap-southeast-2` |

## Test plan
- [ ] Merge and let Amplify redeploy main
- [ ] Hit `/today` and `/results` on production — no more 500 INTERNAL_ERROR
- [ ] Local dev still works (no FIAPP_AWS_* vars needed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)