### PR TITLE
feat(routing): strip focus-guard from decideRoute (v2 Cut 4)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,14 +53,15 @@ UI phase done (commit 9228f33):
 - [x] `/results`: "Try this practice" → v2 CTA logic (Start / Bring this back / View on Today); switch dialog
 - [x] Switch dialog with Q5 copy in both /practices and /results
 
-### Cut 4 — Routing
+### Cut 4 — Routing ✅
 
-- [ ] Strip `todayFocusPracticeId` branch from `lib/decideRoute.ts`
-- [ ] Verify `/today` empty-state UI for 0-active users (build if missing)
-- [ ] Remove "Set as today's focus" CTAs and any related state
-- [ ] Decide: keep `todayFocusPracticeId` as display preference, or delete entirely
-- [ ] Update `tests/unit/decideRoute.test.ts`, `tests/unit/decideRouteClient.test.tsx`
-- [ ] PR to `staging`
+Done on `feat/v2-routing-strip-focus` (commit pending):
+- [x] Strip `todayFocusPracticeId` branch from `lib/decideRoute.ts` (now 2 branches: `/onboarding` if no assessment, otherwise `/today`)
+- [x] `/today` empty-state UI verified — already built in Cut 3 UI
+- [x] "Set as today's focus" CTAs — already removed in Cut 3 UI
+- [x] `todayFocusPracticeId` kept as a stored PROFILE field for display-only use; routing no longer reads it. Final delete deferred to Cut 5.
+- [x] `tests/unit/decideRoute.test.ts` rewritten for the 2-branch logic
+- [x] `tests/unit/decideRouteClient.test.tsx` rewritten — covers /onboarding, /today (with and without focus), /auth paths
 
 ### Cut 5 — Cleanup
 

--- a/lib/decideRoute.ts
+++ b/lib/decideRoute.ts
@@ -1,27 +1,12 @@
 export type ProfileForRouting = {
   latestAssessmentId: string | null;
-  activePracticeIds?: string[] | null;
-  activeTrialCount?: number | null;
-  todayFocusPracticeId?: string | null;
 };
 
 export function decideRoute(
   profile: ProfileForRouting
-): "/onboarding" | "/assessment" | "/results" | "/practices" | "/today" {
+): "/onboarding" | "/today" {
   if (!profile.latestAssessmentId) {
     return "/onboarding";
   }
-
-  const hasActivePractices = (profile.activePracticeIds?.length ?? 0) > 0;
-  const hasActiveTrials = (profile.activeTrialCount ?? 0) > 0;
-
-  if (!hasActivePractices && !hasActiveTrials) {
-    return "/results";
-  }
-
-  if (!profile.todayFocusPracticeId) {
-    return "/practices";
-  }
-
   return "/today";
 }

--- a/tests/unit/decideRoute.test.ts
+++ b/tests/unit/decideRoute.test.ts
@@ -1,120 +1,48 @@
 import { describe, it, expect } from "vitest";
 import { decideRoute, type ProfileForRouting } from "@/lib/decideRoute";
 
-describe("decideRoute", () => {
+describe("decideRoute (v2 — focus-free)", () => {
   it("routes to /onboarding when no assessment", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: null,
-      activePracticeIds: ["p1"],
-      todayFocusPracticeId: "p1",
-    };
-
+    const profile: ProfileForRouting = { latestAssessmentId: null };
     expect(decideRoute(profile)).toBe("/onboarding");
   });
 
-  it("routes to /results when no active practices and no active trials", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: "a1",
-      activePracticeIds: [],
-      activeTrialCount: 0,
-      todayFocusPracticeId: "p1",
-    };
-
-    expect(decideRoute(profile)).toBe("/results");
-  });
-
-  it("routes to /practices when no active practices but has active trial and no focus", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: "a1",
-      activePracticeIds: [],
-      activeTrialCount: 1,
-      todayFocusPracticeId: null,
-    };
-
-    expect(decideRoute(profile)).toBe("/practices");
-  });
-
-  it("routes to /today when has active trial and focus practice set", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: "a1",
-      activePracticeIds: [],
-      activeTrialCount: 1,
-      todayFocusPracticeId: "sleep-consistent-bedtime",
-    };
-
+  it("routes to /today when assessment exists, regardless of active practice count", () => {
+    const profile: ProfileForRouting = { latestAssessmentId: "a1" };
     expect(decideRoute(profile)).toBe("/today");
   });
 
