### PR TITLE
fix: fall back to ID token email claim when fetchUserAttributes is empty

### DIFF
--- a/lib/useUserEmail.ts
+++ b/lib/useUserEmail.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useAuthenticator } from "@aws-amplify/ui-react";
-import { fetchUserAttributes } from "aws-amplify/auth";
+import { fetchAuthSession, fetchUserAttributes } from "aws-amplify/auth";
 
 export function useUserEmail(): string {
   const { user } = useAuthenticator((ctx) => [ctx.user]);
@@ -14,18 +14,32 @@ export function useUserEmail(): string {
       return;
     }
     let cancelled = false;
-    fetchUserAttributes()
-      .then((attrs) => {
-        if (!cancelled && attrs.email) setEmail(attrs.email);
-      })
-      .catch(() => {});
+
+    (async () => {
+      try {
+        const attrs = await fetchUserAttributes();
+        if (!cancelled && attrs.email) {
+          setEmail(attrs.email);
+          return;
+        }
+      } catch {}
+
+      try {
+        const session = await fetchAuthSession();
+        const claim = session.tokens?.idToken?.payload?.email;
+        if (!cancelled && typeof claim === "string" && claim) {
+          setEmail(claim);
+        }
+      } catch {}
+    })();
+
     return () => {
       cancelled = true;
     };
   }, [user]);
 
-  const fallback = user?.signInDetails?.loginId ?? "";
+  const loginId = user?.signInDetails?.loginId ?? "";
   const username = user?.username ?? "";
-  const isFederatedUsername = username.includes("_") && /^[a-z]+_[a-zA-Z0-9-]+$/.test(username);
-  return email || fallback || (isFederatedUsername ? "" : username);
+  const isFederatedUsername = /^[a-z]+_[a-zA-Z0-9-]+$/.test(username);
+  return email || loginId || (isFederatedUsername ? "" : username);
 }


### PR DESCRIPTION
## Summary
After Google account linking, signing in with email/password leaves the account section blank because:
- `fetchUserAttributes()` returns no email in this state
- `signInDetails.loginId` is undefined for the linked-account password flow
- The hook falls through to a federated-username check that returns ""

## Fix
Add a second fallback that reads the `email` claim directly from the ID token via `fetchAuthSession()`. The claim is always populated for both Cognito-native and Google-federated users.

## Test plan
- [ ] Staging: sign in with email/password on an account that has been linked to Google → account section shows email
- [ ] Staging: sign in with Google on a linked account → account section shows email
- [ ] Staging: sign in with email/password on an unlinked account → account section shows email
- [ ] After staging→main merge, verify the same on production with `qianhaopower@gmail.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)