### PR TITLE
fix: DynamoDB credentials + CI improvements + build speed

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,7 +4,14 @@ backend:
     build:
       commands:
         - npm ci --cache .npm --prefer-offline
-        - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
+        - |
+          CHANGED=$(git diff --name-only HEAD^1 HEAD 2>/dev/null || git show --name-only --format="" HEAD)
+          if echo "$CHANGED" | grep -q '^amplify/'; then
+            echo "amplify/ changed — deploying backend"
+            npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
+          else
+            echo "No amplify/ changes — skipping backend deploy"
+          fi
 frontend:
   phases:
     preBuild:


### PR DESCRIPTION
## Summary

- **Debug log**: `[DynamoClient] init` logs to CloudWatch whether `FIAPP_AWS_ACCESS_KEY_ID` is being read — confirms env vars reach the Lambda. Remove after confirming.
- **Build speed**: Skip `npx ampx pipeline-deploy` when no files under `amplify/` changed — saves 2-3 min on every frontend-only deploy.
- **CI**: npm cache, `tsc --noEmit` typecheck, E2E smoke job (8 unauthenticated tests), Playwright artifact on failure.
- **Launch checklist**: `_docs/canon/launch-checklist.md` — 12 sections, 80+ manual checks before public launch.

## After merging
1. Hit `/today` on production
2. CloudWatch → log group `d3nyg9qvz1tj5n` → find `[DynamoClient] init`
3. Confirm `hasAccessKeyId: true` — then remove the debug log in a follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)