### PR TITLE
Support branded Cognito OAuth domain

### DIFF
--- a/_docs/google-login.md
+++ b/_docs/google-login.md
@@ -335,6 +335,40 @@ in Google must be `https://<that-domain>/oauth2/idpresponse`.
 - staging: `859e9affd7cfe5c6d721.auth.ap-southeast-2.amazoncognito.com`
 - production: `f231c36ec852fd5dd1f2.auth.ap-southeast-2.amazoncognito.com`
 
+### Google sign-in branding/domain text
+
+Google can show the Cognito Hosted UI domain on the account chooser:
+`to continue to f231c36ec852fd5dd1f2.auth.ap-southeast-2.amazoncognito.com`.
+That text is outside our React UI. It comes from the Google OAuth/Cognito
+redirect flow.
+
+Preferred production fix:
+
+1. In Cognito, add a custom user-pool domain such as
+   `auth.friendsintelligence.net`.
+2. In DNS, point that subdomain to the CloudFront alias target that Cognito
+   provides.
+3. In Google Cloud Console, add this authorized redirect URI:
+   `https://auth.friendsintelligence.net/oauth2/idpresponse`.
+4. In Amplify Hosting env vars, set
+   `FIAPP_PROD_COGNITO_OAUTH_DOMAIN=auth.friendsintelligence.net`.
+   The build only exposes this as `NEXT_PUBLIC_COGNITO_OAUTH_DOMAIN` on the
+   `main` branch, so staging won't accidentally use the production Cognito
+   domain.
+5. Redeploy the app so `lib/amplifyConfig.ts` swaps the generated
+   `amazoncognito.com` OAuth domain for the custom domain.
+
+Also check Google Auth Platform branding:
+
+- App name: `Friends Intelligence`
+- Support email: monitored support address
+- App logo, privacy policy, terms links
+- Authorized domain: `friendsintelligence.net`
+
+Google may still show a domain instead of the app name/logo until OAuth app
+branding verification is complete. The custom Cognito domain at least makes the
+domain user-facing and recognizable while verification is pending.
+
 ### Pre-Sign-Up Lambda
 - Created by Amplify Gen 2 from `amplify/auth/pre-sign-up-trigger/resource.ts`
 - Runtime: Node.js 18.x (Amplify default)

--- a/_docs/google-login.md
+++ b/_docs/google-login.md
@@ -342,21 +342,52 @@ Google can show the Cognito Hosted UI domain on the account chooser:
 That text is outside our React UI. It comes from the Google OAuth/Cognito
 redirect flow.
 
-Preferred production fix:
+Production custom domain setup:
 
-1. In Cognito, add a custom user-pool domain such as
-   `auth.friendsintelligence.net`.
-2. In DNS, point that subdomain to the CloudFront alias target that Cognito
-   provides.
-3. In Google Cloud Console, add this authorized redirect URI:
-   `https://auth.friendsintelligence.net/oauth2/idpresponse`.
-4. In Amplify Hosting env vars, set
-   `FIAPP_PROD_COGNITO_OAUTH_DOMAIN=auth.friendsintelligence.net`.
-   The build only exposes this as `NEXT_PUBLIC_COGNITO_OAUTH_DOMAIN` on the
-   `main` branch, so staging won't accidentally use the production Cognito
-   domain.
-5. Redeploy the app so `lib/amplifyConfig.ts` swaps the generated
+1. Create the certificate:
+   - AWS Console -> Certificate Manager
+   - Region must be **US East (N. Virginia) / `us-east-1`**
+   - Request a public certificate for `auth.friendsintelligence.net`
+   - Use DNS validation
+   - If DNS is in Route 53, click **Create records in Route 53**
+   - Wait until the certificate status is **Issued**
+2. Create the Cognito custom domain:
+   - AWS Console -> Cognito
+   - Region: **Asia Pacific (Sydney) / `ap-southeast-2`**
+   - Open the production user pool whose current domain is
+     `f231c36ec852fd5dd1f2.auth.ap-southeast-2.amazoncognito.com`
+   - Go to **Branding -> Domain** or **App integration -> Domain**
+   - Create a custom domain for `auth.friendsintelligence.net`
+   - Select the ACM certificate from step 1
+   - Wait for Cognito to finish creating the domain. AWS says this can take up
+     to 60 minutes.
+3. Create the Route 53 app-domain record:
+   - Hosted zone: `friendsintelligence.net`
+   - Record name: `auth`
+   - Record type: `A`
+   - Alias: enabled
+   - Route traffic to: **Alias to CloudFront distribution**
+   - Target: the CloudFront alias target Cognito provides for the custom domain
+   - Evaluate target health: `No`
+4. Add the Google OAuth redirect URI:
+   - Google Cloud Console -> APIs & Services -> Credentials
+   - Open the OAuth 2.0 Web Client
+   - Add `https://auth.friendsintelligence.net/oauth2/idpresponse`
+   - Do **not** add Amplify env vars here; Google only accepts URLs in this list
+5. Add the Amplify Hosting env var:
+   - AWS Console -> Amplify -> app -> Environment variables
+   - Set `FIAPP_PROD_COGNITO_OAUTH_DOMAIN=auth.friendsintelligence.net`
+   - It is okay if Amplify applies this to all branches. `amplify.yml` only
+     exposes it as `NEXT_PUBLIC_COGNITO_OAUTH_DOMAIN` when
+     `AWS_BRANCH=main`, so staging won't accidentally use the production
+     Cognito domain.
+6. Redeploy the app so `lib/amplifyConfig.ts` swaps the generated
    `amazoncognito.com` OAuth domain for the custom domain.
