### PR TITLE
feat: EPIC 17 — privacy, legal & public trust layer

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -50,6 +50,25 @@ export default function AccountPage() {
           </div>
         </Card>
 
+        {/* Data & privacy */}
+        <Card>
+          <div className="space-y-3">
+            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Data & privacy</p>
+            <p className="text-sm text-muted-foreground">
+              To request a copy or deletion of your data, email{' '}
+              <a href="mailto:hello@friendsintelligence.net?subject=Data%20deletion%20request" className="text-primary underline underline-offset-2">
+                hello@friendsintelligence.net
+              </a>
+              . We action deletion requests within 30 days.
+            </p>
+            <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+              <Link href="/privacy" className="hover:text-foreground transition-colors">Privacy policy</Link>
+              <Link href="/terms" className="hover:text-foreground transition-colors">Terms of use</Link>
+              <Link href="/disclaimer" className="hover:text-foreground transition-colors">Disclaimer</Link>
+            </div>
+          </div>
+        </Card>
+
         {/* Sign out */}
         <Card>
           <div className="space-y-3">

--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { assessmentQuestions } from "@/lib/assessment/questions";
 import { pillarColors } from "@/lib/design/pillarColors";
 import { NarrowFormPage } from "@/components/layout";
@@ -229,6 +230,10 @@ export default function AssessmentPage() {
           </div>
         </Card>
       </div>
+      <p className="text-xs text-muted-foreground text-center pt-2">
+        This assessment is for personal reflection only —{' '}
+        <Link href="/disclaimer" className="underline underline-offset-2 hover:text-foreground">not professional advice</Link>.
+      </p>
     </NarrowFormPage>
   );
 }

