### PR TITLE
fix: show real email for Google federated users instead of google_<sub>

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -7,12 +7,12 @@ import { Card, Button } from '@/components/ui';
 import { useProfile } from '@/contexts/ProfileContext';
 import { getPlanLabel } from '@/lib/plans';
 import { UpgradeButton } from '@/components/UpgradeButton';
+import { useUserEmail } from '@/lib/useUserEmail';
 
 export default function AccountPage() {
-  const { user, signOut } = useAuthenticator((ctx) => [ctx.user, ctx.signOut])
+  const { signOut } = useAuthenticator((ctx) => [ctx.signOut])
   const { profile } = useProfile()
-
-  const email = user?.signInDetails?.loginId ?? user?.username ?? '—'
+  const email = useUserEmail() || '—'
   const plan = getPlanLabel(profile?.subscriptionStatus)
 
   async function handleSignOut() {

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -3,13 +3,13 @@
 import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { useAuthenticator } from '@aws-amplify/ui-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui'
 import { PlanBadge } from '@/components/PlanBadge'
 import { DevSubscriptionToggle } from '@/components/DevSubscriptionToggle'
 import { useProfile } from '@/contexts/ProfileContext'
 import { getPlanLabel, isPlusPlan } from '@/lib/plans'
+import { useUserEmail } from '@/lib/useUserEmail'
 
 interface AppShellProps {
   children: React.ReactNode
@@ -48,10 +48,8 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
     }
   }
   const accountRef = useRef<HTMLDivElement>(null)
-  const { user } = useAuthenticator((ctx) => [ctx.user])
   const { profile } = useProfile()
-
-  const email = user?.signInDetails?.loginId ?? user?.username ?? ''
+  const email = useUserEmail()
   const planLabel = getPlanLabel(profile?.subscriptionStatus)
 
   useEffect(() => {

--- a/lib/useUserEmail.ts
+++ b/lib/useUserEmail.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuthenticator } from "@aws-amplify/ui-react";
+import { fetchUserAttributes } from "aws-amplify/auth";
+
+export function useUserEmail(): string {
+  const { user } = useAuthenticator((ctx) => [ctx.user]);
+  const [email, setEmail] = useState<string>("");
+
+  useEffect(() => {
+    if (!user) {
+      setEmail("");
+      return;
+    }
+    let cancelled = false;
+    fetchUserAttributes()
+      .then((attrs) => {
+        if (!cancelled && attrs.email) setEmail(attrs.email);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  const fallback = user?.signInDetails?.loginId ?? "";
+  const username = user?.username ?? "";
+  const isFederatedUsername = username.includes("_") && /^[a-z]+_[a-zA-Z0-9-]+$/.test(username);
+  return email || fallback || (isFederatedUsername ? "" : username);
+}


### PR DESCRIPTION
## Summary
- Account dropdown and `/account` page were showing the raw Cognito username (`google_103586511618624778544`) for Google-federated users instead of their email
- Add a `useUserEmail` hook that reads the `email` attribute via `fetchUserAttributes()` — this works uniformly for both email/password and Google-federated users since the email attribute is mapped from the Google profile

## Test plan
- [ ] Sign in with Google on staging → account dropdown shows real email, not `google_<sub>`
- [ ] `/account` page shows real email
- [ ] Existing email/password users still see their email correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)