### PR TITLE
feat: SEO metadata and og tags for landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,29 @@
 import Link from "next/link";
+import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import LandingAuthRedirect from "@/components/LandingAuthRedirect";
+
+export const metadata: Metadata = {
+  title: "Friends Intelligence — A life operating system for better decisions and energy",
+  description:
+    "Find your focus pillar in 8 minutes. A science-based wellbeing assessment across 7 areas of life — Finance, Relationship, Information, Emotion, Nutrition, Dynamics, Sleep. Free to start.",
+  openGraph: {
+    title: "Friends Intelligence",
+    description:
+      "Find your focus pillar in 8 minutes. Free wellbeing assessment across the 7 Friends pillars.",
+    url: "https://friendsintelligence.net",
+    siteName: "Friends Intelligence",
+    locale: "en_AU",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Friends Intelligence",
+    description:
+      "Find your focus pillar in 8 minutes. Free wellbeing assessment across the 7 Friends pillars.",
+  },
+  metadataBase: new URL("https://friendsintelligence.net"),
+};
 
 function Arrow({ className = "" }: { className?: string }) {
   return (


### PR DESCRIPTION
## Summary

- Adds `title`, `description`, `openGraph`, and `twitter` metadata to the landing page
- `metadataBase` set to `friendsintelligence.net` so og URLs resolve correctly
- Description lists all 7 pillars by name (good for search indexing)
- Overrides the generic root layout metadata for the `/` route only

## Test plan

- [ ] Share `friendsintelligence.net` on WhatsApp / LinkedIn — preview card shows correct title and description
- [ ] Check page `<title>` in browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)