### PR TITLE
fix: stop fetchAuthSession() from depending on Cognito Identity Pool

### DIFF
--- a/lib/amplifyConfig.ts
+++ b/lib/amplifyConfig.ts
@@ -42,4 +42,32 @@ export function withOAuthDomainOverride(
   } as typeof rawOutputs;
 }
 
-export const amplifyOutputs = withOAuthDomainOverride(outputs);
+/**
+ * Remove the Cognito Identity Pool from the Amplify config.
+ *
+ * The app does not use Identity-Pool credentials anywhere (data access goes
+ * through the server's IAM keys, not client AWS creds). Leaving the identity
+ * pool configured causes `fetchAuthSession()` to call
+ * `GetCredentialsForIdentity` whenever it runs — and on production that call
+ * fails with 400 "Logins don't match" because the prod Identity Pool ↔ User
+ * Pool wiring is broken (casualty of the 2026-05-09 pool recreation). When
+ * that throws, `middleware.ts` redirects `/decideRoute → /auth`, AuthGate
+ * sees valid cookies and bounces back to `/decideRoute`, and the app hangs
+ * in an infinite redirect loop on a perpetual spinner.
+ *
+ * Stripping the identity pool here makes `fetchAuthSession()` token-only,
+ * which eliminates the failing call entirely.
+ */
+export function withoutIdentityPool(
+  config: AmplifyOutputsWithOAuth,
+): typeof rawOutputs {
+  if (!config.auth) return config as typeof rawOutputs;
+
+  const nextAuth = { ...config.auth } as Record<string, unknown>;
+  delete nextAuth.identity_pool_id;
+  delete nextAuth.unauthenticated_identities_enabled;
+
+  return { ...config, auth: nextAuth } as typeof rawOutputs;
+}
+
+export const amplifyOutputs = withoutIdentityPool(withOAuthDomainOverride(outputs));

--- a/middleware.ts
+++ b/middleware.ts
@@ -18,9 +18,29 @@ function isProtectedPage(pathname: string): boolean {
   return PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix))
 }
 
