### PR TITLE
fix: remove unsupported eslint option from next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,6 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
-  eslint: { ignoreDuringBuilds: true },
   typescript: { ignoreBuildErrors: false },
   async headers() {
     return [


### PR DESCRIPTION
Next.js 16 removed the `eslint` config option. ESLint is already run as a separate CI step so this has no impact on lint enforcement.