+7. Test in an incognito browser:
+   - Open `https://friendsintelligence.net/auth`
+   - Click **Sign in with Google**
+   - Google should show either `auth.friendsintelligence.net` or, after Google
+     branding verification, `Friends Intelligence`.
 
 Also check Google Auth Platform branding:
 
@@ -401,6 +432,7 @@ The values were entered manually by the user via Amplify Secret Manager.
 hosted UI listens on for the OAuth callback).
 - `https://859e9affd7cfe5c6d721.auth.ap-southeast-2.amazoncognito.com/oauth2/idpresponse` (staging)
 - `https://f231c36ec852fd5dd1f2.auth.ap-southeast-2.amazoncognito.com/oauth2/idpresponse` (production)
+- `https://auth.friendsintelligence.net/oauth2/idpresponse` (production custom domain)
 
 If a user gets `redirect_uri_mismatch` from Google, this is what's wrong — the
 Cognito domain wasn't added to Google.

--- a/amplify.yml
+++ b/amplify.yml
@@ -21,6 +21,9 @@ frontend:
             echo "FIAPP_MAIN_TABLE=FIAPP_MAIN_${BRANCH_UPPER}" >> .env.production
             echo "FIAPP_RETURNS_TABLE=FIAPP_RETURNS_${BRANCH_UPPER}" >> .env.production
           fi
+          if [ "$AWS_BRANCH" = "main" ] && [ -n "$FIAPP_PROD_COGNITO_OAUTH_DOMAIN" ]; then
+            echo "NEXT_PUBLIC_COGNITO_OAUTH_DOMAIN=$FIAPP_PROD_COGNITO_OAUTH_DOMAIN" >> .env.production
+          fi
         - env | grep -e FIAPP_ >> .env.production
         - NEXT_TELEMETRY_DISABLED=1 npm run build
   artifacts:

