### PR TITLE
feat: Stripe one-time payment for Plus plan (EPIC 16)

### DIFF
--- a/app/api/payment/checkout/route.ts
+++ b/app/api/payment/checkout/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/utils/authServer";
+import { getStripeClient } from "@/utils/stripeClient";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  return withAuth(req, async (user) => {
+    const priceId = process.env.FIAPP_STRIPE_PRICE_ID;
+    if (!priceId) {
+      return NextResponse.json({ error: "Payment not configured" }, { status: 500 });
+    }
+
+    const origin = req.headers.get("origin") ?? "http://localhost:3000";
+    const stripe = getStripeClient();
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      line_items: [{ price: priceId, quantity: 1 }],
+      metadata: { userId: user.userId },
+      success_url: `${origin}/payment/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${origin}/practices`,
+    });
+
+    return NextResponse.json({ url: session.url });
+  });
+}

--- a/app/api/payment/webhook/route.ts
+++ b/app/api/payment/webhook/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { getStripeClient } from "@/utils/stripeClient";
+import { createDynamoClient } from "@/utils/dynamoClient";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  const sig = req.headers.get("stripe-signature");
+  const webhookSecret = process.env.FIAPP_STRIPE_WEBHOOK_SECRET;
+
+  if (!sig || !webhookSecret) {
+    return NextResponse.json({ error: "Missing signature or webhook secret" }, { status: 400 });
+  }
+
+  let event;
+  try {
+    const stripe = getStripeClient();
+    event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+  } catch (err) {
+    console.error("[webhook] signature verification failed:", err);
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+  }
+
+  if (event.type === "checkout.session.completed") {
+    const session = event.data.object;
+    const userId = session.metadata?.userId;
+
+    if (!userId) {
+      console.error("[webhook] checkout.session.completed missing userId in metadata");
+      return NextResponse.json({ error: "Missing userId" }, { status: 400 });
+    }
+
+    try {
+      const client = createDynamoClient();
+      await client.updateItem({
+        Key: { PK: `USER#${userId}`, SK: "PROFILE" },
+        UpdateExpression: "SET subscriptionStatus = :status",
+        ExpressionAttributeValues: { ":status": "PAID" },
+      });
+      console.log(`[webhook] upgraded user ${userId} to PAID`);
+    } catch (err) {
+      console.error("[webhook] failed to update DynamoDB:", err);
+      return NextResponse.json({ error: "DB update failed" }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/app/payment/success/page.tsx
+++ b/app/payment/success/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export default function PaymentSuccessPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => router.replace("/practices"), 5000);
+    return () => clearTimeout(timer);
+  }, [router]);
+
+  return (
+    <div className="min-h-screen bg-bg font-sans text-ink antialiased flex items-center justify-center px-6">
+      <div className="max-w-[26rem] text-center">
+        <div className="mb-6 inline-grid h-16 w-16 place-items-center rounded-full bg-primary-soft">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-primary-ink" aria-hidden="true">
+            <path d="M20 6L9 17l-5-5" />
+          </svg>
+        </div>
+        <h1 className="mb-3 text-[1.6rem] font-medium tracking-[-0.02em]">
+          You&apos;re on Plus plan.
+        </h1>
+        <p className="mb-8 text-ink-2">
+          You can now track up to 10 active practices. Redirecting you to your practices now.
+        </p>
+        <Link
+          href="/practices"
+          className="inline-flex h-11 items-center gap-2 rounded-[0.5rem] bg-primary px-5 text-[0.95rem] font-medium text-white no-underline transition-colors hover:bg-[oklch(0.5_0.22_260)]"
+        >
+          Go to practices →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/AppChrome.tsx
+++ b/components/AppChrome.tsx
@@ -13,6 +13,7 @@ function shouldUseAppShell(pathname: string | null) {
   if (pathname === "/privacy") return false;
   if (pathname === "/terms") return false;
   if (pathname === "/contact") return false;
+  if (pathname.startsWith("/payment")) return false;
   return true;
 }
 

--- a/components/UpgradeButton.tsx
+++ b/components/UpgradeButton.tsx
@@ -1,32 +1,42 @@
 "use client";
 
+import { useState } from "react";
 import { toast } from "sonner";
 import { useProfile } from "@/contexts/ProfileContext";
 import { Button } from "@/components/ui";
 
-/**
- * Upgrade CTA shown only for Free plan users.
- * Stubbed: no payments yet; shows toast on click.
- */
 export function UpgradeButton() {
   const { profile, loading } = useProfile();
+  const [busy, setBusy] = useState(false);
 
   if (loading || profile?.subscriptionStatus !== "FREE") return null;
 
-  function handleClick() {
-    toast.info("Plus plan is coming soon", {
-      description: "Plus lets you keep up to 10 active practices.",
-    });
+  async function handleClick() {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/payment/checkout", { method: "POST" });
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        toast.error("Could not start checkout. Please try again.");
+      }
+    } catch {
+      toast.error("Could not start checkout. Please try again.");
+    } finally {
+      setBusy(false);
+    }
   }
 
   return (
     <Button
       variant="outline"
       size="sm"
+      disabled={busy}
       onClick={handleClick}
       className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary/50"
     >
-      Upgrade to Plus
+      {busy ? "Loading…" : "Upgrade to Plus"}
     </Button>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "19.2.3",
         "recharts": "^3.8.1",
         "sonner": "^2.0.7",
+        "stripe": "^22.1.0",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -35699,7 +35700,7 @@
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -46245,6 +46246,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.0.tgz",
+      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/strnum": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
@@ -46939,7 +46957,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "19.2.3",
     "recharts": "^3.8.1",
     "sonner": "^2.0.7",
+    "stripe": "^22.1.0",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/utils/stripeClient.ts
+++ b/utils/stripeClient.ts
@@ -1,0 +1,12 @@
+import Stripe from "stripe";
+
+let client: Stripe | null = null;
+
+export function getStripeClient(): Stripe {
+  if (!client) {
+    const key = process.env.FIAPP_STRIPE_SECRET_KEY;
+    if (!key) throw new Error("FIAPP_STRIPE_SECRET_KEY is not set");
+    client = new Stripe(key, { apiVersion: "2026-04-22.dahlia" });
+  }
+  return client;
+}


### PR DESCRIPTION
## Summary

- `POST /api/payment/checkout` — creates Stripe Checkout session (A\$19 AUD, one-time) with `userId` in metadata
- `POST /api/payment/webhook` — verifies Stripe signature, sets `subscriptionStatus = PAID` in DynamoDB on `checkout.session.completed`
- `/payment/success` — confirmation page, auto-redirects to `/practices` after 5s
- `UpgradeButton` — replaced "coming soon" toast with real Stripe Checkout redirect
- `AppChrome` — `/payment/*` excluded from AppShell

## Environment variables required

| Key | Where |
|---|---|
| `FIAPP_STRIPE_SECRET_KEY` | Amplify + .env.local |
| `FIAPP_STRIPE_PRICE_ID` | Amplify + .env.local |
| `FIAPP_STRIPE_WEBHOOK_SECRET` | Amplify + .env.local |
| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Amplify + .env.local |

## Test plan

- [ ] Click "Upgrade to Plus" → redirects to Stripe Checkout
- [ ] Use test card `4242 4242 4242 4242` → payment succeeds
- [ ] Redirected to `/payment/success` → auto-redirects to `/practices`
- [ ] `subscriptionStatus` updated to `PAID` in DynamoDB
- [ ] UpgradeButton disappears after upgrade
- [ ] Free user cap still enforced before payment

🤖 Generated with [Claude Code](https://claude.com/claude-code)