### PR TITLE
fix: CloudFormation circular dependency in Pre-Sign-Up Lambda IAM policy

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -3,7 +3,7 @@ import { defineBackend } from "@aws-amplify/backend";
 import { auth } from "./auth/resource";
 import { data } from "./data/resource";
 import { preSignUpTrigger } from "./auth/pre-sign-up-trigger/resource";
-import { aws_dynamodb, aws_iam, RemovalPolicy } from "aws-cdk-lib";
+import { Aws, aws_dynamodb, aws_iam, RemovalPolicy } from "aws-cdk-lib";
 
 export const backend = defineBackend({
   auth,
@@ -53,6 +53,6 @@ backend.preSignUpTrigger.resources.lambda.addToRolePolicy(
       "cognito-idp:ListUsers",
       "cognito-idp:AdminLinkProviderForUser",
     ],
-    resources: [backend.auth.resources.userPool.userPoolArn],
+    resources: [`arn:aws:cognito-idp:${Aws.REGION}:${Aws.ACCOUNT_ID}:userpool/*`],
   })
 );


### PR DESCRIPTION
## Problem

The staging Amplify deploy for PR #342 failed with:

```
[CloudformationStackCircularDependencyError] circular dependency found between nested stacks [auth, data, function]
```

`backend.auth.resources.userPool.userPoolArn` created a CloudFormation cross-stack reference from the **function** stack → **auth** stack. But the auth stack already depends on the function stack for the trigger Lambda ARN — creating a cycle.

## Fix

Replace the specific user pool ARN with `Aws.REGION` and `Aws.ACCOUNT_ID` (CloudFormation pseudo-parameters). These resolve at deploy time without any cross-stack reference, breaking the cycle. The policy is still scoped to `userpool/*` in the correct account and region — the Lambda can only be invoked by Cognito for its own user pool anyway.

## Test plan

- [ ] `npx tsc --noEmit` clean ✅
- [ ] Staging Amplify deploy succeeds
- [ ] Cognito hosted UI domain appears after deploy
- [ ] Google Sign-In works on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)