### PR TITLE
chore: branch protection guardrails

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -1,0 +1,21 @@
+name: Branch policy
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  staging-only:
+    name: Branch policy — staging only
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce staging → main only
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "❌ PRs to main must come from the staging branch."
+            echo "   Source branch: ${{ github.head_ref }}"
+            echo ""
+            echo "   Flow: feat/* → PR to staging → test → PR to main"
+            exit 1
+          fi
+          echo "✅ Source branch is staging — policy satisfied."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, staging ]
   push:
-    branches: [ main ]
+    branches: [ main, staging ]
 
 jobs:
   unit:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,26 @@
 # FIApp v1 — Claude Code Instructions
 
+## Branching strategy — HARD RULES
+
+**NEVER merge a PR.** The user merges all PRs manually from the GitHub web UI. Do not run
+`gh pr merge`, `git merge`, or any equivalent. If the user asks you to merge, remind them
+to do it from the GitHub UI.
+
+**NEVER push directly to `main` or `staging`.** All changes go through a PR.
+
+**Only `staging` may merge into `main`.** Feature branches merge to `staging` first.
+This is enforced by the `Branch policy` CI check — do not attempt to bypass it.
+
+**Branching flow:**
+```
+feat/* branch  →  PR to staging  →  test on staging URL  →  PR to main  →  production
+```
+
+After merging a feature to `main`, sync staging back up:
+```
+git checkout staging && git merge main && git push origin staging
+```
+
 ## E2E tests (Layer 3) — SAFETY RULES
 
 **NEVER run `npm run test:e2e` or `npx playwright test` unless one of these is true:**


### PR DESCRIPTION
## What this does

Sets up the guardrails that enforce the branching strategy from here on.

### 1. CLAUDE.md — hard rules for the AI agent
- Never run `gh pr merge` or equivalent
- Never push directly to `main` or `staging`
- Only `staging` may merge into `main`

### 2. Branch policy CI check (`.github/workflows/branch-policy.yml`)
- Runs on every PR targeting `main`
- Fails if the source branch is anything other than `staging`
- This becomes a **required status check** — technically enforces the staging → main rule

### 3. CI on staging (`.github/workflows/ci.yml`)
- Unit, integration, and E2E smoke tests now run on PRs to `staging` too
- Previously only ran on main

## After merging this PR

Set branch protection rules for both branches (one-time console step):

**main:**
- Require PR before merging ✓ (already set)
- Required status checks: `Lint, typecheck & unit tests`, `Integration tests (dynalite)`, `Branch policy — staging only`
- No force pushes, no deletions, enforce for admins

**staging:**
- Require PR before merging
- Required status checks: `Lint, typecheck & unit tests`, `Integration tests (dynalite)`
- No force pushes, no deletions

## Note
This PR targets `main` directly — a one-time exception since we're bootstrapping the policy itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)