### PR TITLE
feat(onboarding): collapse 3-screen intro to 1 (Pillars + radar)

### DIFF
--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -136,6 +136,9 @@ export default function AssessmentPage() {
                   <span>You can retake it any time from your account</span>
                 </li>
               </ul>
+              <p className="rounded-lg bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground leading-relaxed">
+                After this, you&apos;ll get a focus pillar, try one small practice from it, and check in daily.
+              </p>
               <Button className="w-full" onClick={() => setIntroAccepted(true)}>
                 Start assessment →
               </Button>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { pillarOrder, pillarLabels, type Pillar } from "@/lib/assessment/pillars";
 import { pillarColors } from "@/lib/design/pillarColors";
@@ -17,165 +16,70 @@ const SAMPLE_SCORES: Record<Pillar, number> = {
   sleep: 3,
 };
 
-const STEPS = 3;
-
-function StepDots({ current }: { current: number }) {
-  return (
-    <div className="flex items-center gap-2">
-      {Array.from({ length: STEPS }).map((_, i) => (
-        <span
-          key={i}
-          className={`h-1.5 rounded-full transition-all ${
-            i === current ? "w-5 bg-primary" : "w-1.5 bg-muted-foreground/30"
-          }`}
-        />
-      ))}
-    </div>
-  );
-}
-
-function StepWelcome({ onNext }: { onNext: () => void }) {
-  return (
-    <div className="space-y-8">
-      <div className="space-y-4">
-        <p className="text-xs tracking-[0.12em] uppercase text-muted-foreground">
-          Friends Intelligence
-        </p>
-        <h1 className="text-2xl font-semibold text-foreground leading-snug">
-          Welcome.
-        </h1>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          Friends Intelligence is a framework for building the habits that matter most across the seven areas of a well-lived life.
-        </p>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          This app helps you assess where you are today, find your focus, and build one small practice at a time — day by day.
-        </p>
-      </div>
-      <Button className="w-full" onClick={onNext}>
-        Continue →
-      </Button>
-    </div>
-  );
-}
-
-function StepPillars({ onNext }: { onNext: () => void }) {
-  return (
-    <div className="space-y-5 sm:space-y-8">
-      <div className="space-y-4">
-        <p className="text-xs tracking-[0.12em] uppercase text-muted-foreground">
-          The framework
-        </p>
-        <h1 className="text-2xl font-semibold text-foreground leading-snug">
-          7 areas of your life
-        </h1>
-        <p className="text-sm text-muted-foreground leading-relaxed">
-          You&apos;ll get a score for each. The one with the most room to grow becomes your starting focus.
-        </p>
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {pillarOrder.map((pillar) => {
-          const color = pillarColors[pillar];
-          return (
-            <span
-              key={pillar}
-              className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium"
-              style={{ backgroundColor: color, borderColor: color, color: "#fff" }}
-            >
-              <span className="h-1.5 w-1.5 rounded-full bg-white/80" />
-              {pillarLabels[pillar]}
-            </span>
-          );
-        })}
-      </div>
-      <div className="rounded-xl border border-border bg-muted/20 p-3 sm:p-4">
-        <div className="mx-auto max-w-[280px] sm:max-w-none">
-          <PillarRadarChart scores={SAMPLE_SCORES} focusPillar="financial" />
-        </div>
-        <p className="mt-1 text-center text-xs text-muted-foreground">Sample results</p>
-      </div>
-      <Button className="w-full" onClick={onNext}>
-        Continue →
-      </Button>
-    </div>
-  );
-}
-
-function StepLoop({ onDone }: { onDone: () => void }) {
-  const steps = [
-    { label: "Assess", desc: "Answer 35 yes/no questions across all 7 pillars" },
-    { label: "Focus", desc: "Your lowest-opportunity pillar becomes your focus area" },
-    { label: "Practice", desc: "Try one small practice from your focus pillar" },
-    { label: "Check in", desc: "Each day, log whether you did it — build the streak" },
-  ];
-
-  return (
-    <div className="space-y-8">
-      <div className="space-y-4">
-        <p className="text-xs tracking-[0.12em] uppercase text-muted-foreground">
-          How it works
-        </p>
-        <h1 className="text-2xl font-semibold text-foreground leading-snug">
-          One loop. Repeated.
-        </h1>
-      </div>
-      <ol className="space-y-4">
-        {steps.map((s, i) => (
-          <li key={s.label} className="flex items-start gap-4">
-            <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-[0.7rem] font-semibold text-primary-foreground">
-              {i + 1}
-            </span>
-            <div>
-              <p className="text-sm font-medium text-foreground">{s.label}</p>
-              <p className="text-xs text-muted-foreground leading-relaxed">{s.desc}</p>
-            </div>
-          </li>
-        ))}
-      </ol>
-      <Button className="w-full" onClick={onDone}>
-        Take your first assessment →
-      </Button>
-    </div>
-  );
-}
-
 export default function OnboardingPage() {
   const router = useRouter();
-  const [step, setStep] = useState(0);
 
-  function next() {
-    setStep((s) => s + 1);
-  }
-
-  function done() {
+  function start() {
     router.replace("/assessment");
   }
 
   return (
     <div className="min-h-screen bg-background font-sans antialiased">
       <header className="border-b border-border px-6">
-        <div className="mx-auto flex h-14 max-w-lg items-center">
+        <div className="mx-auto flex h-14 max-w-lg items-center justify-between">
           <span className="text-sm font-semibold text-foreground">
             Friends Intelligence
           </span>
+          <button
+            onClick={start}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Skip intro →
+          </button>
         </div>
       </header>
 
       <main className="mx-auto max-w-lg px-6 py-8 sm:py-12">
-        <div className="mb-8 flex items-center gap-4">
-          {step > 0 && (
-            <button
-              onClick={() => setStep((s) => s - 1)}
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              ← Back
-            </button>
-          )}
-          <StepDots current={step} />
-        </div>
+        <div className="space-y-5 sm:space-y-8">
+          <div className="space-y-4">
+            <p className="text-xs tracking-[0.12em] uppercase text-muted-foreground">
+              Welcome
+            </p>
+            <h1 className="text-2xl font-semibold text-foreground leading-snug">
+              7 areas of your life
+            </h1>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              Friends Intelligence is a framework for building the habits that matter most across seven areas of a well-lived life. You&apos;ll get a score for each — the one with the most room to grow becomes your starting focus.
+            </p>
+          </div>
 
-        {step === 0 && <StepWelcome onNext={next} />}
-        {step === 1 && <StepPillars onNext={next} />}
-        {step === 2 && <StepLoop onDone={done} />}
+          <div className="flex flex-wrap gap-2">
+            {pillarOrder.map((pillar) => {
+              const color = pillarColors[pillar];
+              return (
+                <span
+                  key={pillar}
+                  className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium"
+                  style={{ backgroundColor: color, borderColor: color, color: "#fff" }}
+                >
+                  <span className="h-1.5 w-1.5 rounded-full bg-white/80" />
+                  {pillarLabels[pillar]}
+                </span>
+              );
+            })}
+          </div>
+
+          <div className="rounded-xl border border-border bg-muted/20 p-3 sm:p-4">
+            <div className="mx-auto max-w-[280px] sm:max-w-none">
+              <PillarRadarChart scores={SAMPLE_SCORES} focusPillar="financial" />
+            </div>
+            <p className="mt-1 text-center text-xs text-muted-foreground">Sample results</p>
+          </div>
+
+          <Button className="w-full" onClick={start}>
+            Take your first assessment →
+          </Button>
+        </div>
       </main>
     </div>
   );

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -4,56 +4,40 @@ import { AUTH_STATE_PATH } from "./global-setup";
 test.use({ storageState: AUTH_STATE_PATH });
 
 test.describe("/onboarding", () => {
-  test("step 0 shows Welcome heading and Continue button", async ({ page }) => {
+  test("shows welcome label and pillar heading", async ({ page }) => {
     await page.goto("/onboarding");
     await expect(page.getByText(/Welcome/i)).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByRole("button", { name: /continue/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /7 areas of your life/i })).toBeVisible();
   });
 
-  test("Back button is not visible on step 0", async ({ page }) => {
+  test("renders all 7 pillar chips", async ({ page }) => {
     await page.goto("/onboarding");
-    await expect(page.getByRole("button", { name: /back/i })).not.toBeVisible();
-  });
-
-  test("step dots are visible", async ({ page }) => {
-    await page.goto("/onboarding");
-    // Step indicator dots rendered as spans
-    await expect(page.locator("span.rounded-full").first()).toBeVisible({ timeout: 10_000 });
-  });
-
-  test("Continue advances to step 1 — 7 pillars", async ({ page }) => {
-    await page.goto("/onboarding");
-    await page.getByRole("button", { name: /continue/i }).click();
     await expect(page.getByText(/financial/i).first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText(/relationship/i).first()).toBeVisible();
+    await expect(page.getByText(/sleep/i).first()).toBeVisible();
   });
 
-  test("Back button appears on step 1", async ({ page }) => {
+  test("shows primary CTA to start the assessment", async ({ page }) => {
     await page.goto("/onboarding");
-    await page.getByRole("button", { name: /continue/i }).click();
-    await expect(page.getByRole("button", { name: /back/i })).toBeVisible();
-  });
-
-  test("Back on step 1 returns to step 0", async ({ page }) => {
-    await page.goto("/onboarding");
-    await page.getByRole("button", { name: /continue/i }).click();
-    await page.getByRole("button", { name: /back/i }).click();
-    await expect(page.getByText(/Welcome/i)).toBeVisible();
-  });
-
-  test("step 2 shows Take your first assessment button", async ({ page }) => {
-    await page.goto("/onboarding");
-    await page.getByRole("button", { name: /continue/i }).click();
-    await page.getByRole("button", { name: /continue/i }).click();
     await expect(
       page.getByRole("button", { name: /take your first assessment/i })
     ).toBeVisible({ timeout: 5_000 });
   });
 
+  test("Skip intro link is visible", async ({ page }) => {
+    await page.goto("/onboarding");
+    await expect(page.getByRole("button", { name: /skip intro/i })).toBeVisible();
+  });
+
   test("Take first assessment navigates to /assessment", async ({ page }) => {
     await page.goto("/onboarding");
-    await page.getByRole("button", { name: /continue/i }).click();
-    await page.getByRole("button", { name: /continue/i }).click();
     await page.getByRole("button", { name: /take your first assessment/i }).click();
+    await expect(page).toHaveURL(/\/assessment/);
+  });
+
+  test("Skip intro navigates to /assessment", async ({ page }) => {
+    await page.goto("/onboarding");
+    await page.getByRole("button", { name: /skip intro/i }).click();
     await expect(page).toHaveURL(/\/assessment/);
   });
 });


### PR DESCRIPTION
## Summary

- New-user onboarding flow is reduced from **4 screens → 2** (onboarding intro → Before-you-begin → Q1).
- Cut the Welcome and Loop screens. Kept the Pillars + sample radar screen as the single intro.
- Folded the Loop's expectation-setting into a one-line note on the existing "Before you begin" screen on `/assessment`.
- Added a "Skip intro" link in the onboarding header.

## Why

[NN/G research](https://www.nngroup.com/articles/mobile-app-onboarding/) finds that deck-of-cards tutorial onboarding doesn't improve task completion — users who skip perform the same as users who read. Industry data (Appcues) shows ~15% completion drop per onboarding screen beyond 5. The Loop screen was also redundant with "Before you begin" — both prepped users for the 35-question assessment.

Kept what earns its place:
- **Pillars + sample radar** — concrete preview of value (not a tutorial)
- **Before you begin** — contract screen for the high-friction 35Q step (duration, framing rule, disclaimer)

## Test plan

- [x] `npm run test` — 301/301 pass
- [x] `npx tsc --noEmit` — clean
- [x] E2E tests updated ([tests/e2e/onboarding.spec.ts](tests/e2e/onboarding.spec.ts)) to match single-screen flow
- [ ] Run `BASE_URL=https://staging.d3nyg9qvz1tj5n.amplifyapp.com npm run test:e2e` after merge to staging
- [ ] Visual check on staging: `/onboarding` renders Pillars + radar + Skip intro link
- [ ] Visual check on staging: `/assessment` "Before you begin" includes the new one-liner

🤖 Generated with [Claude Code](https://claude.com/claude-code)