### PR TITLE
feat: EPIC 14 — assessment intro & contextual help layer

### DIFF
--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -15,6 +15,7 @@ export default function AssessmentPage() {
   const [answers, setAnswers] = useState<Record<string, boolean>>({});
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [introAccepted, setIntroAccepted] = useState(false);
 
   function getContrastingTextColor(hex: string) {
     const match = /^#?([0-9a-fA-F]{6})$/.exec(hex);
@@ -100,6 +101,53 @@ export default function AssessmentPage() {
     setIndex(0);
     setError(null);
     setSubmitting(false);
+  }
+
+  if (!introAccepted) {
+    return (
+      <NarrowFormPage title="">
+        <div className="space-y-3">
+          <p className="text-xs tracking-[0.12em] text-muted-foreground">
+            Friends Intelligence · Assessment
+          </p>
+          <Card>
+            <div className="space-y-5">
+              <div>
+                <h1 className="text-xl font-semibold text-foreground">Before you begin</h1>
+                <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
+                  This assessment helps you see where you stand across the seven Friends Intelligence pillars — Financial, Relationship, Information, Emotional, Nutrition, Dynamic, and Sleep.
+                </p>
+              </div>
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                <li className="flex items-start gap-2.5">
+                  <span className="mt-0.5 text-primary font-semibold shrink-0">35</span>
+                  <span>yes/no questions — takes about 8 minutes</span>
+                </li>
+                <li className="flex items-start gap-2.5">
+                  <span className="mt-0.5 text-primary font-semibold shrink-0">→</span>
+                  <span>Answer based on the last 7–14 days, not how you want things to be</span>
+                </li>
+                <li className="flex items-start gap-2.5">
+                  <span className="mt-0.5 text-primary font-semibold shrink-0">✓</span>
+                  <span>Scores are for self-reflection only — not a diagnosis or judgment</span>
+                </li>
+                <li className="flex items-start gap-2.5">
+                  <span className="mt-0.5 text-primary font-semibold shrink-0">↺</span>
+                  <span>You can retake it any time from your account</span>
+                </li>
+              </ul>
+              <Button className="w-full" onClick={() => setIntroAccepted(true)}>
+                Start assessment →
+              </Button>
+            </div>
+          </Card>
+          <p className="text-xs text-muted-foreground text-center">
+            For personal reflection only —{' '}
+            <Link href="/disclaimer" className="underline underline-offset-2 hover:text-foreground">not professional advice</Link>.
+          </p>
+        </div>
+      </NarrowFormPage>
+    );
   }
 
   return (

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { HelpTooltip } from '@/components/HelpTooltip';
 import { StandardPage } from '@/components/layout';
 import { Card, Button, EmptyState, Loading, ErrorState } from '@/components/ui';
 import { pillarColors } from '@/lib/design/pillarColors';
@@ -368,6 +369,12 @@ export default function PracticesPage() {
                   )
                 })}
 
+                {activeTrials.length > 0 && (
+                  <div className="flex items-center gap-2 pt-2">
+                    <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Trying out</p>
+                    <HelpTooltip content="A trial lets you test a practice for 7 days before committing. Trials don't use your active practice slot. At the end, keep it or let it go." />
+                  </div>
+                )}
                 {activeTrials.map((t) => (
                   <Card key={t.id} variant="interactive" className="flex items-start justify-between gap-4">
                     <div className="space-y-2 min-w-0">

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { HelpTooltip } from '@/components/HelpTooltip';
 import { StandardPage } from '@/components/layout';
 import { Card, Button, Loading, ErrorState, EmptyState } from '@/components/ui';
 import { PillarRadarChart } from '@/components/ui/PillarRadarChart';
@@ -121,7 +122,10 @@ export default function ResultsPage() {
           <>
             {/* Focus pillar highlight */}
             <Card className="border-primary/30 bg-primary/5">
-              <p className="text-xs uppercase tracking-[0.2em] text-primary mb-2">Focus Pillar</p>
+              <div className="flex items-center gap-2 mb-2">
+                <p className="text-xs uppercase tracking-[0.2em] text-primary">Focus Pillar</p>
+                <HelpTooltip content="Your focus pillar is your lowest-scoring area. It's where small changes tend to have the biggest impact. You're not broken — you just have the most room to grow here." />
+              </div>
               <div className="flex items-center gap-3">
                 <span
                   className="h-4 w-4 rounded-full shrink-0"
@@ -146,7 +150,10 @@ export default function ResultsPage() {
 
             {/* All pillar scores */}
             <div>
-              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">All Pillars</p>
+              <div className="flex items-center gap-2 mb-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">All Pillars</p>
+                <HelpTooltip content="Each pillar has 5 questions. Your score reflects how many you answered Yes to in the last 7–14 days. A 3/5 isn't a failure — it's a starting point." />
+              </div>
               <div className="space-y-3">
                 {pillarOrder.map((pillar) => {
                   const score = scores![pillar] ?? 0;

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { HelpTooltip } from '@/components/HelpTooltip';
 import { NarrowFormPage } from '@/components/layout';
 import { Card, Button, Loading, ErrorState } from '@/components/ui';
 import { pillarColors } from '@/lib/design/pillarColors';
@@ -209,6 +210,9 @@ export default function TodayPage() {
 
                 {/* Primary action */}
                 <div className="space-y-2 pt-1">
+                  <div className="flex items-center justify-end gap-1.5 mb-1">
+                    <HelpTooltip content="'Did it' logs that you completed your practice today. 'Not today' logs that you skipped — no judgment, it still counts as showing up. You can change your answer any time today." />
+                  </div>
                   <Button
                     size="lg"
                     variant={todayDidIt === true ? 'default' : 'outline'}

--- a/components/HelpTooltip.tsx
+++ b/components/HelpTooltip.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface HelpTooltipProps {
+  content: string;
+}
+
+export function HelpTooltip({ content }: HelpTooltipProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) document.addEventListener("mousedown", handleOutside);
+    return () => document.removeEventListener("mousedown", handleOutside);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative inline-flex shrink-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Help"
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-muted text-[0.65rem] font-semibold text-muted-foreground transition-colors hover:bg-muted/70"
+      >
+        ?
+      </button>
+      {open && (
+        <div className="absolute left-0 top-6 z-50 w-64 rounded-lg border border-border bg-card p-3 text-xs leading-relaxed text-muted-foreground shadow-lg">
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Assessment intro screen** — shown before questions start: explains what the 35 questions are for, 8-minute estimate, reflective not diagnostic, can retake any time
- **HelpTooltip component** — reusable `?` button, tap/click to toggle inline explanation, works on mobile and desktop
- **Focus pillar `?`** — explains why this pillar was chosen and that it's not a judgment
- **All Pillars `?`** — explains what the score means (5 questions per pillar, a 3/5 is a starting point)
- **Trial practices `?`** — explains what "Trying out" means: 7-day trial, no active slot used, keep or let go
- **Today check-in `?`** — explains Did it / Not today: no judgment, can change answer any time today

## Test plan
- [ ] `/assessment` shows intro screen before questions
- [ ] Tapping "Start assessment →" shows question 1
- [ ] `?` tooltips open on tap, close when tapping outside
- [ ] Tooltips don't overflow off screen on 375px mobile
- [ ] Trial section shows "Trying out" header + `?` when trials exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)