### PR TITLE
feat(practices): clearer copy for paused practices

### DIFF
--- a/_docs/canon/business-logic-v2.md
+++ b/_docs/canon/business-logic-v2.md
@@ -71,8 +71,10 @@ Rules:
 ## Practice card CTA
 
 - No `UserPractice` → "Start this practice"
-- `UserPractice.status = "inactive"` → "Bring this back" (+ "You've completed this X times before")
-- `UserPractice.status = "active"` → "Active" badge + "View on Today"
+- `UserPractice.status = "inactive"` → **Paused** badge + "Resume" CTA. Always show a context line below the description: with prior history, `You've practiced this N times before — currently paused. Resume anytime.`; without history, `You started this before — currently paused. Resume anytime.`
+- `UserPractice.status = "active"` → **Active** badge + "View on Today" (link) + "Pause" (secondary action)
+
+**Why "Paused" not "Inactive":** `status: "inactive"` stays as the storage term. The user-facing label is **Paused** because "Inactive" reads as "this practice is unavailable" rather than "you've put it on hold."
 
 Same CTA rules everywhere: results screen, practice bank, recommendation cards.
 
@@ -154,7 +156,7 @@ When a free user at the 1-active cap taps "Start this practice" on a different p
 
 > **Switch to "[new practice title]"?**
 >
-> "[current practice title]" will move to your practice bank. You can bring it back anytime.
+> "[current practice title]" will be paused. You can resume it anytime.
 >
 > [ Switch ] [ Cancel ]
 
@@ -169,7 +171,7 @@ The dialog deliberately does **not** name the active/inactive mechanic — users
 | Mode | Operation | Notes |
 |---|---|---|
 | `startPractice` | start-or-reactivate | Handles the "no record" case and the "inactive record" case identically |
-| `reactivatePractice` | start-or-reactivate (alias) | Same server handler as `startPractice`; distinct name so the client can be explicit about user intent ("Bring this back") |
+| `reactivatePractice` | start-or-reactivate (alias) | Same server handler as `startPractice`; distinct name so the client can be explicit about user intent ("Resume") |
 | `makePracticeInactive` | flip to inactive | |
 | `switchToPractice` | atomic deactivate + activate | For the free-user 1-cap switch flow |
 
@@ -307,7 +309,7 @@ Flips an active practice to inactive. Removes from `activePracticeIds`. Preserve
 
 #### `mode: "reactivatePractice"`
 
-Alias for `startPractice` when a record exists with `status: "inactive"`. Provided as a separate mode for UX clarity (UI button "Bring this back"). Server may route both to the same handler.
+Alias for `startPractice` when a record exists with `status: "inactive"`. Provided as a separate mode for UX clarity (UI button "Resume"). Server may route both to the same handler.
 
 #### `mode: "switchToPractice"`
 
@@ -388,9 +390,11 @@ The app must not manage practice lifecycles like Jira tickets. Active = on Today
 
 ## UI copy
 
-Use: "Start this practice", "Bring this back", "Make inactive", "View on Today", "Active", "You've completed this X times before", "Welcome back".
+Use: "Start this practice", "Resume", "Pause", "View on Today", "Active", "Paused", "You've practiced this N times before — currently paused. Resume anytime.", "You started this before — currently paused. Resume anytime.", "Switch", "Cancel".
 
