### PR TITLE
feat: EPIC 18 — production monitoring, analytics & operator dashboard

### DIFF
--- a/_docs/plans/daily-return-reset-time.md
+++ b/_docs/plans/daily-return-reset-time.md
@@ -1,0 +1,163 @@
+# Daily Return Reset Time Plan
+
+## Goal
+
+Daily returns should use a user-facing "habit day," not UTC. The default should be 4:00 AM in the user's local timezone, with a setting that lets users change when their day resets.
+
+## Product Recommendation
+
+Do not keep UTC as the default reset behavior. A daily habit app should follow the user's lived day. A Melbourne user whose "new day" starts at 10:00 AM or 11:00 AM will experience the app as incorrect.
+
+Recommended first version:
+
+- Default to 4:00 AM local time.
+- Add a simple reset-time setting with fixed options.
+- Avoid fully custom time until users ask for it.
+
+The product principle is that most users should never have to think about reset time, but users with night shifts, late routines, travel, or sleep issues should not be punished by the app's clock.
+
+## Implementation Plan
+
+### 1. Add Profile Settings
+
+Add fields to the user profile:
+
+- `timezone`: IANA timezone string, for example `Australia/Melbourne` or `America/New_York`.
+- `dayResetTime`: minutes after local midnight, for example `240` for 4:00 AM.
+
+Defaults:
+
+- `timezone`: browser-detected timezone on first client load, fallback to `UTC` if unavailable.
+- `dayResetTime`: `240`.
+
+Existing profiles without these fields should receive defaults on read.
+
+### 2. Create A Canonical Return-Day Helper
+
+Replace the current UTC-only `todayUTC()` behavior with a helper such as:
+
+```ts
+returnDayForUser({
+  now,
+  timezone,
+  resetMinutes,
+})
+```
+
+Logic:
+
+- Determine the user's local date and time.
+- If local time is before `resetMinutes`, return yesterday's `YYYY-MM-DD`.
+- Otherwise return today's `YYYY-MM-DD`.
+
+Place this in `lib/returns/returns.ts` or a new focused module such as `lib/dates/returnDay.ts`.
+
+Add unit tests for:
+
+- Melbourne timezone.
+- UTC timezone.
+- US timezones.
+- Before reset time.
+- After reset time.
+- DST edge cases.
+
+### 3. Update `POST /api/return`
+
+When `date` is omitted:
+
+- Load the user's profile.
+- Use `timezone` and `dayResetTime` to calculate the return date.
+- Store the return using the existing key shape: `DATE#YYYY-MM-DD`.
+
+Keep explicit `date` support for tests, admin workflows, or future backfill needs. Normal UI logging should omit `date`.
+
+### 4. Update `GET /api/returns`
+
+Generate the last N habit days using the user's configured timezone and reset time.
+
+The response should include the server's current return date, for example:
+
+```json
+{
+  "currentReturnDate": "2026-05-08",
+  "returns": []
+}
+```
+
+This prevents the Today page from independently calculating "today" and disagreeing with the server.
+
+### 5. Update The Today Page
+
+Stop importing `todayUTC()` client-side for deciding today's dot.
+
+Instead:
+
+- Use `currentReturnDate` from `GET /api/returns`.
+- Find the current dot by matching `date === currentReturnDate`.
+- Continue omitting `date` when calling `POST /api/return`.
+
+This keeps the UI and API aligned.
+
+### 6. Add Settings UI
+
+Add an Account or Settings section for:
+
+- Timezone display/select.
+- "Day resets at" select or segmented control.
+
+Initial reset-time options:
+
+- Midnight
+- 3:00 AM
+- 4:00 AM recommended
+- 6:00 AM
+
+Avoid fully custom time in the first version unless there is a clear user need.
+
+### 7. Migration And Backward Compatibility
+
+No table migration is required.
+
+Existing return records remain valid. Their dates were previously UTC-derived, but future records will use the configured habit-day date.
+
+Profiles without `timezone` or `dayResetTime` should behave as:
+
+- `timezone = UTC`
+- `dayResetTime = 240`
+
+Then, on the client, the app can update `timezone` to the browser-detected value when appropriate.
+
+### 8. Docs And Tests
+
+Update docs:
+
+- API contract: define "today" as the user's configured return day.
+- DB schema: document the new profile fields.
+- Product/canon docs: explain reset-time behavior and defaults.
+
+Add tests for:
+
+- Default settings.
+- Changing reset time.
+- Logging before reset.
+- Logging after reset.
+- Date range generation in `GET /api/returns`.
+- Today page using server-provided `currentReturnDate`.
+
+## Open Decisions
+
+- Should timezone be set automatically on first authenticated client load, or explicitly confirmed in Settings?
+- Should changing reset time affect only future logs, or can it reinterpret today's current log during the same calendar day?
+- Should travelers keep their home timezone or follow their device timezone?
+- Do we need account-level timezone immediately, or can v1 derive it from the browser and only persist reset time?
+
+## Suggested First Version
+
+Ship timezone-aware daily returns with:
+
+- Browser-detected timezone persisted to profile.
+- 4:00 AM local reset by default.
+- Fixed reset-time options in Account settings.
+- Server-provided `currentReturnDate` in `GET /api/returns`.
+
+This fixes the core daily-return bug while keeping the settings experience simple.

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { pillarLabels } from '@/lib/assessment/pillars'
+import { pillarColors } from '@/lib/design/pillarColors'
+import type { MetricsTotals, MetricsDaily } from '@/utils/metricsClient'
+import type { Pillar } from '@/lib/assessment/pillars'
+
+type MetricsResponse = {
+  totals: MetricsTotals
+  daily: MetricsDaily[]
+}
+
+const PILLARS: Pillar[] = ['financial', 'relationship', 'information', 'emotional', 'nutrition', 'dynamic', 'sleep']
+
+function StatCard({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-xl border border-border/60 bg-card p-5">
+      <p className="text-xs uppercase tracking-[0.15em] text-muted-foreground mb-1">{label}</p>
+      <p className="text-3xl font-semibold text-foreground">{value}</p>
+    </div>
+  )
+}
+
+function MiniBar({ value, max, color }: { value: number; max: number; color?: string }) {
+  const pct = max > 0 ? Math.round((value / max) * 100) : 0
+  return (
+    <div className="h-1.5 w-full rounded-full bg-muted/50">
+      <div
+        className="h-1.5 rounded-full"
+        style={{ width: `${pct}%`, backgroundColor: color ?? 'hsl(var(--primary))' }}
+      />
+    </div>
+  )
+}
+
+export default function AdminPage() {
+  const [data, setData] = useState<MetricsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    fetch('/api/admin/metrics')
+      .then((r) => {
+        if (r.status === 403) throw new Error('forbidden')
+        if (!r.ok) throw new Error('failed')
+        return r.json() as Promise<MetricsResponse>
+      })
+      .then(setData)
+      .catch((e) => setError(e.message === 'forbidden' ? 'Access denied.' : 'Failed to load metrics.'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const t = data?.totals ?? {}
+  const daily = data?.daily ?? []
+
+  const maxReturns = Math.max(...daily.map((d) => d.returns ?? 0), 1)
+  const maxAssessments = Math.max(...daily.map((d) => d.assessments ?? 0), 1)
+
+  const pillarMax = Math.max(
+    ...PILLARS.map((p) => (t[`pillarFocus_${p}` as keyof MetricsTotals] as number | undefined) ?? 0),
+    1
+  )
+
+  return (
+    <div className="min-h-screen bg-background font-sans">
+      <header className="sticky top-0 z-50 border-b border-border/60 bg-card/95 backdrop-blur px-6">
+        <div className="mx-auto flex h-14 max-w-5xl items-center justify-between">
+          <p className="text-sm font-semibold text-foreground">Operator Dashboard</p>
+          <Link href="/today" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+            ← Back to app
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-5xl px-6 py-10 space-y-10">
+        {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {data && (
+          <>
+            {/* Funnel */}
+            <section>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Funnel — all time</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+                <StatCard label="Users" value={t.totalUsers ?? 0} />
+                <StatCard label="Assessments" value={t.totalAssessments ?? 0} />
+                <StatCard label="Trials started" value={t.totalTrials ?? 0} />
+                <StatCard label="Trials promoted" value={t.totalPromotions ?? 0} />
+                <StatCard label="Returns logged" value={t.totalReturns ?? 0} />
+              </div>
+              {(t.totalUsers ?? 0) > 0 && (
+                <div className="mt-4 rounded-xl border border-border/40 bg-muted/30 p-4 text-xs text-muted-foreground space-y-1.5">
+                  <p>Assessment rate: <span className="font-medium text-foreground">{Math.round(((t.totalAssessments ?? 0) / (t.totalUsers ?? 1)) * 100)}%</span> of users completed assessment</p>
+                  <p>Trial rate: <span className="font-medium text-foreground">{Math.round(((t.totalTrials ?? 0) / Math.max(t.totalAssessments ?? 1, 1)) * 100)}%</span> of assessments led to a trial</p>
+                  <p>Promotion rate: <span className="font-medium text-foreground">{Math.round(((t.totalPromotions ?? 0) / Math.max(t.totalTrials ?? 1, 1)) * 100)}%</span> of trials were promoted</p>
+                </div>
+              )}
+            </section>
+
+            {/* Daily returns — last 30 days */}
+            <section>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Daily returns — last 30 days</p>
+              <div className="rounded-xl border border-border/60 bg-card p-5">
+                <div className="flex items-end gap-1 h-24">
+                  {daily.map((d) => {
+                    const h = maxReturns > 0 ? Math.round(((d.returns ?? 0) / maxReturns) * 100) : 0
+                    return (
+                      <div key={d.date} className="flex-1 flex flex-col items-center justify-end gap-1" title={`${d.date}: ${d.returns ?? 0} returns`}>
+                        <div
+                          className="w-full rounded-sm"
+                          style={{ height: `${Math.max(h, 2)}%`, backgroundColor: 'hsl(var(--primary))', opacity: h === 0 ? 0.15 : 0.85 }}
+                        />
+                      </div>
+                    )
+                  })}
+                </div>
+                <div className="flex justify-between mt-2 text-[10px] text-muted-foreground">
+                  <span>{daily[0]?.date}</span>
+                  <span>{daily[daily.length - 1]?.date}</span>
+                </div>
+              </div>
+            </section>
+
+            {/* Daily assessments — last 30 days */}
+            <section>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Daily assessments — last 30 days</p>
+              <div className="rounded-xl border border-border/60 bg-card p-5">
+                <div className="flex items-end gap-1 h-16">
+                  {daily.map((d) => {
+                    const h = maxAssessments > 0 ? Math.round(((d.assessments ?? 0) / maxAssessments) * 100) : 0
+                    return (
+                      <div key={d.date} className="flex-1 flex flex-col items-center justify-end" title={`${d.date}: ${d.assessments ?? 0} assessments`}>
+                        <div
+                          className="w-full rounded-sm"
+                          style={{ height: `${Math.max(h, 2)}%`, backgroundColor: 'hsl(var(--secondary))', opacity: h === 0 ? 0.15 : 0.85 }}
+                        />
+                      </div>
+                    )
+                  })}
+                </div>
+                <div className="flex justify-between mt-2 text-[10px] text-muted-foreground">
+                  <span>{daily[0]?.date}</span>
+                  <span>{daily[daily.length - 1]?.date}</span>
+                </div>
+              </div>
+            </section>
+
+            {/* Pillar focus distribution */}
+            <section>
+              <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-4">Focus pillar distribution — all time</p>
+              <div className="rounded-xl border border-border/60 bg-card p-5 space-y-3">
+                {PILLARS.map((p) => {
+                  const count = (t[`pillarFocus_${p}` as keyof MetricsTotals] as number | undefined) ?? 0
+                  return (
+                    <div key={p}>
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-xs text-foreground">{pillarLabels[p]}</span>
+                        <span className="text-xs text-muted-foreground">{count}</span>
+                      </div>
+                      <MiniBar value={count} max={pillarMax} color={pillarColors[p]} />
+                    </div>
+                  )
+                })}
+              </div>
+            </section>
+
+            {/* Last updated */}
+            {t.updatedAt && (
+              <p className="text-xs text-muted-foreground">Last updated: {new Date(t.updatedAt).toLocaleString()}</p>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/app/api/admin/metrics/route.ts
+++ b/app/api/admin/metrics/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { withAuth } from '@/utils/authServer'
+import { getMetricsTotals, getMetricsDaily } from '@/utils/metricsClient'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const ADMIN_USER_ID = process.env.FIAPP_ADMIN_USER_ID
+
+export async function GET(req: Request) {
+  return withAuth(req, async (user) => {
+    if (!ADMIN_USER_ID || user.userId !== ADMIN_USER_ID) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const [totals, daily] = await Promise.all([
+      getMetricsTotals(),
+      getMetricsDaily(30),
+    ])
+
+    return NextResponse.json({ totals, daily })
+  })
+}

--- a/app/api/assessment/route.ts
+++ b/app/api/assessment/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/assessment/questions";
 import { computeScores, pickFocusPillar } from "../../../lib/assessment/scoring";
 import { withAuth } from "@/utils/authServer";
+import { trackEvent, trackPillarFocus } from "@/utils/metricsClient";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -81,6 +82,9 @@ export async function POST(req: Request) {
         ":focusPillar": focusPillar,
       },
     });
+
+    trackEvent('totalAssessments', 'assessments')
+    trackPillarFocus(focusPillar)
 
     return NextResponse.json(
       { assessmentId, focusPillar, scoresByPillar },

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server'
+import { createDynamoClient } from '@/utils/dynamoClient'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const started = Date.now()
+
+  let dbOk = false
+  try {
+    const client = createDynamoClient()
+    await client.getItem({ PK: 'METRICS', SK: 'TOTALS' })
+    dbOk = true
+  } catch {
+    // DynamoDB unreachable — still return a response, just flag it
+  }
+
+  const status = dbOk ? 200 : 503
+  return NextResponse.json(
+    {
+      ok: dbOk,
+      timestamp: new Date().toISOString(),
+      latencyMs: Date.now() - started,
+      checks: { dynamodb: dbOk ? 'ok' : 'error' },
+    },
+    { status }
+  )
+}

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { getDataClient } from "@/utils/dataServerClient";
 import { createDynamoClient } from "@/utils/dynamoClient";
 import { withAuth } from "@/utils/authServer";
+import { trackEvent } from "@/utils/metricsClient";
 import { isTrialActive, type TrialItem } from "@/lib/practices/trial";
 
 export const runtime = "nodejs";
@@ -75,6 +76,7 @@ export async function GET(req: Request) {
       return jsonWithNoStore({ ok: true, data: { ...read2.data, activeTrialCount } }, 200);
     }
 
+    trackEvent('totalUsers', 'newUsers')
     return jsonWithNoStore({ ok: true, data: { ...created.data, activeTrialCount } }, 200);
   });
 }

--- a/app/api/practice/route.ts
+++ b/app/api/practice/route.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto'
 import { NextResponse } from 'next/server'
 import { createDynamoClient } from '@/utils/dynamoClient'
 import { withAuth } from '@/utils/authServer'
+import { trackEvent } from '@/utils/metricsClient'
 import { practicesById } from '@/lib/practices/library'
 import {
   TRIAL_DURATION_DAYS,
@@ -125,6 +126,7 @@ export async function POST(req: Request) {
         expiresAt,
       }
       await client.putItem(trial)
+      trackEvent('totalTrials', 'trials')
       return NextResponse.json({ trial }, { status: 201 })
     }
 
@@ -223,6 +225,7 @@ export async function POST(req: Request) {
           },
         }),
       ])
