### PR TITLE
feat: FAQ page, assessment retake on Insights, account polish

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -50,6 +50,19 @@ export default function AccountPage() {
           </div>
         </Card>
 
+        {/* Help */}
+        <Card>
+          <div className="space-y-3">
+            <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Help</p>
+            <p className="text-sm text-muted-foreground">
+              New to the app or have questions about how it works?
+            </p>
+            <Button variant="outline" asChild>
+              <Link href="/faq">Read the FAQ →</Link>
+            </Button>
+          </div>
+        </Card>
+
         {/* Data & privacy */}
         <Card>
           <div className="space-y-3">

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "FAQ — Friends Intelligence",
+};
+
+const faqs = [
+  {
+    q: "What is Friends Intelligence?",
+    a: "Friends Intelligence is a personal reflection and habit-building app based on the F.R.I.E.N.D.S Intelligence framework. The idea is simple: lasting wellbeing comes from small, consistent actions across the areas that matter most in life — not from one big change. The app helps you see where you stand, pick one thing to work on, and build the habit of showing up daily.",
+  },
+  {
+    q: "What are the 7 pillars?",
+    a: "The pillars are Financial, Relationship, Information, Emotional, Nutrition, Dynamic (movement and physical activity), and Sleep. Each one represents an area of life where consistent habits have an outsized effect on how you feel and function day to day.",
+  },
+  {
+    q: "What does my pillar score actually mean?",
+    a: "Each pillar has 5 yes/no questions. Your score (e.g. 3/5) reflects how many you answered Yes to based on the last 7–14 days. It's a snapshot of your current habits — not a permanent label, not a grade. A 2/5 just means there's room to grow in that area right now.",
+  },
+  {
+    q: "Why is one pillar highlighted as my focus?",
+    a: "Your focus pillar is your lowest-scoring area. Research on behaviour change shows that improving your weakest area tends to have the biggest positive ripple effect on everything else. It's not that the other pillars don't matter — it's that starting where you have the most room to grow gives you the fastest return.",
+  },
+  {
+    q: "My score seems low — does that mean I'm failing?",
+    a: "No. A low score means you have room to grow, not that something is wrong with you. The assessment measures recent habits at a single point in time. Most people score low in at least one or two areas — that's normal and expected. The score is a starting point, not a verdict.",
+  },
+  {
+    q: "What's the difference between a trial and an active practice?",
+    a: "A trial is a 7-day test run. It doesn't count toward your active practice limit, so you can try something without committing a slot. You check in daily just like an active practice. After 7 days, you decide: promote it to active, or discard it. Trials are a low-pressure way to see if a practice actually fits your life.",
+  },
+  {
+    q: "How often should I retake the assessment?",
+    a: "Every 4–6 weeks is a good rhythm. Retaking too soon won't show meaningful change — habits take time to shift. After a few weeks of consistent daily check-ins, retaking gives you a more honest picture of whether things have moved. You can retake any time from the Insights page.",
+  },
+  {
+    q: "Why can I only have one active practice on the free plan?",
+    a: "It's intentional. Research on habit formation consistently shows that trying to change multiple things at once leads to burnout and abandonment. One practice, done consistently, builds the habit muscle. Once that's solid, adding more makes sense. Plus plan unlocks up to 10 active practices for when you're ready.",
+  },
+  {
+    q: "What's the difference between 'Did it' and 'Not today'?",
+    a: "'Did it' logs that you completed your practice. 'Not today' logs that you skipped — and that's completely fine. Both count as showing up to your check-in. What matters long-term is the habit of reflecting, not perfection. There's no judgment attached to 'Not today'.",
+  },
+  {
+    q: "Does skipping a day reset my progress?",
+    a: "Your streak resets if you skip a day, but your total progress — your counters and milestones — never resets. Every 'Did it' you've ever logged is permanently counted. A skipped day is just a skipped day. Your history stays intact.",
+  },
+];
+
+export default function FAQPage() {
+  return (
+    <div className="min-h-screen bg-bg font-sans text-ink antialiased">
+      <header className="border-b border-line-2 px-6">
+        <div className="mx-auto flex h-16 max-w-[70rem] items-center justify-between">
+          <Link href="/" className="text-[0.95rem] font-semibold text-ink no-underline hover:text-ink-2">
+            ← Friends Intelligence
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-[42rem] px-6 py-16 sm:py-24">
+        <p className="mb-3 font-mono text-[0.72rem] uppercase tracking-[0.14em] text-ink-3">Help</p>
+        <h1 className="mb-4 text-[clamp(1.8rem,3vw,2.4rem)] font-medium leading-[1.1] tracking-[-0.02em]">
+          Frequently asked questions
+        </h1>
+        <p className="mb-12 text-ink-2">
+          Answers to the questions most people have while getting started.
+        </p>
+
+        <div className="grid gap-8">
+          {faqs.map(({ q, a }) => (
+            <section key={q}>
+              <h2 className="mb-2 text-base font-medium text-ink">{q}</h2>
+              <p className="text-[0.95rem] leading-[1.7] text-ink-2">{a}</p>
+            </section>
+          ))}
+        </div>
+
+        <div className="mt-16 border-t border-line-2 pt-8 text-[0.9rem] text-ink-3">
+          Still have a question?{" "}
+          <a href="mailto:hello@friendsintelligence.net" className="text-primary no-underline hover:underline">
+            Email us
+          </a>
+          {" "}or visit the{" "}
+          <Link href="/disclaimer" className="text-primary no-underline hover:underline">
+            disclaimer
+          </Link>
+          {" "}for what the app is and isn&apos;t.
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -152,6 +152,9 @@
     overflow-x: hidden;
     touch-action: pan-y;
   }
+  button, input, select, textarea {
+    font: inherit;
+  }
 }
 
 @keyframes dot-pop {

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -99,11 +99,6 @@ export default function ResultsPage() {
     <StandardPage
       title="Your Insights"
       description="Where you stand across the 7 Friends pillars — and what to work on next."
-      actions={assessment ? (
-        <Button variant="ghost" size="sm" asChild>
-          <Link href="/assessment">Retake assessment</Link>
-        </Button>
-      ) : undefined}
     >
       <div className="space-y-10">
 
@@ -231,10 +226,19 @@ export default function ResultsPage() {
             </div>
 
             {/* CTA */}
-            <div className="pt-2">
-              <Button asChild size="lg">
+            <div className="pt-2 space-y-3">
+              <Button asChild size="lg" className="w-full sm:w-auto">
                 <Link href="/practices">Go to My Practices →</Link>
               </Button>
+              <div>
+                <Button asChild variant="outline" size="lg" className="w-full sm:w-auto">
+                  <Link href="/assessment">Retake assessment</Link>
+                </Button>
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  Scores update when you retake — useful after a few weeks of practice.{" "}
+                  <Link href="/faq" className="underline underline-offset-2 hover:text-foreground">Questions about your scores?</Link>
+                </p>
+              </div>
             </div>
           </>
         )}

--- a/components/AppChrome.tsx
+++ b/components/AppChrome.tsx
@@ -14,6 +14,7 @@ function shouldUseAppShell(pathname: string | null) {
   if (pathname === "/terms") return false;
   if (pathname === "/contact") return false;
   if (pathname === "/disclaimer") return false;
+  if (pathname === "/faq") return false;
   if (pathname.startsWith("/payment")) return false;
   return true;
 }

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -124,14 +124,21 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
                   <Link
                     href="/account"
                     onClick={() => setAccountOpen(false)}
-                    className="block px-4 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                    className="block px-4 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                   >
                     View account
+                  </Link>
+                  <Link
+                    href="/faq"
+                    onClick={() => setAccountOpen(false)}
+                    className="block px-4 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                  >
+                    Help & FAQ
                   </Link>
                   {onSignOut && (
                     <button
                       onClick={() => { setAccountOpen(false); onSignOut() }}
-                      className="w-full text-left px-4 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors border-t border-border/60"
+                      className="w-full text-left px-4 py-2 font-sans !text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors border-t border-border/60"
                     >
                       Sign out
                     </button>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,6 +4,7 @@ Allow: /privacy
 Allow: /terms
 Allow: /disclaimer
 Allow: /contact
+Allow: /faq
 
 Disallow: /auth
 Disallow: /today


### PR DESCRIPTION
## Summary
- Add `/faq` page with 10 questions (public, no auth required, indexed in robots.txt)
- Link FAQ from account page (Help card), desktop account dropdown, and Results page
- Move "Retake assessment" to bottom of Insights page as a prominent `size="lg"` outlined button — removes the easy-to-miss ghost button from the page header
- Match CTA button sizes on Insights page (both `size="lg"`)
- Add `font: inherit` CSS reset for form elements so button text respects Tailwind font utilities
- Use `!text-xs` on Sign out dropdown item to override browser default button font size

## Test plan
- [ ] `/faq` loads without auth, all 10 questions render correctly
- [ ] Account page shows Help card with "Read the FAQ →" button
- [ ] Account dropdown shows "Help & FAQ" link
- [ ] Insights page shows "Retake assessment" as outlined button at bottom, same size as "Go to My Practices"
- [ ] Account dropdown: View account, Help & FAQ, Sign out all same font size

🤖 Generated with [Claude Code](https://claude.com/claude-code)