+/**
+ * True if the request is carrying Cognito session cookies. Used as a
+ * safety net so that a transient `fetchAuthSession()` error here can never
+ * bounce an authenticated user to /auth — which would trigger an infinite
+ * /auth ↔ /decideRoute redirect loop, since AuthGate re-redirects
+ * authenticated users back to /decideRoute. See
+ * project_auth_hang_identity_pool memory for the 2026-05-13 incident.
+ */
+function hasCognitoSessionCookie(request: NextRequest): boolean {
+  return request.cookies.getAll().some(
+    (c) =>
+      c.name.startsWith('CognitoIdentityServiceProvider.') &&
+      (c.name.endsWith('.accessToken') || c.name.endsWith('.idToken')),
+  )
+}
+
 export async function middleware(request: NextRequest) {
   const response = NextResponse.next()
   const { pathname } = request.nextUrl
+
+  if (!isProtectedPage(pathname)) {
+    return response
+  }
 
   try {
     const session = await runWithAmplifyServerContext({
@@ -28,17 +48,25 @@ export async function middleware(request: NextRequest) {
       operation: (contextSpec) => fetchAuthSession(contextSpec),
     })
 
-    // Redirect to /auth if tokens are missing on a protected page
-    if (!session.tokens && isProtectedPage(pathname)) {
-      return NextResponse.redirect(new URL('/auth', request.url))
+    if (session.tokens) {
+      return response
     }
-  } catch {
-    if (isProtectedPage(pathname)) {
-      return NextResponse.redirect(new URL('/auth', request.url))
-    }
-  }
 
-  return response
+    // No tokens from fetchAuthSession — but only redirect if the request
+    // really has no Cognito cookies. Otherwise it's a session-resolution
+    // hiccup, not a missing session; let client-side guards sort it out
+    // rather than risk a redirect loop.
+    if (!hasCognitoSessionCookie(request)) {
+      return NextResponse.redirect(new URL('/auth', request.url))
+    }
+    return response
+  } catch (err) {
+    console.error('[middleware] fetchAuthSession failed:', err)
+    if (!hasCognitoSessionCookie(request)) {
+      return NextResponse.redirect(new URL('/auth', request.url))
+    }
+    return response
+  }
 }
 
 export const config = {

--- a/tests/unit/amplifyConfig.test.ts
+++ b/tests/unit/amplifyConfig.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { withOAuthDomainOverride } from "@/lib/amplifyConfig";
+import { withOAuthDomainOverride, withoutIdentityPool } from "@/lib/amplifyConfig";
 
 const baseConfig = {
   version: "1.4",
@@ -34,5 +34,47 @@ describe("withOAuthDomainOverride", () => {
     expect(config.auth.oauth.domain).toBe(
       "generated.auth.ap-southeast-2.amazoncognito.com",
     );
+  });
+});
+
+describe("withoutIdentityPool", () => {
+  it("strips identity_pool_id and unauthenticated_identities_enabled from auth", () => {
+    const input = {
+      ...baseConfig,
+      auth: {
+        ...baseConfig.auth,
+        identity_pool_id: "ap-southeast-2:abc-123",
+        unauthenticated_identities_enabled: true,
+      },
+    };
+
+    const result = withoutIdentityPool(input);
+
+    expect(result.auth).not.toHaveProperty("identity_pool_id");
+    expect(result.auth).not.toHaveProperty("unauthenticated_identities_enabled");
+  });
+
+  it("preserves all other auth fields, including oauth", () => {
+    const input = {
+      ...baseConfig,
+      auth: {
+        ...baseConfig.auth,
+        identity_pool_id: "ap-southeast-2:abc-123",
+      },
+    };
+
+    const result = withoutIdentityPool(input);
+
+    expect(result.auth.user_pool_id).toBe(baseConfig.auth.user_pool_id);
+    expect(result.auth.user_pool_client_id).toBe(baseConfig.auth.user_pool_client_id);
+    expect(result.auth.aws_region).toBe(baseConfig.auth.aws_region);
+    expect(result.auth.oauth?.domain).toBe(baseConfig.auth.oauth.domain);
+  });
+
+  it("is a no-op when the fields are already absent", () => {
+    const result = withoutIdentityPool(baseConfig);
+
+    expect(result.auth.user_pool_id).toBe(baseConfig.auth.user_pool_id);
+    expect(result.auth.oauth?.domain).toBe(baseConfig.auth.oauth.domain);
   });
 });


### PR DESCRIPTION
New users on cold/fresh visits to production were getting stuck on /auth with a perpetual spinner. Root cause traced today:

  GET /decideRoute -> 307 Location: /auth   (even with valid Cognito cookies)

middleware.ts calls fetchAuthSession() server-side on protected pages. fetchAuthSession() also resolves Cognito Identity-Pool AWS credentials via GetCredentialsForIdentity, which on prod returns
  400 NotAuthorizedException: "Logins don't match"
(the prod Identity Pool <-> User Pool wiring is broken, casualty of the 2026-05-09 pool recreation). When it throws, middleware redirects /decideRoute -> /auth; AuthGate then sees the valid cookies and bounces back to /decideRoute -> infinite redirect loop -> eternal spinner. /api/me returns 200 with the same cookies because it uses getCurrentUser() (token-only), confirming the failure is specifically credential resolution.

The app uses zero Identity-Pool credentials anywhere on the client (only useUserEmail and middleware call fetchAuthSession, both read .tokens only). Data access is server-side IAM (fiapp-server). So the Identity Pool can be removed from the Amplify config harmlessly.

Changes:

  - lib/amplifyConfig.ts: add withoutIdentityPool() that strips auth.identity_pool_id and auth.unauthenticated_identities_enabled from the config. Applied to the exported amplifyOutputs alongside the existing OAuth-domain override. Both the client (AmplifyProvider, ConfigureAmplifyClientSide) and the server runner (utils/amplifyServerUtils.ts) consume amplifyOutputs from here, so one change fixes both paths.

  - middleware.ts: harden against redirect loops. Skip middleware entirely on non-protected paths; on protected paths, only redirect to /auth when Cognito session cookies are *also* absent. A fetchAuthSession() failure on a request that's carrying valid Cognito cookies can no longer bounce the user to /auth, so the /auth <-> /decideRoute loop is structurally impossible even if some future config issue makes fetchAuthSession() throw again.

  - tests/unit/amplifyConfig.test.ts: cover the new transform.