### PR TITLE
fix: redirect after Google OAuth callback when Authenticator state lags

### DIFF
--- a/components/AuthenticatorWrapper.tsx
+++ b/components/AuthenticatorWrapper.tsx
@@ -4,6 +4,8 @@ import { useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react";
+import { Hub } from "aws-amplify/utils";
+import { getCurrentUser } from "aws-amplify/auth";
 import { ensureAmplifyConfigured } from "@/lib/amplifyClient";
 
 const passwordSettings = {
@@ -66,6 +68,28 @@ function AuthRedirect() {
 
 export default function AuthenticatorWrapper() {
   ensureAmplifyConfigured();
+  const router = useRouter();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getCurrentUser()
+      .then(() => {
+        if (!cancelled) router.replace("/decideRoute");
+      })
+      .catch(() => {});
+
+    const unsubscribe = Hub.listen("auth", ({ payload }) => {
+      if (payload.event === "signedIn" || payload.event === "signInWithRedirect") {
+        router.replace("/decideRoute");
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [router]);
 
   return (
     <div className="min-h-screen bg-muted/40 flex items-center justify-center px-4 py-10">


### PR DESCRIPTION
## Summary
- Amplify v6 SSR mode + Google OAuth leaves users stuck on `/auth` after the code exchange — tokens are written to cookies but `useAuthenticator`'s render-prop `user` value doesn't update
- Add a mount-time `getCurrentUser()` check on `/auth` that redirects to `/decideRoute` as soon as a valid session is detected
- Add a `Hub` listener for `signedIn` / `signInWithRedirect` events as a backup for any timing race during OAuth code exchange

## Test plan
- [ ] On staging: click "Sign in with Google", select Google account, verify redirect lands on `/decideRoute` (not stuck on `/auth`)
- [ ] On staging: email/password sign-in still works
- [ ] On staging: visiting `/auth` while already signed in auto-redirects to `/decideRoute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)