### PR TITLE
fix: timezone is a DynamoDB reserved keyword in PATCH /api/me

### DIFF
--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -147,7 +147,8 @@ export async function PATCH(req: Request) {
     const client = createDynamoClient()
     await client.updateItem({
       Key: { PK: `USER#${user.userId}`, SK: "PROFILE" },
-      UpdateExpression: `SET ${keys.map((k, i) => `${k} = :v${i}`).join(", ")}`,
+      UpdateExpression: `SET ${keys.map((k, i) => `#a${i} = :v${i}`).join(", ")}`,
+      ExpressionAttributeNames: Object.fromEntries(keys.map((k, i) => [`#a${i}`, k])),
       ExpressionAttributeValues: Object.fromEntries(keys.map((k, i) => [`:v${i}`, updates[k]])),
     })
 

--- a/tests/unit/api/me.test.ts
+++ b/tests/unit/api/me.test.ts
@@ -172,7 +172,7 @@ describe('PATCH /api/me', () => {
     expect((await res.json()).ok).toBe(true)
     expect(updateItemMock).toHaveBeenCalledOnce()
     const call = updateItemMock.mock.calls[0][0]
-    expect(call.UpdateExpression).toContain('timezone')
+    expect(Object.values(call.ExpressionAttributeNames)).toContain('timezone')
     expect(Object.values(call.ExpressionAttributeValues)).toContain('America/New_York')
   })
 
@@ -181,7 +181,7 @@ describe('PATCH /api/me', () => {
     expect(res.status).toBe(200)
     expect(updateItemMock).toHaveBeenCalledOnce()
     const call = updateItemMock.mock.calls[0][0]
-    expect(call.UpdateExpression).toContain('dayResetTime')
+    expect(Object.values(call.ExpressionAttributeNames)).toContain('dayResetTime')
     expect(Object.values(call.ExpressionAttributeValues)).toContain(180)
   })
 
@@ -190,8 +190,8 @@ describe('PATCH /api/me', () => {
     expect(res.status).toBe(200)
     expect(updateItemMock).toHaveBeenCalledOnce()
     const call = updateItemMock.mock.calls[0][0]
-    expect(call.UpdateExpression).toContain('timezone')
-    expect(call.UpdateExpression).toContain('dayResetTime')
+    expect(Object.values(call.ExpressionAttributeNames)).toContain('timezone')
+    expect(Object.values(call.ExpressionAttributeNames)).toContain('dayResetTime')
   })
 
   it('returns 200 without calling updateItem when body is empty', async () => {


### PR DESCRIPTION
## Summary
`timezone` is a DynamoDB reserved keyword — using it directly in `UpdateExpression` throws `ValidationException`. Fixed by aliasing all attribute names with `ExpressionAttributeNames` (#a0, #a1, etc.).

Updated tests to assert on `ExpressionAttributeNames` values instead of `UpdateExpression` string contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)