+      trackEvent('totalPromotions')
       return NextResponse.json(
         { practiceId, warning: capCheck.allowed && capCheck.warning ? capCheck.warning : undefined },
         { status: 201 }

--- a/app/api/return/route.ts
+++ b/app/api/return/route.ts
@@ -17,6 +17,7 @@ import {
   makeMilestoneSK,
   type NewMilestone,
 } from '@/lib/milestones/milestones'
+import { trackEvent } from '@/utils/metricsClient'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -80,6 +81,11 @@ export async function POST(req: Request) {
     // No-op if value unchanged
     if (existing && delta === 0) {
       return NextResponse.json({ ok: true, noop: true, didIt, date: returnDate, newMilestones: [] }, { status: 200 })
+    }
+
+    // Track new didIt=true returns (net new check-ins only)
+    if (didIt === true && delta > 0) {
+      trackEvent('totalReturns', 'returns')
     }
 
     const now = new Date().toISOString()

--- a/components/AppChrome.tsx
+++ b/components/AppChrome.tsx
@@ -15,6 +15,7 @@ function shouldUseAppShell(pathname: string | null) {
   if (pathname === "/contact") return false;
   if (pathname === "/disclaimer") return false;
   if (pathname === "/faq") return false;
+  if (pathname.startsWith("/admin")) return false;
   if (pathname.startsWith("/payment")) return false;
   return true;
 }

--- a/docs/operations/analytics-privacy-boundaries.md
+++ b/docs/operations/analytics-privacy-boundaries.md
@@ -1,0 +1,57 @@
+# Analytics Privacy Boundaries
+
+FIApp v1 collects only aggregate, non-personal metrics. This document defines exactly what is and is not tracked.
+
+---
+
+## Allowed — aggregate counters only
+
+| Field | What it counts | Where stored |
+|---|---|---|
+| `totalUsers` | Total profiles ever created | `METRICS#TOTALS` |
+| `totalAssessments` | Total assessments submitted | `METRICS#TOTALS` |
+| `totalTrials` | Total trial practices started | `METRICS#TOTALS` |
+| `totalPromotions` | Total trials promoted to active | `METRICS#TOTALS` |
+| `totalReturns` | Total `didIt=true` returns logged | `METRICS#TOTALS` |
+| `pillarFocus_<pillar>` | Count of times each pillar was selected as focus | `METRICS#TOTALS` |
+| `DAILY#<date>.*` | Per-day counts of the above events | `METRICS#DAILY#<date>` |
+
+All fields are counters. No user IDs, emails, or identifiers are stored alongside metrics.
+
+---
+
+## Forbidden — never tracked
+
+- Individual user identifiers linked to any metric
+- Assessment answers (individual yes/no responses)
+- Which specific practice a user chose
+- Which user belongs to which pillar focus
+- Session data, device fingerprints, IP addresses
+- Any field that could re-identify a user
+
+---
+
+## Event model
+
+Events are fired fire-and-forget via `utils/metricsClient.ts`. They never block a request and never throw to the caller. A metrics write failure has zero impact on the user experience.
+
+| Event | Trigger | Fields incremented |
+|---|---|---|
+| `signup` | New profile created in `GET /api/me` | `totalUsers`, daily `newUsers` |
+| `assessment_completed` | `POST /api/assessment` success | `totalAssessments`, daily `assessments`, `pillarFocus_<pillar>` |
+| `trial_started` | `POST /api/practice` mode=startTrial success | `totalTrials`, daily `trials` |
+| `trial_promoted` | `POST /api/practice` mode=promoteTrial success | `totalPromotions` |
+| `return_logged` | `POST /api/return` with `didIt=true` and `delta > 0` | `totalReturns`, daily `returns` |
+
+---
+
+## Data retention
+
+- `METRICS#TOTALS` — no expiry, permanent running totals
+- `METRICS#DAILY#<date>` — TTL of 90 days set on write
+
+---
+
+## Access
+
+Metrics are only accessible via `GET /api/admin/metrics`, which requires the caller's Cognito `userId` to match the `FIAPP_ADMIN_USER_ID` environment variable. No metrics data is exposed to regular authenticated users.

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -1,0 +1,109 @@
+# FIApp v1 Operations Runbook
+
+---
+
+## Production smoke routine
+
+Run after every deploy to verify the app is working.
+
+### 1. Health check
+```
+GET https://app.friendsintelligence.net/api/health
+```
+Expected: `{ "ok": true, "checks": { "dynamodb": "ok" } }` with HTTP 200.
+If `ok: false` or HTTP 503 — DynamoDB is unreachable. Check AWS Console → DynamoDB → Tables.
+
+### 2. Landing page
+- Open `https://friendsintelligence.net`
+- Page loads, hero text visible, CTA buttons present
+
+### 3. Auth flow
+- Open `/auth`
+- Sign in with a test account
+- Should redirect to `/today` or `/assessment` depending on account state
+
+### 4. Assessment
+- Navigate to `/assessment`
+- Answer a few questions, confirm progress bar advances
+- Submit — should redirect to `/results`
+
+### 5. Today page
+- Navigate to `/today`
+- Focus practice card visible
+- Tap "Did it" — button fills, count increments
+
+### 6. Admin dashboard
+- Navigate to `/admin`
+- Funnel numbers visible, charts render
+- If 403 — `FIAPP_ADMIN_USER_ID` env var not set or wrong userId
+
+---
+
+## Incident response checklist
+
+### App is down / health check fails
+1. Check `GET /api/health` — note which check failed
+2. AWS Console → Amplify → your app → check latest deployment status
+3. AWS Console → DynamoDB → FIAPP_MAIN → check table status
+4. AWS Console → CloudWatch → Log groups → `/aws/amplify/` → scan for errors
+5. If recent deploy — roll back via Amplify Console → Deployments → Redeploy previous
+
+### Users can't sign in
+1. AWS Console → Cognito → User Pools → check pool status
+2. Check Amplify env vars: `NEXT_PUBLIC_AMPLIFY_*` configured correctly
+3. Check CloudWatch logs for `[withAuth]` errors
+
+### Payments not working
+1. Check Stripe Dashboard → Webhooks → recent events — look for failed deliveries
+2. Verify `FIAPP_STRIPE_WEBHOOK_SECRET` env var in Amplify matches Stripe webhook secret
+3. Verify `FIAPP_STRIPE_PRICE_ID` matches the active price in Stripe
+4. CloudWatch logs for `/api/payment/webhook` errors
+
+### DynamoDB errors in logs
+1. Check IAM role attached to Amplify Lambda has `dynamodb:GetItem`, `PutItem`, `UpdateItem`, `Query` on both tables
+2. Check table names match env vars `FIAPP_MAIN_TABLE`, `FIAPP_RETURNS_TABLE`
+
+---
+
+## Rollback procedure
+
+1. AWS Console → Amplify → your app → Hosting → Deployments
+2. Find the last known-good deployment
+3. Click "Redeploy this version"
+4. Run smoke routine to verify
+
+---
+
+## Environment variables (Amplify)
+
+| Variable | Purpose |
+|---|---|
+| `FIAPP_MAIN_TABLE` | DynamoDB main table name |
+| `FIAPP_RETURNS_TABLE` | DynamoDB returns table name |
+| `FIAPP_AWS_ACCESS_KEY_ID` | AWS credentials for DynamoDB |
+| `FIAPP_AWS_SECRET_ACCESS_KEY` | AWS credentials for DynamoDB |
+| `FIAPP_AWS_REGION` | AWS region |
+| `FIAPP_STRIPE_SECRET_KEY` | Stripe secret key |
+| `FIAPP_STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret |
+| `FIAPP_STRIPE_PRICE_ID` | Stripe price ID for Plus plan |
+| `FIAPP_ADMIN_USER_ID` | Cognito userId of the operator (for /admin access) |
+| `NEXT_PUBLIC_FIAPP_APP_URL` | Public app URL |
+
+---
+
+## CloudWatch log access
+
+1. AWS Console → CloudWatch → Log groups
+2. Look for `/aws/amplify/<app-id>` or `/aws/lambda/`
+3. Key patterns to search:
+   - `[withAuth] handler error` — unhandled API errors
+   - `[metrics]` — metrics write failures (non-critical)
+   - `[GET /api/me]` — profile creation errors
+   - `ERROR` — any Lambda error
+
+---
+
+## Post-launch feedback
+
+Users can email `hello@friendsintelligence.net` for support or feedback.  
+Monitor inbox after launch. First 48 hours are highest signal — respond to every email.

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,6 +9,7 @@ const PROTECTED_PREFIXES = [
   '/assessment',
   '/progress',
   '/account',
+  '/admin',
   '/decideRoute',
 ]
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -14,5 +14,6 @@ Disallow: /progress
 Disallow: /account
 Disallow: /assessment
 Disallow: /decideRoute
+Disallow: /admin
 Disallow: /api/
 Disallow: /payment/

--- a/utils/metricsClient.ts
+++ b/utils/metricsClient.ts
@@ -1,0 +1,125 @@
+import { createDynamoClient } from './dynamoClient'
+
+const PK = 'METRICS'
+const TOTALS_SK = 'TOTALS'
+
+function todayUTC() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function ttl90Days() {
+  return Math.floor(Date.now() / 1000) + 90 * 86400
+}
+
+/**
+ * Atomically increment a total counter and optionally a daily counter.
+ * Fire-and-forget — never throws, never blocks the calling route.
+ */
+export function trackEvent(
+  totalField: string,
+  dailyField?: string,
+  by = 1
+): void {
+  const client = createDynamoClient()
+  const now = new Date().toISOString()
+  const today = todayUTC()
+
+  // Totals
+  client
+    .updateItem({
+      Key: { PK, SK: TOTALS_SK },
+      UpdateExpression: 'ADD #f :n SET updatedAt = :now',
+      ExpressionAttributeNames: { '#f': totalField },
+      ExpressionAttributeValues: { ':n': by, ':now': now },
+    })
+    .catch((e) => console.error('[metrics] totals update failed:', e))
+
+  // Daily
+  if (dailyField) {
+    client
+      .updateItem({
+        Key: { PK, SK: `DAILY#${today}` },
+        UpdateExpression: 'ADD #f :n SET #d = :date, #ttl = :ttl',
+        ExpressionAttributeNames: { '#f': dailyField, '#d': 'date', '#ttl': 'ttl' },
+        ExpressionAttributeValues: {
+          ':n': by,
+          ':date': today,
+          ':ttl': ttl90Days(),
+        },
+      })
+      .catch((e) => console.error('[metrics] daily update failed:', e))
+  }
+}
+
+/**
+ * Increment the focus pillar counter when an assessment is completed.
+ * Stored as top-level fields: pillarFocus_financial, pillarFocus_sleep, etc.
+ */
+export function trackPillarFocus(pillar: string): void {
+  const client = createDynamoClient()
+  const field = `pillarFocus_${pillar}`
+  client
+    .updateItem({
+      Key: { PK, SK: TOTALS_SK },
+      UpdateExpression: 'ADD #f :n SET updatedAt = :now',
+      ExpressionAttributeNames: { '#f': field },
+      ExpressionAttributeValues: { ':n': 1, ':now': new Date().toISOString() },
+    })
+    .catch((e) => console.error('[metrics] pillar focus update failed:', e))
+}
+
+export type MetricsTotals = {
+  totalUsers?: number
+  totalAssessments?: number
+  totalReturns?: number
+  totalTrials?: number
+  totalPromotions?: number
+  pillarFocus_financial?: number
+  pillarFocus_relationship?: number
+  pillarFocus_information?: number
+  pillarFocus_emotional?: number
+  pillarFocus_nutrition?: number
+  pillarFocus_dynamic?: number
+  pillarFocus_sleep?: number
+  updatedAt?: string
+}
+
+export type MetricsDaily = {
+  date: string
+  newUsers?: number
+  assessments?: number
+  returns?: number
+  trials?: number
+}
+
+export async function getMetricsTotals(): Promise<MetricsTotals> {
+  const client = createDynamoClient()
+  const item = await client.getItem<MetricsTotals>({ PK, SK: TOTALS_SK })
+  return item ?? {}
+}
+
+export async function getMetricsDaily(days = 30): Promise<MetricsDaily[]> {
+  const client = createDynamoClient()
+
+  // Build list of last N dates
+  const dates: string[] = []
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date()
+    d.setUTCDate(d.getUTCDate() - i)
+    dates.push(d.toISOString().slice(0, 10))
+  }
+
+  const oldest = dates[0]
+  const items = await client.query<MetricsDaily>({
+    KeyConditionExpression: 'PK = :pk AND SK BETWEEN :from AND :to',
+    ExpressionAttributeValues: {
+      ':pk': PK,
+      ':from': `DAILY#${oldest}`,
+      ':to': `DAILY#9999`,
+    },
+  })
+
+  // Merge query results with the full date list so gaps show as zero
+  const byDate = new Map(items.map((i) => [i.date, i]))
+  return dates.map((d) => byDate.get(d) ?? { date: d })
+}