-  it("routes to /practices when no focus practice", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: "a1",
-      activePracticeIds: ["p1"],
-      todayFocusPracticeId: null,
-    };
-
-    expect(decideRoute(profile)).toBe("/practices");
-  });
-
-  it("routes to /today when assessment, practices, and focus exist", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: "a1",
-      activePracticeIds: ["p1"],
-      todayFocusPracticeId: "p1",
-    };
-
-    expect(decideRoute(profile)).toBe("/today");
-  });
-
-  it("treats undefined activePracticeIds as empty (no trials → /results)", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: "a1",
-      activePracticeIds: undefined,
-      activeTrialCount: 0,
-      todayFocusPracticeId: "p1",
-    };
-
-    expect(decideRoute(profile)).toBe("/results");
-  });
-
-  it("treats null activePracticeIds as empty (no trials → /results)", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: "a1",
-      activePracticeIds: null,
-      activeTrialCount: null,
-      todayFocusPracticeId: "p1",
-    };
-
-    expect(decideRoute(profile)).toBe("/results");
-  });
-
-  it("treats omitted activeTrialCount as zero", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: "a1",
-      activePracticeIds: [],
-      todayFocusPracticeId: "p1",
-    };
-
-    expect(decideRoute(profile)).toBe("/results");
-  });
-
-  it("GAP-D1: has both active practices and active trial with focus → /today", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: "a1",
-      activePracticeIds: ["p1"],
-      activeTrialCount: 1,
-      todayFocusPracticeId: "p1",
-    };
-
-    expect(decideRoute(profile)).toBe("/today");
-  });
-
-  it("GAP-D2: empty string latestAssessmentId → /onboarding", () => {
-    const profile: ProfileForRouting = {
-      latestAssessmentId: "",
-      activePracticeIds: ["p1"],
-      todayFocusPracticeId: "p1",
-    };
-
+  it("empty-string latestAssessmentId is treated as no assessment", () => {
+    const profile: ProfileForRouting = { latestAssessmentId: "" };
     expect(decideRoute(profile)).toBe("/onboarding");
+  });
+
+  it("0 active practices no longer redirects to /results — /today renders its own empty state", () => {
+    // ProfileForRouting in v2 doesn't even carry activePracticeIds — routing is
+    // a pure function of latestAssessmentId. Verify that even profiles with
+    // extra legacy fields route to /today when they have an assessment.
+    const profile = {
+      latestAssessmentId: "a1",
+      activePracticeIds: [],
+      activeTrialCount: 0,
+      todayFocusPracticeId: null,
+    } as ProfileForRouting & {
+      activePracticeIds: string[];
+      activeTrialCount: number;
+      todayFocusPracticeId: null;
+    };
+    expect(decideRoute(profile)).toBe("/today");
+  });
+
+  it("missing todayFocusPracticeId no longer redirects to /practices", () => {
+    const profile = {
+      latestAssessmentId: "a1",
+      activePracticeIds: ["p1"],
+      todayFocusPracticeId: null,
+    } as ProfileForRouting & {
+      activePracticeIds: string[];
+      todayFocusPracticeId: null;
+    };
+    expect(decideRoute(profile)).toBe("/today");
   });
 });

