### PR TITLE
chore: add TODO.md with remaining work

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,54 @@
+# FIApp v1 — Remaining Work
+
+Last updated: 2026-05-07
+
+---
+
+## Code Gaps (post-epic audit)
+
+- [ ] **Gap 4** — Show next-up milestones on Progress page. Users can't see what they're working toward. Compute next unachieved milestone from `returnCounters` vs thresholds in `lib/milestones/milestones.ts`. Add `nextMilestones` to `GET /api/progress` and render a "Coming up" section on the progress page.
+- [ ] **Gap 3** — `practiceCounters` PROFILE field is never written anywhere. Likely superseded by `returnCounters`. Formally deprecate it in `_docs/canon/db-schema.md`.
+- [ ] **Gap 5** *(optional)* — Individual assessment answers not stored. After writing `ASSESS#<id>`, batch-write `ANS#<assessmentId>#<questionId>` items. No user-facing impact right now.
+
+---
+
+## Business / Payments
+
+- [ ] **Stripe live mode** — Currently on test keys. Update `FIAPP_STRIPE_SECRET_KEY`, `FIAPP_STRIPE_WEBHOOK_SECRET`, and `FIAPP_STRIPE_PRICE_ID` in Amplify to live values when ready to accept real payments.
+
+---
+
+## Product
+
+- [ ] **Onboarding flow** — First-time users jump straight to the assessment with no warm welcome. Consider a brief intro screen after signup that explains the core loop (assess → focus → practice → check in daily) before routing to `/assessment`.
+- [ ] **Email notifications** — No emails sent at all currently. Key candidates: daily check-in reminder, milestone celebration, weekly summary. Needs an email provider (e.g. SES, Resend).
+- [ ] **Practice library depth** — Audit whether each of the 7 pillars has enough practices to keep users engaged across multiple trial/promote cycles. Aim for at least 8–10 per pillar.
+
+---
+
+## Technical Health
+
+- [ ] **Error monitoring** — No Sentry or equivalent. Production errors are invisible. Add Sentry (or similar) to both the Next.js frontend and API routes.
+- [ ] **Analytics** — No visibility into drop-off points, feature usage, or retention. Add lightweight analytics (e.g. Plausible, PostHog) to understand how users actually use the app.
+
+---
+
+## Growth
+
+- [ ] **Marketing landing page** — Audit the `/` landing page for clarity and conversion. Does it clearly explain the value prop? Is the CTA prominent? Is there social proof or a demo?
+
+---
+
+## Open GitHub Epics
+
+### EPIC 12 — Core Regression Guardrails (issue #172)
+25 tickets. Build a layered test system: unit tests for pure logic, API/integration tests for backend rules, E2E smoke suite for CI, full staging regression suite for releases, and a manual launch checklist. Covers auth, routing, assessment, practices, trials, returns, progress, account, and plan caps.
+
+### EPIC 13 — Staging Environment & Deployment Readiness (issue #198)
+15 tickets. Create a production-like staging environment on Amplify with separate env vars, separate DynamoDB resources, seeded/resettable test data, staging health checks, deployment checklist, rollback process, and a release readiness runbook.
+
+### EPIC 18 — Production Monitoring, Analytics & Launch Operations (issue #283)
+17 tickets. Add health check endpoint, structured server error logging, client-friendly error patterns, aggregate (privacy-conscious) analytics event model, daily metrics snapshot, operator dashboard, CloudWatch access docs, production smoke routine, incident response checklist, and post-launch feedback capture.
+
+### EPIC 10 — Production Readiness (issue #11)
+8 tickets. Structured logging, error normalization, basic rate limiting, scan-based metrics snapshot job, snapshot schema, daily metrics storage, CloudWatch dashboard, rollback runbook.


### PR DESCRIPTION
Adds TODO.md to the repo capturing all remaining items — spec gaps, Stripe live mode, onboarding, email, analytics, error monitoring, landing page, and the 4 open GitHub epics (10, 12, 13, 18). Safe to merge anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)