### PR DESCRIPTION
Closes #283

## What's in this PR

### Health check
- `GET /api/health` — pings DynamoDB and returns `{ ok, latencyMs, checks }`. HTTP 200 when healthy, 503 when DynamoDB is unreachable.

### Metrics tracking
- `utils/metricsClient.ts` — fire-and-forget atomic DynamoDB counter utility. Never blocks requests, never throws to callers.
- Tracks **totals**: users, assessments, trials, promotions, returns, per-pillar focus distribution
- Tracks **daily snapshots** with 90-day TTL: `METRICS#DAILY#<date>`
- Wired into `/api/me` (signup), `/api/assessment`, `/api/return`, `/api/practice` (trial + promotion)

### Operator dashboard
- `GET /api/admin/metrics` — owner-only endpoint guarded by `FIAPP_ADMIN_USER_ID` env var
- `/admin` page — funnel stats (all-time), 30-day bar charts for returns + assessments, pillar focus distribution

### Operations docs
- `docs/operations/analytics-privacy-boundaries.md` — what is/isn't tracked, event model, retention
- `docs/operations/runbook.md` — smoke routine, incident response checklist, rollback procedure, env var reference

## Setup required
Add `FIAPP_ADMIN_USER_ID` to Amplify environment variables. Value = your Cognito `userId` (visible in the Amplify auth console or from `GET /api/dev/whoami` on a dev build).

## Test plan
- [ ] `GET /api/health` returns `{ ok: true }` in production
- [ ] Complete an assessment — check `/admin` totals increment
- [ ] Log a return — check `/admin` daily chart updates
- [ ] `/admin` returns 403 for a non-owner user
- [ ] `/admin` is blocked by middleware for unauthenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)