-Avoid in user-facing copy: "Trial", "Promote", "Discard", "Expire", "Replace", "Pause", "Resume" (as system term), "Focus" (as required system state).
+Avoid in user-facing copy: "Trial", "Promote", "Discard", "Expire", "Replace", "Focus" (as required system state), "Inactive" (storage term only — show as "Paused" in the UI), "Bring this back", "Make inactive", "Welcome back".
+
+**Revised 2026-05-13** — "Pause"/"Resume" were originally on the avoid list to keep distance from v1's pause-state machine, but in v2 they're just labels for the active↔inactive transition and read more naturally than "Bring this back" / "Make inactive."
 
 ---
 

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -309,7 +309,7 @@ function SwitchDialog({
           Switch to &ldquo;{newPractice.title}&rdquo;?
         </p>
         <p className="text-sm text-muted-foreground">
-          &ldquo;{currentActive.title}&rdquo; will move to your practice bank. You can bring it back anytime.
+          &ldquo;{currentActive.title}&rdquo; will be paused. You can resume it anytime.
         </p>
         <div className="flex gap-2 pt-2">
           <Button disabled={loading} onClick={onConfirm}>

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -117,7 +117,7 @@ export default function PracticesPage() {
         const cap = (json as { cap?: number }).cap ?? 10
         setInlineError((p) => ({
           ...p,
-          [practice.id]: `You're at the ${cap}-practice limit. Make one inactive first.`,
+          [practice.id]: `You're at the ${cap}-practice limit. Pause one first.`,
         }))
         return
       }
@@ -133,7 +133,7 @@ export default function PracticesPage() {
     try {
       const res = await callPractice({ mode: 'makePracticeInactive', practiceId })
       if (!res.ok) {
-        setInlineError((p) => ({ ...p, [practiceId]: 'Could not make inactive. Try again.' }))
+        setInlineError((p) => ({ ...p, [practiceId]: 'Could not pause. Try again.' }))
         return
       }
       await load()
@@ -220,15 +220,17 @@ export default function PracticesPage() {
                           )}
                           {status === 'inactive' && (
                             <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-muted text-muted-foreground border border-border">
-                              Inactive
+                              Paused
                             </span>
                           )}
                         </div>
                         <p className="font-semibold text-foreground">{p.title}</p>
                         <p className="text-sm text-muted-foreground">{p.description}</p>
-                        {status === 'inactive' && completions > 0 && (
+                        {status === 'inactive' && (
                           <p className="text-xs text-muted-foreground">
-                            Welcome back — you&apos;ve completed this {completions} {completions === 1 ? 'time' : 'times'} before.
+                            {completions > 0
+                              ? `You've practiced this ${completions} ${completions === 1 ? 'time' : 'times'} before — currently paused. Resume anytime.`
+                              : "You started this before — currently paused. Resume anytime."}
                           </p>
                         )}
                         {inlineError[p.id] && (
@@ -244,7 +246,7 @@ export default function PracticesPage() {
                         )}
                         {status === 'inactive' && (
                           <Button size="sm" variant="outline" disabled={busy} onClick={() => handleStart(p)}>
-                            {busy ? '…' : 'Bring this back'}
+                            {busy ? '…' : 'Resume'}
                           </Button>
                         )}
                         {status === 'active' && (
@@ -253,7 +255,7 @@ export default function PracticesPage() {
                               <Link href="/today">View on Today</Link>
                             </Button>
                             <Button size="sm" variant="ghost" disabled={busy} onClick={() => handleMakeInactive(p.id)}>
-                              {busy ? '…' : 'Make inactive'}
+                              {busy ? '…' : 'Pause'}
                             </Button>
                           </>
                         )}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -129,7 +129,7 @@ export default function ResultsPage() {
         const cap = (json as { cap?: number }).cap ?? 10
         setInlineError((p) => ({
           ...p,
-          [practice.id]: `You're at the ${cap}-practice limit. Make one inactive first.`,
+          [practice.id]: `You're at the ${cap}-practice limit. Pause one first.`,
         }))
         return
       }
@@ -274,12 +274,17 @@ export default function ResultsPage() {
                               )}
                               {status === 'inactive' && (
                                 <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-muted text-muted-foreground border border-border">
-                                  Inactive
+                                  Paused
                                 </span>
                               )}
                             </div>
                             <p className="font-semibold text-foreground">{practice.title}</p>
                             <p className="text-sm text-muted-foreground">{practice.description}</p>
+                            {status === 'inactive' && (
+                              <p className="text-xs text-muted-foreground">
+                                You started this before — currently paused. Resume anytime.
+                              </p>
+                            )}
                             {practice.rationale && (
                               <p className="text-xs text-muted-foreground border-l-2 border-border pl-3">
                                 {practice.rationale}
@@ -294,7 +299,7 @@ export default function ResultsPage() {
                             )}
                             {status === 'inactive' && (
                               <Button variant="outline" disabled={busy} onClick={() => handleStart(practice)}>
-                                {busy ? '…' : 'Bring this back'}
+                                {busy ? '…' : 'Resume'}
                               </Button>
                             )}
                             {status === 'active' && (

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -387,7 +387,7 @@ function SwitchDialog({
           Switch to &ldquo;{newPracticeTitle}&rdquo;?
         </p>
         <p className="text-sm text-muted-foreground">
-          &ldquo;{currentActiveTitle}&rdquo; will move to your practice bank. You can bring it back anytime.
+          &ldquo;{currentActiveTitle}&rdquo; will be paused. You can resume it anytime.
         </p>
         <div className="flex gap-2 pt-2">
           <Button disabled={loading} onClick={onConfirm}>


### PR DESCRIPTION
## Summary

Reframe the "Inactive" state so users understand it means *"a practice they've used before that's currently paused"* — not *"an unavailable practice"*.

| Before | After |
|---|---|
| `Inactive` badge | `Paused` badge |
| `Bring this back` button | `Resume` button |
| `Make inactive` button | `Pause` button |
| `Make one inactive first` error | `Pause one first` error |
| Context line only shown when `completions > 0` | Always shown for paused practices |

Also added the explainer line to `/results` suggestion cards (previously had no explainer when a suggested practice was paused).

## Why

Voice feedback: *"He sounds like a disparaging. He's not available to choose from. Can we communicate the fact that this user has used this practice?"*

"Inactive" + "Bring this back" reads as a binary availability state. "Paused" + "Resume" + a short explainer ("You started this before — currently paused. Resume anytime.") makes it clear the practice is *yours* and reactivatable, just dormant.

## Test plan

- [x] `npm run test` — 294/294 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Visual check on staging `/practices`: paused practices show `Paused` badge, `Resume` button, and "You started this before — currently paused" text
- [ ] Visual check on staging `/results`: same for paused suggestions
- [ ] Trigger CAP_REACHED on Free tier with 1 active → confirm switch dialog still works; with >1 active on Paid → confirm error reads "Pause one first"

🤖 Generated with [Claude Code](https://claude.com/claude-code)