--- a/tests/unit/decideRouteClient.test.tsx
+++ b/tests/unit/decideRouteClient.test.tsx
@@ -39,13 +39,9 @@ describe("DecideRouteClient", () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it("redirects to /assessment when no assessment", async () => {
+  it("redirects to /onboarding when no assessment", async () => {
     useProfileMock.mockReturnValue({
-      profile: {
-        latestAssessmentId: null,
-        activePracticeIds: ["p1"],
-        todayFocusPracticeId: "p1",
-      },
+      profile: { latestAssessmentId: null },
       loading: false,
       error: null,
       refetch: vi.fn(),
@@ -58,13 +54,11 @@ describe("DecideRouteClient", () => {
     });
   });
 
-  it("redirects to /results when no active practices", async () => {
+  it("redirects to /today when assessment exists (no active practices)", async () => {
+    // v2: /today is the default destination once an assessment exists; it renders
+    // an empty state for 0-active users instead of bouncing to /results.
     useProfileMock.mockReturnValue({
-      profile: {
-        latestAssessmentId: "a1",
-        activePracticeIds: [],
-        todayFocusPracticeId: "p1",
-      },
+      profile: { latestAssessmentId: "a1", activePracticeIds: [] },
       loading: false,
       error: null,
       refetch: vi.fn(),
@@ -73,36 +67,14 @@ describe("DecideRouteClient", () => {
     render(<DecideRouteClient />);
 
     await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith("/results");
+      expect(replaceMock).toHaveBeenCalledWith("/today");
     });
   });
 
-  it("redirects to /practices when no focus practice", async () => {
+  it("redirects to /today when assessment exists, regardless of todayFocusPracticeId", async () => {
+    // v2: todayFocusPracticeId is no longer a routing input.
     useProfileMock.mockReturnValue({
-      profile: {
-        latestAssessmentId: "a1",
-        activePracticeIds: ["p1"],
-        todayFocusPracticeId: null,
-      },
-      loading: false,
-      error: null,
-      refetch: vi.fn(),
-    });
-
-    render(<DecideRouteClient />);
-
-    await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith("/practices");
-    });
-  });
-
-  it("redirects to /today when focus practice exists", async () => {
-    useProfileMock.mockReturnValue({
-      profile: {
-        latestAssessmentId: "a1",
-        activePracticeIds: ["p1"],
-        todayFocusPracticeId: "p1",
-      },
+      profile: { latestAssessmentId: "a1", todayFocusPracticeId: null },
       loading: false,
       error: null,
       refetch: vi.fn(),


### PR DESCRIPTION
## Summary

Cut 4 of the v2 business-logic refactor. Tiny code change, big semantic shift:

`decideRoute` is now a pure function of `latestAssessmentId`:

| Condition | Route |
|---|---|
| no assessment | `/onboarding` |
| has assessment | `/today` |

Removed branches from v1:
- `activePracticeCount === 0 → /results` — gone; `/today` renders its own empty state (built in Cut 3).
- `todayFocusPracticeId == null → /practices` — gone; focus is no longer a routing input.
- `activeTrialCount` check — gone; trials removed in Cut 3.

`ProfileForRouting` narrows from 4 fields to `{ latestAssessmentId }`. `todayFocusPracticeId` remains a stored PROFILE field per the v2 spec ("display-only"); final deletion is queued for Cut 5.

**Net diff:** 4 files, +44/-158. Just `lib/decideRoute.ts` and the two routing test suites + a TODO checklist update.

## Test plan

- [ ] **Empty-state on /today:** sign in as a user with 0 active practices → land on `/today` (not redirected to `/results` or `/practices`) → empty state CTAs visible.
- [ ] **No focus required:** even if `todayFocusPracticeId` is `null` for an authed-with-assessment user, they land on `/today` (the page handles its own rendering for any active-practice count).
- [ ] **Onboarding gate:** new user with no assessment → still redirected to `/onboarding`.
- [ ] **Auth gate:** signed-out user → still redirected to `/auth` (handled by `DecideRouteClient`, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)