### PR TITLE
docs: add as-built reference for Google Sign-In feature

### DIFF
--- a/_docs/google-login.md
+++ b/_docs/google-login.md
@@ -331,9 +331,9 @@ in Google must be `https://<that-domain>/oauth2/idpresponse`.
 **To find the domain**:
 - AWS Console → Cognito → User pools → click the pool → **App integration** tab → scroll to **Domain**
 
-**Domains seen so far**:
+**Domains in use**:
 - staging: `859e9affd7cfe5c6d721.auth.ap-southeast-2.amazoncognito.com`
-- production: (look it up — need to add to this doc)
+- production: `f231c36ec852fd5dd1f2.auth.ap-southeast-2.amazoncognito.com`
 
 ### Pre-Sign-Up Lambda
 - Created by Amplify Gen 2 from `amplify/auth/pre-sign-up-trigger/resource.ts`
@@ -366,7 +366,7 @@ The values were entered manually by the user via Amplify Secret Manager.
 **Critical**: must include `/oauth2/idpresponse` (the path that Cognito's
 hosted UI listens on for the OAuth callback).
 - `https://859e9affd7cfe5c6d721.auth.ap-southeast-2.amazoncognito.com/oauth2/idpresponse` (staging)
-- `https://<prod-cognito-domain>/oauth2/idpresponse` (production — fill in after looking up)
+- `https://f231c36ec852fd5dd1f2.auth.ap-southeast-2.amazoncognito.com/oauth2/idpresponse` (production)
 
 If a user gets `redirect_uri_mismatch` from Google, this is what's wrong — the
 Cognito domain wasn't added to Google.


### PR DESCRIPTION
## Summary
- Captures the full context of today's Google Sign-In rollout in a single doc at `_docs/google-login.md`
- Includes architecture overview, end-to-end flows for all 4 sign-in scenarios, file-by-file change log, AWS + Google config notes, and a detailed war-stories section
- Companion to the existing `_docs/plans/google-login.md` (the original planning doc) — this new doc is the as-built reference

## Why
After this Claude Code session ends, the conversation context is gone. This doc preserves the WHY behind decisions (circular dep workaround, defensive Hub listener, three-layer email fallback) so future-you doesn't have to rediscover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)