### PR TITLE
feat: staging environment — branch-scoped DynamoDB tables

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -4,14 +4,7 @@ backend:
     build:
       commands:
         - npm ci --cache .npm --prefer-offline
-        - |
-          CHANGED=$(git diff --name-only HEAD^1 HEAD 2>/dev/null || git show --name-only --format="" HEAD)
-          if echo "$CHANGED" | grep -q '^amplify/'; then
-            echo "amplify/ changed — deploying backend"
-            npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
-          else
-            echo "No amplify/ changes — skipping backend deploy"
-          fi
+        - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:
     preBuild:
@@ -20,6 +13,15 @@ frontend:
     build:
       commands:
         - env | grep -e FIAPP_ >> .env.production
+        - |
+          if [ "$AWS_BRANCH" = "main" ]; then
+            echo "FIAPP_MAIN_TABLE=FIAPP_MAIN" >> .env.production
+            echo "FIAPP_RETURNS_TABLE=FIAPP_RETURNS" >> .env.production
+          else
+            BRANCH_UPPER=$(echo "$AWS_BRANCH" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+            echo "FIAPP_MAIN_TABLE=FIAPP_MAIN_${BRANCH_UPPER}" >> .env.production
+            echo "FIAPP_RETURNS_TABLE=FIAPP_RETURNS_${BRANCH_UPPER}" >> .env.production
+          fi
         - NEXT_TELEMETRY_DISABLED=1 npm run build
   artifacts:
     baseDirectory: .next

--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -11,20 +11,29 @@ export const backend = defineBackend({
 
 const externalDataSourcesStack = backend.createStack("FIAppExternalDataSources");
 
-// FIAPP_MAIN was created by the sandbox stack — import it so the production stack
-// references the existing table instead of trying to create a duplicate.
-const fiappMainTable = aws_dynamodb.Table.fromTableName(
-  externalDataSourcesStack,
-  "FIAPP_MAIN",
-  "FIAPP_MAIN"
-);
+const branch = process.env.AWS_BRANCH ?? "main";
+const isProduction = branch === "main";
+const mainTableName = isProduction ? "FIAPP_MAIN" : `FIAPP_MAIN_${branch.toUpperCase()}`;
+const returnsTableName = isProduction ? "FIAPP_RETURNS" : `FIAPP_RETURNS_${branch.toUpperCase()}`;
+
+// Production: import the existing table (created by the original sandbox stack).
+// All other branches: create a fresh table scoped to that branch.
+const fiappMainTable = isProduction
+  ? aws_dynamodb.Table.fromTableName(externalDataSourcesStack, "FIAPP_MAIN", mainTableName)
+  : new aws_dynamodb.Table(externalDataSourcesStack, "FIAPP_MAIN", {
+      tableName: mainTableName,
+      partitionKey: { name: "PK", type: aws_dynamodb.AttributeType.STRING },
+      sortKey: { name: "SK", type: aws_dynamodb.AttributeType.STRING },
+      billingMode: aws_dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: RemovalPolicy.RETAIN,
+    });
 
 // IMPORTANT: This string is the DataSource name your schema must reference
 backend.data.addDynamoDbDataSource("FIAppMainDataSource", fiappMainTable);
 
-// Returns table — created and owned by the production pipeline.
+// Returns table — always owned by the pipeline; scoped by branch on non-production.
 new aws_dynamodb.Table(externalDataSourcesStack, "FIAPP_RETURNS", {
-  tableName: "FIAPP_RETURNS",
+  tableName: returnsTableName,
   partitionKey: { name: "PK", type: aws_dynamodb.AttributeType.STRING },
   sortKey: { name: "SK", type: aws_dynamodb.AttributeType.STRING },
   billingMode: aws_dynamodb.BillingMode.PAY_PER_REQUEST,

--- a/infra/cloudwatch-staging.yml
+++ b/infra/cloudwatch-staging.yml
@@ -1,0 +1,103 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: FIApp staging monitoring — metric filters and CloudWatch dashboard
+
+Parameters:
+  AmplifyAppId:
+    Type: String
+    Default: d3nyg9qvz1tj5n
+    Description: Amplify app ID (same app as production, different branch)
+
+Resources:
+
+  # ── Metric Filters ──────────────────────────────────────────────────────────
+
+  APIErrorFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub /aws/amplify/${AmplifyAppId}
+      FilterPattern: '"[withAuth] handler error"'
+      MetricTransformations:
+        - MetricName: APIErrors
+          MetricNamespace: FIApp-Staging
+          MetricValue: "1"
+          DefaultValue: 0
+
+  AllErrorFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub /aws/amplify/${AmplifyAppId}
+      FilterPattern: "ERROR"
+      MetricTransformations:
+        - MetricName: AllErrors
+          MetricNamespace: FIApp-Staging
+          MetricValue: "1"
+          DefaultValue: 0
+
+  AuthErrorFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Sub /aws/amplify/${AmplifyAppId}
+      FilterPattern: '"UNAUTHORIZED" OR "NoSignedUser"'
+      MetricTransformations:
+        - MetricName: AuthErrors
+          MetricNamespace: FIApp-Staging
+          MetricValue: "1"
+          DefaultValue: 0
+
+  # ── Dashboard ───────────────────────────────────────────────────────────────
+
+  Dashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: FIApp-Staging
+      DashboardBody: !Sub |
+        {
+          "widgets": [
+            {
+              "type": "metric",
+              "x": 0, "y": 0, "width": 8, "height": 6,
+              "properties": {
+                "title": "API Errors (5-min)",
+                "metrics": [["FIApp-Staging", "APIErrors"]],
+                "stat": "Sum",
+                "period": 300,
+                "view": "timeSeries",
+                "region": "ap-southeast-2"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 8, "y": 0, "width": 8, "height": 6,
+              "properties": {
+                "title": "Auth Errors (5-min)",
+                "metrics": [["FIApp-Staging", "AuthErrors"]],
+                "stat": "Sum",
+                "period": 300,
+                "view": "timeSeries",
+                "region": "ap-southeast-2"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 16, "y": 0, "width": 8, "height": 6,
+              "properties": {
+                "title": "All Errors (5-min)",
+                "metrics": [["FIApp-Staging", "AllErrors"]],
+                "stat": "Sum",
+                "period": 300,
+                "view": "timeSeries",
+                "region": "ap-southeast-2"
+              }
+            },
+            {
+              "type": "log",
+              "x": 0, "y": 6, "width": 24, "height": 8,
+              "properties": {
+                "title": "Recent API Errors",
+                "query": "SOURCE '/aws/amplify/${AmplifyAppId}' | fields @timestamp, @message | filter @message like /withAuth/ | sort @timestamp desc | limit 25",
+                "region": "ap-southeast-2",
+                "view": "table"
+              }
+            }
+          ]
+        }


### PR DESCRIPTION
## Summary

- **amplify/backend.ts**: non-production branches now CREATE their own `FIAPP_MAIN_<BRANCH>` and `FIAPP_RETURNS_<BRANCH>` DynamoDB tables (with `RemovalPolicy.RETAIN`). Production branch continues to import the existing `FIAPP_MAIN` table unchanged.
- **amplify.yml**: simplified backend phase to always run `pipeline-deploy` (CDK detects no-ops, so this adds only seconds when nothing changed, but guarantees `amplify_outputs.json` is always generated). Frontend phase now injects branch-derived `FIAPP_MAIN_TABLE` / `FIAPP_RETURNS_TABLE` into `.env.production` at build time.
- **infra/cloudwatch-staging.yml**: new CloudWatch stack for staging — metric filters under the `FIApp-Staging` namespace and a dashboard. No email alerts (staging isn't monitored 24/7).

## What's next (manual steps after merging)

1. Connect `staging` branch in Amplify console → Branch deployments
2. Set env vars in Amplify console **for staging branch only**: copy all `FIAPP_AWS_*` vars from production (table name vars are derived automatically from branch name)
3. Trigger first staging deploy and verify it succeeds
4. Deploy staging CloudWatch stack:
   ```sh
   aws cloudformation deploy \
     --template-file infra/cloudwatch-staging.yml \
     --stack-name fiapp-monitoring-staging \
     --region ap-southeast-2
   ```
5. Register `qianhaopower+e2etest@gmail.com` in staging Cognito
6. Run E2E against staging: `BASE_URL=https://staging.your-domain.com npm run test:e2e`

## Test plan

- [ ] Production branch deploy unaffected (`AWS_BRANCH=main` still imports existing table)
- [ ] Staging branch deploy creates `FIAPP_MAIN_STAGING` and `FIAPP_RETURNS_STAGING` tables
- [ ] `.env.production` contains correct `FIAPP_MAIN_TABLE=FIAPP_MAIN_STAGING` for staging build
- [ ] CloudWatch staging stack deploys without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)