--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Disclaimer — Friends Intelligence",
+};
+
+export default function DisclaimerPage() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-ink antialiased">
+      <header className="border-b border-line-2 px-6">
+        <div className="mx-auto flex h-16 max-w-[70rem] items-center justify-between">
+          <Link href="/" className="text-[0.95rem] font-semibold text-ink no-underline hover:text-ink-2">
+            ← Friends Intelligence
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-[42rem] px-6 py-16 sm:py-24">
+        <p className="mb-3 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-ink-3">Disclaimer</p>
+        <h1 className="mb-4 text-[clamp(1.8rem,3vw,2.4rem)] font-medium leading-[1.1] tracking-[-0.02em]">
+          Not professional advice
+        </h1>
+        <p className="mb-12 text-ink-2">Last updated: May 2026</p>
+
+        <div className="grid gap-8 text-[0.95rem] leading-[1.7] text-ink-2">
+          <section>
+            <h2 className="mb-3 text-base font-medium text-ink">What Friends Intelligence is</h2>
+            <p>Friends Intelligence is a personal reflection and habit-building tool based on the F.R.I.E.N.D.S Intelligence framework. It is designed to help you notice patterns in your own life and build small, consistent practices across the areas that matter to you.</p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-base font-medium text-ink">What it is not</h2>
+            <p>Friends Intelligence is <strong className="font-medium text-ink">not</strong> a substitute for professional advice of any kind. Nothing in this app constitutes or should be interpreted as:</p>
+            <ul className="mt-3 list-disc pl-5 space-y-1.5">
+              <li>Medical or clinical advice</li>
+              <li>Mental health or psychological therapy</li>
+              <li>Financial, legal, or investment advice</li>
+              <li>Nutritional or dietary advice from a qualified professional</li>
+              <li>Crisis intervention or emergency support</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-base font-medium text-ink">If you need professional help</h2>
+            <p>If you are experiencing a mental health crisis, medical emergency, or any situation requiring professional support, please contact a qualified professional or emergency service in your country. The app is not monitored and cannot provide real-time help.</p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-base font-medium text-ink">Assessment results</h2>
+            <p>The assessment in Friends Intelligence is a self-reflection tool, not a diagnostic instrument. Results reflect your own responses at a point in time and are intended to help you identify where to direct your attention — not to diagnose, classify, or evaluate you.</p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-base font-medium text-ink">Contact</h2>
+            <p>Questions about this disclaimer? Email <a href="mailto:hello@friendsintelligence.net" className="text-primary no-underline hover:underline">hello@friendsintelligence.net</a></p>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -404,6 +404,7 @@ export default function LandingPage() {
           <div className="flex gap-5">
             <Link href="/privacy" className="text-ink-3 no-underline hover:text-ink">Privacy</Link>
             <Link href="/terms" className="text-ink-3 no-underline hover:text-ink">Terms</Link>
+            <Link href="/disclaimer" className="text-ink-3 no-underline hover:text-ink">Disclaimer</Link>
             <Link href="/contact" className="text-ink-3 no-underline hover:text-ink">Contact</Link>
           </div>
           <div>© 2026 Friends Intelligence</div>

--- a/components/AppChrome.tsx
+++ b/components/AppChrome.tsx
@@ -13,6 +13,7 @@ function shouldUseAppShell(pathname: string | null) {
   if (pathname === "/privacy") return false;
   if (pathname === "/terms") return false;
   if (pathname === "/contact") return false;
+  if (pathname === "/disclaimer") return false;
   if (pathname.startsWith("/payment")) return false;
   return true;
 }

--- a/components/AuthenticatorWrapper.tsx
+++ b/components/AuthenticatorWrapper.tsx
@@ -79,6 +79,9 @@ export default function AuthenticatorWrapper() {
           <p className="text-sm text-muted-foreground mt-2">
             Sign in to continue your journey
           </p>
+          <p className="text-xs text-muted-foreground mt-3 max-w-sm mx-auto leading-5">
+            An account saves your assessment results and practice progress so you can pick up where you left off. We only store your email and your responses — nothing is shared or sold.
+          </p>
         </div>
 
         <div className="fiapp-auth-shell">
@@ -122,10 +125,17 @@ export default function AuthenticatorWrapper() {
           </Authenticator>
         </div>
 
-        <div className="mt-6 text-center text-xs text-muted-foreground">
-          <Link href="/" className="text-muted-foreground hover:text-foreground">
-            ← Back to home
-          </Link>
+        <div className="mt-6 text-center text-xs text-muted-foreground space-y-2">
+          <div>
+            <Link href="/" className="text-muted-foreground hover:text-foreground">
+              ← Back to home
+            </Link>
+          </div>
+          <div className="flex justify-center gap-4">
+            <Link href="/privacy" className="hover:text-foreground transition-colors">Privacy</Link>
+            <Link href="/terms" className="hover:text-foreground transition-colors">Terms</Link>
+            <Link href="/disclaimer" className="hover:text-foreground transition-colors">Disclaimer</Link>
+          </div>
         </div>
       </div>
     </div>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,17 @@
+User-agent: *
+Allow: /
+Allow: /privacy
+Allow: /terms
+Allow: /disclaimer
+Allow: /contact
+
+Disallow: /auth
+Disallow: /today
+Disallow: /practices
+Disallow: /results
+Disallow: /progress
+Disallow: /account
+Disallow: /assessment
+Disallow: /decideRoute
+Disallow: /api/
+Disallow: /payment/

--- a/tests/unit/trustPages.test.tsx
+++ b/tests/unit/trustPages.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PrivacyPage from "@/app/privacy/page";
+import TermsPage from "@/app/terms/page";
+import DisclaimerPage from "@/app/disclaimer/page";
+import ContactPage from "@/app/contact/page";
+
+describe("Trust pages render without errors", () => {
+  it("Privacy page renders key content", () => {
+    render(<PrivacyPage />);
+    expect(screen.getByRole("heading", { name: /privacy policy/i })).toBeInTheDocument();
+    expect(screen.getByText(/what we collect/i)).toBeInTheDocument();
+  });
+
+  it("Terms page renders key content", () => {
+    render(<TermsPage />);
+    expect(screen.getByRole("heading", { name: /terms of use/i })).toBeInTheDocument();
+  });
+
+  it("Disclaimer page renders key content", () => {
+    render(<DisclaimerPage />);
+    expect(screen.getByRole("heading", { name: /not professional advice/i })).toBeInTheDocument();
+    expect(screen.getByText(/what it is not/i)).toBeInTheDocument();
+  });
+
+  it("Contact page renders key content", () => {
+    render(<ContactPage />);
+    expect(screen.getByRole("heading", { name: /get in touch/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /hello@friendsintelligence\.net/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- New `/disclaimer` page — not medical/financial/professional advice
- Landing page footer now includes Disclaimer link
- Account page — Data & privacy section with deletion request email + links to Privacy, Terms, Disclaimer
- Auth page — explains why an account is needed + privacy/terms/disclaimer footer links
- Assessment page — footnote: "for personal reflection only, not professional advice"
- `robots.txt` — disallows all app/API routes from indexing, allows public trust pages
- Smoke tests for all 4 trust pages (privacy, terms, disclaimer, contact)

## Test plan
- [ ] `/disclaimer` loads without login
- [ ] Account page shows Data & privacy section with working links
- [ ] Auth page shows "why login" explanation and footer links
- [ ] Assessment page shows disclaimer footnote
- [ ] `robots.txt` accessible at `/robots.txt`
- [ ] All trust page smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)