### PR TITLE
fix: write branch-derived table names before env catch-all in amplify.yml

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -12,7 +12,6 @@ frontend:
         - npm ci --cache .npm --prefer-offline
     build:
       commands:
-        - env | grep -e FIAPP_ >> .env.production
         - |
           if [ "$AWS_BRANCH" = "main" ]; then
             echo "FIAPP_MAIN_TABLE=FIAPP_MAIN" >> .env.production
@@ -22,6 +21,7 @@ frontend:
             echo "FIAPP_MAIN_TABLE=FIAPP_MAIN_${BRANCH_UPPER}" >> .env.production
             echo "FIAPP_RETURNS_TABLE=FIAPP_RETURNS_${BRANCH_UPPER}" >> .env.production
           fi
+        - env | grep -e FIAPP_ >> .env.production
         - NEXT_TELEMETRY_DISABLED=1 npm run build
   artifacts:
     baseDirectory: .next


### PR DESCRIPTION
Dotenv is first-value-wins. The previous ordering wrote `FIAPP_MAIN_TABLE` / `FIAPP_RETURNS_TABLE` from branch logic *after* the `env | grep -e FIAPP_` catch-all — meaning any console-level env var for those keys would silently win and point staging at the prod tables.

This swaps the order so branch-derived values are always written first and take precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)