--- a/components/ConfigureAmplifyClientSide.tsx
+++ b/components/ConfigureAmplifyClientSide.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { Amplify } from "aws-amplify";
-import outputs from "../amplify_outputs.json";
+import { amplifyOutputs } from "@/lib/amplifyConfig";
 
 let configured = false;
 
 export default function ConfigureAmplifyClientSide() {
   if (!configured) {
-    Amplify.configure(outputs, { ssr: true });
+    Amplify.configure(amplifyOutputs, { ssr: true });
     configured = true;
   }
   return null;

--- a/lib/amplifyClient.ts
+++ b/lib/amplifyClient.ts
@@ -1,10 +1,10 @@
 import { Amplify } from "aws-amplify";
-import outputs from "@/amplify_outputs.json";
+import { amplifyOutputs } from "@/lib/amplifyConfig";
 
 let configured = false;
 
 export function ensureAmplifyConfigured() {
   if (configured) return;
-  Amplify.configure(outputs, { ssr: true });
+  Amplify.configure(amplifyOutputs, { ssr: true });
   configured = true;
 }

--- a/lib/amplifyConfig.ts
+++ b/lib/amplifyConfig.ts
@@ -1,0 +1,45 @@
+import rawOutputs from "@/amplify_outputs.json";
+
+type OAuthConfig = {
+  domain?: string;
+  [key: string]: unknown;
+};
+
+type AmplifyOutputsWithOAuth = typeof rawOutputs & {
+  auth?: (typeof rawOutputs extends { auth: infer Auth } ? Auth : Record<string, unknown>) & {
+    oauth?: OAuthConfig;
+  };
+};
+
+const outputs = rawOutputs as AmplifyOutputsWithOAuth;
+
+function normalizeOAuthDomain(domain: string | undefined) {
+  const trimmed = domain?.trim();
+  if (!trimmed) return undefined;
+
+  return trimmed.replace(/^https?:\/\//, "").replace(/\/.*$/, "");
+}
+
+export function withOAuthDomainOverride(
+  config: AmplifyOutputsWithOAuth,
+  domain = process.env.NEXT_PUBLIC_COGNITO_OAUTH_DOMAIN,
+): typeof rawOutputs {
+  const oauthDomain = normalizeOAuthDomain(domain);
+
+  if (!oauthDomain || !config.auth?.oauth) {
+    return config as typeof rawOutputs;
+  }
+
+  return {
+    ...config,
+    auth: {
+      ...config.auth,
+      oauth: {
+        ...config.auth.oauth,
+        domain: oauthDomain,
+      },
+    },
+  } as typeof rawOutputs;
+}
+
+export const amplifyOutputs = withOAuthDomainOverride(outputs);

--- a/tests/integration/api/progress.test.ts
+++ b/tests/integration/api/progress.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 import { GET } from "@/app/api/progress/route";
 import { makeRawClient, makeTableNames, createTables, deleteTables } from "../tableUtils";
 import { seedProfile, seedActivePractice, seedReturn, seedMilestone } from "../seeds";
+import { dateRange, returnDayForUser } from "@/lib/returns/returns";
 import type { withAuth as WithAuthType } from "@/utils/authServer";
 
 vi.mock("@/utils/metricsClient", () => ({ trackEvent: vi.fn(), trackPillarFocus: vi.fn() }));
@@ -111,7 +112,11 @@ describe("GET /api/progress", () => {
     });
     await seedActivePractice(userId, PRACTICE);
 
-    const dates = ["2026-05-06", "2026-05-07", "2026-05-08"];
+    const today = returnDayForUser({
+      timezone: "UTC",
+      resetMinutes: 0,
+    });
+    const dates = dateRange(3, today);
     for (const d of dates) {
       await seedReturn(userId, PRACTICE, d, true);
     }

--- a/tests/unit/amplifyConfig.test.ts
+++ b/tests/unit/amplifyConfig.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { withOAuthDomainOverride } from "@/lib/amplifyConfig";
+
+const baseConfig = {
+  version: "1.4",
+  auth: {
+    user_pool_id: "ap-southeast-2_pool",
+    aws_region: "ap-southeast-2",
+    user_pool_client_id: "client",
+    oauth: {
+      identity_providers: ["GOOGLE"],
+      domain: "generated.auth.ap-southeast-2.amazoncognito.com",
+      scopes: ["email", "openid", "profile"],
+      redirect_sign_in_uri: ["https://friendsintelligence.net/auth"],
+      redirect_sign_out_uri: ["https://friendsintelligence.net/auth"],
+      response_type: "code",
+    },
+  },
+};
+
+describe("withOAuthDomainOverride", () => {
+  it("uses the custom OAuth domain when provided", () => {
+    const config = withOAuthDomainOverride(
+      baseConfig,
+      "https://auth.friendsintelligence.net/oauth2/idpresponse",
+    );
+
+    expect(config.auth.oauth.domain).toBe("auth.friendsintelligence.net");
+  });
+
+  it("keeps the generated Cognito domain when no custom domain is provided", () => {
+    const config = withOAuthDomainOverride(baseConfig, "");
+
+    expect(config.auth.oauth.domain).toBe(
+      "generated.auth.ap-southeast-2.amazoncognito.com",
+    );
+  });
+});

--- a/utils/amplifyServerUtils.ts
+++ b/utils/amplifyServerUtils.ts
@@ -1,8 +1,8 @@
 // utils/amplifyServerUtils.ts
 import { createServerRunner } from "@aws-amplify/adapter-nextjs";
-import outputs from "../amplify_outputs.json";
+import { amplifyOutputs } from "@/lib/amplifyConfig";
 
 
 export const { runWithAmplifyServerContext } = createServerRunner({
-  config: outputs,
+  config: amplifyOutputs,
 });

--- a/utils/dataServerClient.ts
+++ b/utils/dataServerClient.ts
@@ -1,12 +1,12 @@
 import type { Schema } from "@/amplify/data/resource";
-import outputs from "../amplify_outputs.json";
+import { amplifyOutputs } from "@/lib/amplifyConfig";
 import { cookies } from "next/headers";
 import { generateServerClientUsingCookies } from "@aws-amplify/adapter-nextjs/data";
 
 // IMPORTANT: create the client per-request, inside route handlers
 export function getDataClient() {
   return generateServerClientUsingCookies<Schema>({
-    config: outputs,
+    config: amplifyOutputs,
     cookies,
   });
 }


### PR DESCRIPTION
## Summary

- Add an Amplify config wrapper that can override the Cognito OAuth domain at build time
- Wire client and server Amplify config usage through the shared wrapper
- Expose `FIAPP_PROD_COGNITO_OAUTH_DOMAIN` as `NEXT_PUBLIC_COGNITO_OAUTH_DOMAIN` only for the `main` branch
- Document the Cognito custom domain and Google OAuth setup
- Add unit coverage for OAuth domain override behavior
- Fix the date-dependent progress streak integration test seed

## Deployment Notes

Set this Amplify environment variable:

```text
FIAPP_PROD_COGNITO_OAUTH_DOMAIN=auth.friendsintelligence.net
```

It can be configured for all branches because `amplify.yml` only applies it on `main`.

## Validation

- `git diff --check`
- `npm run lint`
- `npx tsc --noEmit`
- `npx vitest run tests/unit/amplifyConfig.test.ts`
- `npx vitest run --config vitest.integration.config.ts tests/integration/api/progress.test.ts`
