### PR TITLE
feat: EPIC 15 design polish + fix infinite spinner on mobile

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -30,8 +30,8 @@ export default function AccountPage() {
               </div>
               <div>
                 <p className="text-xs text-muted-foreground mb-0.5">Plan</p>
-                <p className="text-sm font-medium text-foreground mb-2">{plan}</p>
-                <UpgradeButton />
+                <p className="text-sm font-medium text-foreground">{plan}</p>
+                <div className="mt-2"><UpgradeButton /></div>
               </div>
             </div>
           </div>

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -50,6 +50,25 @@ export default function AccountPage() {
           </div>
         </Card>
 
+        {/* Data & privacy */}
+        <Card>
+          <div className="space-y-3">
+            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Data & privacy</p>
+            <p className="text-sm text-muted-foreground">
+              To request a copy or deletion of your data, email{' '}
+              <a href="mailto:hello@friendsintelligence.net?subject=Data%20deletion%20request" className="text-primary underline underline-offset-2">
+                hello@friendsintelligence.net
+              </a>
+              . We action deletion requests within 30 days.
+            </p>
+            <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+              <Link href="/privacy" className="hover:text-foreground transition-colors">Privacy policy</Link>
+              <Link href="/terms" className="hover:text-foreground transition-colors">Terms of use</Link>
+              <Link href="/disclaimer" className="hover:text-foreground transition-colors">Disclaimer</Link>
+            </div>
+          </div>
+        </Card>
+
         {/* Sign out */}
         <Card>
           <div className="space-y-3">

--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { assessmentQuestions } from "@/lib/assessment/questions";
 import { pillarColors } from "@/lib/design/pillarColors";
 import { NarrowFormPage } from "@/components/layout";
@@ -229,6 +230,10 @@ export default function AssessmentPage() {
           </div>
         </Card>
       </div>
+      <p className="text-xs text-muted-foreground text-center pt-2">
+        This assessment is for personal reflection only —{' '}
+        <Link href="/disclaimer" className="underline underline-offset-2 hover:text-foreground">not professional advice</Link>.
+      </p>
     </NarrowFormPage>
   );
 }

--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Disclaimer — Friends Intelligence",
+};
+
+export default function DisclaimerPage() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-ink antialiased">
+      <header className="border-b border-line-2 px-6">
+        <div className="mx-auto flex h-16 max-w-[70rem] items-center justify-between">
+          <Link href="/" className="text-[0.95rem] font-semibold text-ink no-underline hover:text-ink-2">
+            ← Friends Intelligence
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-[42rem] px-6 py-16 sm:py-24">
+        <p className="mb-3 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-ink-3">Disclaimer</p>
+        <h1 className="mb-4 text-[clamp(1.8rem,3vw,2.4rem)] font-medium leading-[1.1] tracking-[-0.02em]">
+          Not professional advice
+        </h1>
+        <p className="mb-12 text-ink-2">Last updated: May 2026</p>
+
+        <div className="grid gap-8 text-[0.95rem] leading-[1.7] text-ink-2">
+          <section>
+            <h2 className="mb-3 text-base font-medium text-ink">What Friends Intelligence is</h2>
+            <p>Friends Intelligence is a personal reflection and habit-building tool based on the F.R.I.E.N.D.S Intelligence framework. It is designed to help you notice patterns in your own life and build small, consistent practices across the areas that matter to you.</p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-base font-medium text-ink">What it is not</h2>
+            <p>Friends Intelligence is <strong className="font-medium text-ink">not</strong> a substitute for professional advice of any kind. Nothing in this app constitutes or should be interpreted as:</p>
+            <ul className="mt-3 list-disc pl-5 space-y-1.5">
+              <li>Medical or clinical advice</li>
+              <li>Mental health or psychological therapy</li>
+              <li>Financial, legal, or investment advice</li>
+              <li>Nutritional or dietary advice from a qualified professional</li>
+              <li>Crisis intervention or emergency support</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-base font-medium text-ink">If you need professional help</h2>
+            <p>If you are experiencing a mental health crisis, medical emergency, or any situation requiring professional support, please contact a qualified professional or emergency service in your country. The app is not monitored and cannot provide real-time help.</p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-base font-medium text-ink">Assessment results</h2>
+            <p>The assessment in Friends Intelligence is a self-reflection tool, not a diagnostic instrument. Results reflect your own responses at a point in time and are intended to help you identify where to direct your attention — not to diagnose, classify, or evaluate you.</p>
+          </section>
+
+          <section>
+            <h2 className="mb-3 text-base font-medium text-ink">Contact</h2>
+            <p>Questions about this disclaimer? Email <a href="mailto:hello@friendsintelligence.net" className="text-primary no-underline hover:underline">hello@friendsintelligence.net</a></p>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -144,9 +144,13 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    overflow-x: hidden;
+  }
   body {
     @apply bg-background text-foreground;
-    overflow-x: clip;
+    overflow-x: hidden;
+    touch-action: pan-y;
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -404,6 +404,7 @@ export default function LandingPage() {
           <div className="flex gap-5">
             <Link href="/privacy" className="text-ink-3 no-underline hover:text-ink">Privacy</Link>
             <Link href="/terms" className="text-ink-3 no-underline hover:text-ink">Terms</Link>
+            <Link href="/disclaimer" className="text-ink-3 no-underline hover:text-ink">Disclaimer</Link>
             <Link href="/contact" className="text-ink-3 no-underline hover:text-ink">Contact</Link>
           </div>
           <div>© 2026 Friends Intelligence</div>

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -252,7 +252,7 @@ export default function PracticesPage() {
   return (
     <StandardPage
       title="My Practices"
-      description="Your committed practices and what you're testing."
+      description="Active, paused, and trials."
       actions={
         <Button variant="outline" size="sm" asChild>
           <Link href="/results">+ Add practice</Link>

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -127,7 +127,7 @@ export default function ProgressPage() {
               {data.milestones.map((m) => (
                 <Card key={m.sk} variant="subtle" className="flex items-start gap-4">
                   <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
-                    ★
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>
                   </div>
                   <div>
                     <p className="font-semibold text-foreground">{m.title}</p>

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -127,7 +127,7 @@ export default function ResultsPage() {
                   className="h-4 w-4 rounded-full shrink-0"
                   style={{ backgroundColor: pillarColors[focusPillar!] }}
                 />
-                <h2 className="text-2xl font-bold text-foreground">
+                <h2 className="text-xl font-semibold text-foreground">
                   {pillarLabels[focusPillar!]} Intelligence
                 </h2>
               </div>
@@ -156,23 +156,21 @@ export default function ResultsPage() {
                   return (
                     <div
                       key={pillar}
-                      className={`flex items-center gap-4 rounded-xl p-4 border ${
+                      className={`rounded-xl p-4 border ${
                         isFocus ? 'border-primary/30 bg-primary/5' : 'border-border/60 bg-card'
                       }`}
                     >
-                      <span className="h-3 w-3 rounded-full shrink-0" style={{ backgroundColor: color }} />
-                      <span className="w-28 text-sm font-medium text-foreground shrink-0">
-                        {pillarLabels[pillar]}
-                      </span>
-                      <div className="flex-1 h-2 rounded-full bg-muted/60">
-                        <div className="h-2 rounded-full" style={{ width: `${pct}%`, backgroundColor: color }} />
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="h-2.5 w-2.5 rounded-full shrink-0" style={{ backgroundColor: color }} />
+                        <span className="text-sm font-medium text-foreground flex-1">{pillarLabels[pillar]}</span>
+                        <span className="text-xs text-muted-foreground">{score}/{MAX_SCORE}</span>
+                        {isFocus && (
+                          <span className="text-xs font-semibold text-primary">focus</span>
+                        )}
                       </div>
-                      <span className="w-10 text-right text-sm text-muted-foreground shrink-0">
-                        {score}/{MAX_SCORE}
-                      </span>
-                      {isFocus && (
-                        <span className="text-xs font-semibold text-primary shrink-0">focus</span>
-                      )}
+                      <div className="h-1.5 rounded-full bg-muted/60">
+                        <div className="h-1.5 rounded-full" style={{ width: `${pct}%`, backgroundColor: color }} />
+                      </div>
                     </div>
                   );
                 })}

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -147,7 +147,7 @@ export default function TodayPage() {
   }
 
   return (
-    <NarrowFormPage title="Today" description="Your daily check-in.">
+    <NarrowFormPage title="Today">
       <div className="space-y-8">
 
         {newMilestones.length > 0 && (

--- a/components/AppChrome.tsx
+++ b/components/AppChrome.tsx
@@ -13,6 +13,7 @@ function shouldUseAppShell(pathname: string | null) {
   if (pathname === "/privacy") return false;
   if (pathname === "/terms") return false;
   if (pathname === "/contact") return false;
+  if (pathname === "/disclaimer") return false;
   if (pathname.startsWith("/payment")) return false;
   return true;
 }

--- a/components/AuthenticatorWrapper.tsx
+++ b/components/AuthenticatorWrapper.tsx
@@ -79,6 +79,9 @@ export default function AuthenticatorWrapper() {
           <p className="text-sm text-muted-foreground mt-2">
             Sign in to continue your journey
           </p>
+          <p className="text-xs text-muted-foreground mt-3 max-w-sm mx-auto leading-5">
+            An account saves your assessment results and practice progress so you can pick up where you left off. We only store your email and your responses — nothing is shared or sold.
+          </p>
         </div>
 
         <div className="fiapp-auth-shell">
@@ -122,10 +125,17 @@ export default function AuthenticatorWrapper() {
           </Authenticator>
         </div>
 
-        <div className="mt-6 text-center text-xs text-muted-foreground">
-          <Link href="/" className="text-muted-foreground hover:text-foreground">
-            ← Back to home
-          </Link>
+        <div className="mt-6 text-center text-xs text-muted-foreground space-y-2">
+          <div>
+            <Link href="/" className="text-muted-foreground hover:text-foreground">
+              ← Back to home
+            </Link>
+          </div>
+          <div className="flex justify-center gap-4">
+            <Link href="/privacy" className="hover:text-foreground transition-colors">Privacy</Link>
+            <Link href="/terms" className="hover:text-foreground transition-colors">Terms</Link>
+            <Link href="/disclaimer" className="hover:text-foreground transition-colors">Disclaimer</Link>
+          </div>
         </div>
       </div>
     </div>

--- a/components/DecideRouteClient.tsx
+++ b/components/DecideRouteClient.tsx
@@ -37,7 +37,7 @@ export default function DecideRouteClient() {
   }
 
   if (loading) {
-    return <FullPageSpinner label="Loading..." />;
+    return <FullPageSpinner label="Loading your profile…" />;
   }
 
   if (error && error.status !== 401 && error.status !== 403) {

--- a/components/ui/content-primitives.tsx
+++ b/components/ui/content-primitives.tsx
@@ -23,17 +23,17 @@ interface PageHeaderProps {
 
 export function PageHeader({ eyebrow, title, description, actions }: PageHeaderProps) {
   return (
-    <div className="border-b border-border/60 pb-8 mb-10">
-      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+    <div className="border-b border-border/60 pb-5 mb-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div>
           {eyebrow && (
             <span className="inline-flex items-center rounded-full bg-muted/60 px-3 py-1 text-xs uppercase tracking-[0.22em] text-muted-foreground">
               {eyebrow}
             </span>
           )}
-          <h1 className={`text-4xl sm:text-5xl font-bold text-foreground${eyebrow ? ' mt-3' : ''}`}>{title}</h1>
+          <h1 className={`text-2xl sm:text-3xl font-semibold tracking-tight text-foreground${eyebrow ? ' mt-3' : ''}`}>{title}</h1>
           {description && (
-            <p className="mt-3 text-lg text-muted-foreground max-w-2xl">{description}</p>
+            <p className="mt-1.5 text-sm text-muted-foreground max-w-2xl">{description}</p>
           )}
         </div>
         {actions && <div className="flex items-center gap-2">{actions}</div>}

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -8,10 +8,19 @@ export async function fetchMe<TProfile>(): Promise<{
   status: number;
   data: ApiMeResponse<TProfile> | null;
 }> {
-  const res = await fetch("/api/me", {
-    cache: "no-store",
-    credentials: "include",
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  let res: Response;
+  try {
+    res = await fetch("/api/me", {
+      cache: "no-store",
+      credentials: "include",
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
 
   let body: { ok?: boolean; data?: TProfile } | null = null;
   try {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,17 @@
+User-agent: *
+Allow: /
+Allow: /privacy
+Allow: /terms
+Allow: /disclaimer
+Allow: /contact
+
+Disallow: /auth
+Disallow: /today
+Disallow: /practices
+Disallow: /results
+Disallow: /progress
+Disallow: /account
+Disallow: /assessment
+Disallow: /decideRoute
+Disallow: /api/
+Disallow: /payment/

--- a/tests/unit/trustPages.test.tsx
+++ b/tests/unit/trustPages.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PrivacyPage from "@/app/privacy/page";
+import TermsPage from "@/app/terms/page";
+import DisclaimerPage from "@/app/disclaimer/page";
+import ContactPage from "@/app/contact/page";
+
+describe("Trust pages render without errors", () => {
+  it("Privacy page renders key content", () => {
+    render(<PrivacyPage />);
+    expect(screen.getByRole("heading", { name: /privacy policy/i })).toBeInTheDocument();
+    expect(screen.getByText(/what we collect/i)).toBeInTheDocument();
+  });
+
+  it("Terms page renders key content", () => {
+    render(<TermsPage />);
+    expect(screen.getByRole("heading", { name: /terms of use/i })).toBeInTheDocument();
+  });
+
+  it("Disclaimer page renders key content", () => {
+    render(<DisclaimerPage />);
+    expect(screen.getByRole("heading", { name: /not professional advice/i })).toBeInTheDocument();
+    expect(screen.getByText(/what it is not/i)).toBeInTheDocument();
+  });
+
+  it("Contact page renders key content", () => {
+    render(<ContactPage />);
+    expect(screen.getByRole("heading", { name: /get in touch/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /hello@friendsintelligence\.net/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- **PageHeader**: reduced from `text-4xl/5xl font-bold` → `text-2xl/3xl font-semibold`, spacing tightened — affects all app pages
- **Results**: pillar score rows now stack cleanly on mobile (was fixed `w-28` overflowing 375px)
- **Results**: focus pillar heading weight reduced to `font-semibold`
- **Progress**: milestone icon is now a proper SVG checkmark (was `★` text character)
- **Today**: removed redundant "Your daily check-in." description from header
- **Practices**: shorter page description
- **Account**: UpgradeButton wrapper div avoids gap when button is hidden (Plus users)
- **Bug fix**: `fetchMe` now has a 10s `AbortController` timeout — Lambda cold-start hangs now resolve to the "Something went wrong / Retry" state instead of spinning forever

## Test plan
- [ ] All app page headers look calmer on mobile
- [ ] Results pillar scores display correctly on 375px screen
- [ ] Progress milestones show checkmark icon
- [ ] Sign in on mobile → if profile loads slowly, shows Retry instead of infinite spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)