### PR TITLE
docs(canon): full v2 rewrites of launch + testing checklists

### DIFF
--- a/_docs/canon/launch-checklist.md
+++ b/_docs/canon/launch-checklist.md
@@ -1,8 +1,8 @@
-# FIApp v1 — Manual Launch Checklist
-
-> **PARTIALLY SUPERSEDED 2026-05-13 by [business-logic-v2.md](business-logic-v2.md).** This checklist will need full revision once v2 UI ships (Cuts 3-4 of the v2 refactor). Specifically: §3 "Try this practice → starts trial", all of §4 (Set focus / Pause / Resume / Replace / Trial promote+discard), §5 Today (focus chip, Trying-out section, trial logging, "no focus → redirect" hint), and §9 "Free user can replace…" are all replaced by the v2 active/inactive lifecycle and the always-accessible /today empty state. Sections 0-2, 6-8, 10-12 remain valid.
+# FIApp v1 — Manual Launch Checklist (v2 UI)
 
 Run this end-to-end before any public launch or major release. Use a real device (phone + desktop). Automated tests cover rules; this covers the human experience.
+
+Last revised: 2026-05-13 (v2 business-logic refactor).
 
 **Sign in as a real test user with a populated account before starting sections 2–8.**
 
@@ -10,9 +10,9 @@ Run this end-to-end before any public launch or major release. Use a real device
 
 ## 0. Pre-launch infra
 
-- [ ] Production URL loads (`main.*.amplifyapp.com`)
+- [ ] Production URL loads (`main.*.amplifyapp.com` and `friendsintelligence.net`)
 - [ ] Amplify environment variables are set (`FIAPP_AWS_ACCESS_KEY_ID`, `FIAPP_AWS_SECRET_ACCESS_KEY`, `FIAPP_AWS_REGION`, `FIAPP_RETURNS_TABLE`, `FIAPP_MAIN_TABLE`)
-- [ ] CI is green on `main` branch (lint + typecheck + unit + E2E smoke)
+- [ ] CI is green on `main` branch (lint + typecheck + unit + Layer 3 E2E smoke)
 - [ ] No open `P0` GitHub issues
 
 ---
@@ -21,8 +21,8 @@ Run this end-to-end before any public launch or major release. Use a real device
 
 - [ ] `/auth` loads — Friends Intelligence logo, sign in tab visible, no layout breaks
 - [ ] Sign up: create a new account with email + password — confirmation email received
-- [ ] Confirm email → redirected into app (not stuck on auth screen)
-- [ ] Sign in with confirmed account → lands on correct page (assessment if new, today if returning)
+- [ ] Confirm email → redirected into app (lands on `/onboarding` for new users, `/today` for returning users with assessment)
+- [ ] Sign in with confirmed account → lands on correct page per `decideRoute` (auth → `/auth`; authed without assessment → `/onboarding`; authed with assessment → `/today`)
 - [ ] Wrong password → error message visible, not cryptic
 - [ ] "Forgot password" flow — email sent, reset works
 - [ ] Sign out → redirected to `/auth`, cannot navigate back to protected pages
@@ -32,7 +32,7 @@ Run this end-to-end before any public launch or major release. Use a real device
 
 ## 2. Assessment
 
-- [ ] All 35 questions load, no missing text
+- [ ] All **35** questions load, no missing text
 - [ ] Yes / No buttons respond — question auto-advances
 - [ ] Back button works — previous answer is preserved
 - [ ] Progress bar advances correctly
@@ -44,57 +44,80 @@ Run this end-to-end before any public launch or major release. Use a real device
 
 ## 3. Results / Insights
 
-- [ ] Focus pillar card shows correct pillar with correct colour
-- [ ] Radar chart renders — all 7 pillars visible, focus pillar dot is larger/highlighted
-- [ ] All pillars listed with correct scores and coloured progress bars
-- [ ] 3 suggested practices shown with pillar badge, description, rationale
-- [ ] "Try this practice" → starts trial, redirects to `/practices`
-- [ ] "Retake assessment" button visible top-right, works
-- [ ] "Go to My Practices →" button at bottom works
-- [ ] Empty state (no assessment): CTA to start assessment shown
+- [ ] Focus Pillar card shows the user's lowest-scoring pillar with the correct pillar colour
+- [ ] Help tooltip on Focus Pillar opens and reads correctly
+- [ ] Radar chart renders — all 7 pillars visible, focus pillar dot highlighted
+- [ ] All 7 pillars listed below with correct scores (N/5) and coloured progress bars; the focus pillar has the `focus` tag
+- [ ] **3 suggested practices** shown, all from the lowest-scoring pillar, in deterministic order (weakest-answer first)
+- [ ] Each suggestion card shows: pillar badge, title, description, rationale
+- [ ] **CTA per suggestion** matches state:
+  - No `UserPractice` yet → "Start this practice"
+  - Currently paused → "Resume" + the helper line "You started this before — currently paused. Resume anytime."
+  - Currently active → "Active" badge + "View on Today" link
+- [ ] **"Browse all 35 practices →"** secondary link is present
+- [ ] **"Go to Today →"** primary CTA at bottom
+- [ ] **"Retake assessment"** button visible with explainer text
+- [ ] Empty state (no assessment yet): CTA to start assessment shown — radar/scores absent
 - [ ] **Mobile**: radar chart not clipped, pillar labels readable
+- [ ] **No v1 vocabulary** anywhere: "Try this practice", "Your focus", "Go to My Practices", "Inactive", "Bring this back" must not appear
 
 ---
 
-## 4. Practices
+## 4. Practices (the 35-practice bank)
 
-- [ ] Active practices shown with correct status badges
-- [ ] "Set as today's focus" works — badge updates to "Today's focus"
-- [ ] Pause: practice moves to paused section
-- [ ] Resume: practice becomes active again
-- [ ] Replace: 2-step flow — candidate list shown, amber warning, confirm works
-- [ ] Trial cards show days remaining badge and Promote / Discard actions
-- [ ] Promote trial → moves to active, disappears from trials section
-- [ ] Discard trial → card removed
-- [ ] Free plan cap: attempting to resume at cap shows error (not silent failure)
-- [ ] Empty state: no practices CTA is helpful
-- [ ] **Mobile**: action buttons large enough to tap, no horizontal overflow
+- [ ] Heading reads **"Practice Bank"** with subtitle "All 35 practices, grouped by pillar."
+- [ ] All **7 pillar sections** present in pillar order: Financial / Relationship / Information / Emotional / Nutrition / Dynamic / Sleep — each as a `Pillar Intelligence` heading with a coloured dot
+- [ ] Each pillar section contains exactly **5 cards** (total: 35)
+- [ ] Each card shows pillar badge, title, description; one of three states:
+  - **No record** — just the pillar badge; right side shows "Start this practice"
+  - **Active** — pillar badge + "Active" badge; right side shows "View on Today" (link) + "Pause" (ghost)
+  - **Paused** — pillar badge + "Paused" badge; helper line below description ("You've practiced this N times before — currently paused. Resume anytime." or "You started this before — currently paused. Resume anytime." if N=0); right side shows "Resume"
+- [ ] Clicking **Start this practice** when 0 active: practice becomes Active immediately, no dialog
+- [ ] Clicking **Start this practice** when 1 active (Free user): the **switch dialog** appears with:
+  - Title: `Switch to "[new practice title]"?`
+  - Body: `"[current title]" will be paused. You can resume it anytime.`
+  - Buttons: `Switch` and `Cancel`
+- [ ] **Switch** action: old practice moves to Paused, new one becomes Active
+- [ ] **Cancel** closes the dialog with no state change
+- [ ] Clicking **Pause** on an active card → moves it to the same pillar's Paused state
+- [ ] Clicking **Resume** on a paused card → activates it (subject to cap; triggers switch dialog if Free at cap)
+- [ ] Paid user with 10 active → "Start" on an 11th shows the cap message: `You're at the 10-practice limit. Pause one first.`
+- [ ] Top-right action is **"Go to Today →"**
+- [ ] **No v1 controls** anywhere: Set focus, Replace, Promote, Discard, Trying out, days-remaining badge, "Bring this back", "Make inactive", "Inactive" badge
+- [ ] **Mobile**: cards stack cleanly; pillar headings readable; switch dialog fits the viewport
 
 ---
 
 ## 5. Today
 
-- [ ] Focus practice shown with correct pillar badge and "Today's focus" chip
-- [ ] "✓ Did it" → button fills, confirmation text shows "You've done this N times."
-- [ ] Dot pop animation plays on today's dot in 14-day strip
-- [ ] Button pulse animation on "Did it" click
-- [ ] "Not today" → compassionate copy ("No worries. Tomorrow is a fresh start.")
-- [ ] Toggle: clicking "Did it" again un-logs (dot clears, count decreases)
-- [ ] 14-day strip: only shown after first check-in; filled dot = blue, skipped = grey, empty = faint
+- [ ] Heading reads **"Today"**
+- [ ] **`/today` is always reachable** once authed + has assessment — never redirects to `/results` or `/practices`
+- [ ] **0 active practices** → empty state:
+  - Heading text: "Choose one practice to start."
+  - Sub-copy: "Pick something from your practice bank to begin building a daily habit."
+  - CTAs: "Browse practices →" (link) and "Take assessment" (link)
+- [ ] **1+ active practices** → each rendered as its own card with:
+  - Pillar badge (no "Today's focus" badge anywhere)
+  - Title + description
+  - `✓ Did it` primary button + `Not today` secondary button
+  - Help tooltip explains Did it / Not today
+- [ ] Logging **Did it** → button confirms, completion count appears ("You've done this N times."), 14-day dots show today filled
+- [ ] Logging **Did it** again → toggles off (dot clears, count decreases)
+- [ ] Logging **Not today** → "No worries. Tomorrow is a fresh start."
+- [ ] **14-day dot strip** only appears after the first check-in for that practice; filled = blue, skipped = grey, empty = faint
 - [ ] Hover on dot shows formatted date + status tooltip
-- [ ] Active trials shown in "Trying out" section with countdown badge
-- [ ] Trial "Did it" / "Not today" work independently from focus practice
-- [ ] Milestone banner: appears after unlock, dismisses cleanly
-- [ ] No focus practice set: helpful message with link to practices
+- [ ] **Milestone banner** appears after unlock, dismisses cleanly
+- [ ] Bottom nav: `← Browse practices` and `View progress →` links
 - [ ] Error state: "Try again" reloads correctly
+- [ ] **No v1 elements** anywhere: "Today's focus" chip, "Trying out" section, trial day countdown, "No focus practice set yet"
 - [ ] **Mobile**: buttons full width, dots not too small to see
 
 ---
 
 ## 6. Progress
 
-- [ ] Total check-ins, current streak, longest streak all display
-- [ ] Practices started count correct
+- [ ] Total check-ins, current streak, longest streak, practices started all display
+- [ ] **Streak** number reflects pure rolling logic — consecutive days ending today with `didIt=true`. A gap (whether from missed days or a paused period) breaks the streak.
 - [ ] "Coming up" milestones section shows next milestone with progress bar (if any)
 - [ ] Achieved milestones listed (or empty state if none)
 - [ ] Empty state (zero activity): page doesn't crash, zero values shown cleanly
@@ -106,7 +129,7 @@ Run this end-to-end before any public launch or major release. Use a real device
 
 - [ ] Email displayed correctly
 - [ ] Plan label shows "Free plan" or "Plus plan" correctly
-- [ ] "Retake assessment" link works
+- [ ] "Retake assessment" link navigates to `/assessment`
 - [ ] Sign out works
 - [ ] **Mobile**: readable, no layout issues
 
@@ -114,10 +137,10 @@ Run this end-to-end before any public launch or major release. Use a real device
 
 ## 8. Navigation & App shell
 
-- [ ] All 4 nav items work: Today, Practices, Insights, Progress
+- [ ] All 4 nav items work: Today, Practices, Insights (Results), Progress
 - [ ] Active nav item is visually highlighted
 - [ ] Account dropdown: opens/closes, shows email + plan + sign out
-- [ ] Free plan: "Upgrade to Plus" appears in dropdown, click shows "coming soon" toast
+- [ ] Free plan: "Upgrade to Plus" appears in dropdown, click shows the appropriate flow
 - [ ] Plus plan: no upgrade CTA shown
 - [ ] **Mobile**: hamburger menu opens/closes, all items tappable, no overflow
 - [ ] Trackpad horizontal scroll: page does not shake/overflow
@@ -126,19 +149,23 @@ Run this end-to-end before any public launch or major release. Use a real device
 
 ## 9. Plan gating spot check
 
-- [ ] Free user at 1 active practice cannot add another (error shown)
-- [ ] Free user can replace their 1 active practice
+- [ ] **Free user, 1 active practice** — clicking "Start this practice" on a different practice opens the switch dialog (not a hard error); confirming switches; cancelling does nothing
+- [ ] **Free user, 0 active practices** — Start works immediately, no dialog
+- [ ] **Paid user, 0–9 active practices** — Start works, no warning
+- [ ] **Paid user, 10 active practices** — Start shows inline error: `You're at the 10-practice limit. Pause one first.` (no switch dialog at 10 — that's Free-only)
+- [ ] **No 5+/7+ warnings** appear on Paid plan (v2 dropped these)
 - [ ] Dev toggle (`NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=true`): Free ↔ Plus toggle works in dev, invisible in prod
 
 ---
 
 ## 10. Copy & tone
 
-- [ ] No "Premium" or "Paid" labels visible anywhere (all show "Plus plan" / "Free plan")
+- [ ] No `Premium` or `Paid` labels visible anywhere (all show `Plus plan` / `Free plan`)
 - [ ] Error messages are human — not raw codes or stack traces
 - [ ] Empty states have helpful CTAs — not blank screens
-- [ ] No placeholder text, "TODO", or lorem ipsum visible
-- [ ] Loading states have friendly copy ("Loading your insights…" etc.)
+- [ ] No placeholder text, `TODO`, or lorem ipsum visible
+- [ ] Loading states have friendly copy (`Loading your insights…` etc.)
+- [ ] **v1 vocabulary absent everywhere**: "Try this practice", "Today's focus", "Trying out", "Inactive" (as user-facing), "Bring this back", "Make inactive", "Welcome back" (as a section heading), "Set focus", "Replace", "Promote", "Discard"
 
 ---
 
@@ -147,7 +174,7 @@ Run this end-to-end before any public launch or major release. Use a real device
 - [ ] Auth page: keyboard doesn't cover input
 - [ ] Assessment: buttons easy to tap, no mis-taps
 - [ ] Today: "Did it" button large and prominent
-- [ ] Practices: action buttons not too small
+- [ ] Practices: pillar sections scroll cleanly, switch dialog fits viewport
 - [ ] No horizontal scroll on any page
 - [ ] Font sizes readable without zooming
 - [ ] No text clipping or truncation in unexpected places
@@ -158,6 +185,7 @@ Run this end-to-end before any public launch or major release. Use a real device
 
 - [ ] Today page loads in < 3s on a mobile connection (DevTools throttle to Fast 3G)
 - [ ] Assessment loads all 35 questions without lag
+- [ ] /practices renders 35 cards smoothly (no jank when scrolling)
 - [ ] No visible layout shift (CLS) after initial load
 - [ ] Radar chart renders without flicker
 
@@ -170,11 +198,12 @@ Run this end-to-end before any public launch or major release. Use a real device
 | Auth | | | |
 | Assessment | | | |
 | Results | | | |
-| Practices | | | |
+| Practices (Bank) | | | |
 | Today | | | |
 | Progress | | | |
 | Account | | | |
 | Navigation | | | |
+| Plan gating | | | |
 | Copy & tone | | | |
 | Mobile | | | |
 | Performance | | | |

--- a/_docs/canon/testing-checklist.md
+++ b/_docs/canon/testing-checklist.md
@@ -1,198 +1,208 @@
 # docs/canon/testing-checklist.md
-# FIApp v1 — Canonical Testing Checklist
+# FIApp v1 — Canonical Testing Checklist (v2 invariants)
 
-> **PARTIALLY SUPERSEDED 2026-05-13 by [business-logic-v2.md](business-logic-v2.md).** The following sections enforce v1 invariants that are removed or changed in v2 and must be reworked in Cut 5 of the v2 refactor:
->
-> - §1.3 Trial policy persistence — TRIAL items removed in v2.
-> - §4 Pause / Resume — replaced by `active`/`inactive` lifecycle in v2.
-> - §5 Trial lifecycle — entirely removed in v2.
-> - §6.3 "Trials count toward counters/milestones" — gone in v2.
-> - §8.2 "If no practices, Today redirects to Results" — direct conflict with v2's always-accessible /today.
-> - §9 regression red flags entries for pause logic and trial counting — gone in v2.
->
-> Still valid: §0 setup baseline, §1.1-1.2 PROFILE / returns shape, §2 API contract tests (updated against v2 endpoints), §3 caps & warnings (with 5/7 warnings now optional in v2), §6.1-6.2 return delta counters, §7 progress endpoint.
+**Purpose:** Prevent design drift over the remaining v1 implementation. Every locked v2 invariant should be enforced by at least one automated test.
+**Rule:** Test layers do not overlap unnecessarily. Unit tests cover pure logic, integration tests cover route handlers + DynamoDB, E2E covers the UI shell.
+**Layers:** Unit → Integration (route handlers, dynalite) → E2E smoke (Playwright).
 
-**Purpose:** Prevent design drift over ~160 hours of implementation.  
-**Rule:** Every “LOCKED invariant” in canon docs should be enforced by at least one automated test.  
-**Layers:** Unit → Integration (route handlers) → E2E smoke.
+Last revised: 2026-05-13 (v2 business-logic refactor). Canonical spec: [business-logic-v2.md](business-logic-v2.md).
 
 ---
 
 ## 0) Test Setup Baseline (applies to all)
-- Use a DynamoDB test strategy that supports:
+- DynamoDB strategy must support:
   - isolated tables per test run OR table prefixing
   - deterministic cleanup
 - All API tests run against route handlers with:
   - mocked auth context → stable `userId`
-  - controlled “today” date in `Australia/Melbourne` timezone
-- Enforce JSON response shape:
-  - `ok`, `data`, `error` (or consistent equivalent)
+  - controlled "today" date in `Australia/Melbourne` timezone
+- E2E safety guard (`tests/e2e/global-setup.ts`) refuses to run against non-local environments unless `E2E_EMAIL=qianhaopower+e2etest@gmail.com`.
 
 ---
 
-## 1) DB Schema & Invariants (docs/canon/db-schema.md)
+## 1) Storage shape & DB invariants
 
 ### 1.1 PROFILE creation
 - [ ] `GET /api/me` creates PROFILE if missing
-- [ ] PROFILE contains required fields with safe defaults:
-  - `subscriptionStatus` default (FREE unless dev override)
-  - `activePracticeIds` defaults to `[]`
-  - `latestAssessmentId` defaults to `null`
-- [ ] PROFILE creation is idempotent: calling `GET /api/me` twice returns same profile (no overwrite)
-- **Manual verification:** Sign in → call `GET /api/me` twice → both return same `userId`, `subscriptionStatus`, `createdAt`; default fields present
+- [ ] PROFILE contains required fields with safe defaults: `subscriptionStatus` (FREE), `activePracticeIds` (`[]`), `latestAssessmentId` (`null`), `lowestPillarId` (`null`), `returnCounters` (`{}`), `milestonesAchieved` (`[]`)
+- [ ] PROFILE response **does not include** dead v1 fields: `activePracticeSkById`, `practiceCounters`, `todayFocusPracticeId`, `activeTrialCount`
+- [ ] PROFILE creation is idempotent: two `GET /api/me` calls return the same `userId`/`createdAt`
 
-### 1.2 Returns table shape
-- [ ] `POST /api/return` writes to **FIAPP_RETURNS**:
-  - PK: `USER#<id>#PRACTICE#<practiceId>`
-  - SK: `DATE#YYYY-MM-DD`
-- [ ] Same date is updated in-place (no duplicates)
+### 1.2 UPRACTICE shape (v2)
+- [ ] `startPractice` writes `UPRACTICE#<practiceId>` (no `<startedAt>` prefix — one record per `userId+practiceId`)
+- [ ] New records have `status: "active"`, `firstStartedAt`, `lastActivatedAt`
+- [ ] `makePracticeInactive` sets `status: "inactive"` and `lastInactivatedAt`
+- [ ] Reactivation (`startPractice` on an `inactive` record) **preserves** `firstStartedAt` and updates `lastActivatedAt`
+- [ ] Legacy status values (`"paused"`, `"replaced"`) are read leniently — `startPractice` treats them as reactivatable; `/api/practices/active` surfaces them as `inactive`
 
-### 1.3 Trial policy persistence
-- [ ] `startTrial` creates `TRIAL#<startedAt>#<practiceId>` item
-- [ ] Trial items include `expiresAt` and `status`
-- [ ] Trial items never modify `activePracticeIds` during start/discard
+### 1.3 Returns table shape
+- [ ] `POST /api/return` writes to `FIAPP_RETURNS` with `PK USER#<id>#PRACTICE#<id>` + `SK DATE#YYYY-MM-DD`
+- [ ] Same `(practiceId, date)` is updated in place — no duplicates
+- [ ] DailyReturn rows are preserved across lifecycle transitions (active → inactive → active)
+
+### 1.4 ASSESS shape (v2)
+- [ ] `POST /api/assessment` writes `ASSESS#<id>` with `pillarScores`, `lowestPillarId`, `suggestedPracticeIds[]` (length 3), `focusPillar` (legacy alias)
+- [ ] PROFILE update sets both `latestAssessmentId` and `lowestPillarId`
+
+### 1.5 TRIAL items (gone in v2)
+- [ ] `/api/practice` no longer writes `TRIAL#` items in any mode
+- [ ] `/api/me` does not query the `TRIAL#` partition
+- [ ] `/api/return` does not query the `TRIAL#` partition
+- [ ] Stale `TRIAL#` items in storage do not affect any read response
 
 ---
 
-## 2) API Contract Tests (docs/canon/api-contract.md)
+## 2) API contract tests
 
-### 2.1 Auth guard behavior (baseline)
-- [ ] All endpoints reject unauthenticated requests with consistent error code
-  - (except any explicitly public endpoint, if one exists)
+### 2.1 Auth guard baseline
+- [ ] All endpoints reject unauthenticated requests with `401`
 
 ### 2.2 Assessment contract
-- [ ] `POST /api/assessment`:
-  - persists an `ASSESS#<id>` item
-  - updates PROFILE.latestAssessmentId
-  - returns scores + focusPillar
-- [ ] `GET /api/assessment/latest`:
-  - returns `null` if none
-  - returns latest assessment if present
+- [ ] `POST /api/assessment` returns `{ assessmentId, focusPillar, lowestPillarId, scoresByPillar, suggestedPracticeIds }`
+- [ ] `suggestedPracticeIds.length === 3`; all IDs are real practices in the library
+- [ ] `lowestPillarId === focusPillar` (legacy alias parity)
+- [ ] `GET /api/assessment/latest` returns the persisted item including `suggestedPracticeIds` or `null` if none
 
 ### 2.3 Suggestions contract
-- [ ] `GET /api/practices/suggestions` returns exactly 3 suggestions
-- [ ] Works with and without assessment (fallback logic)
-- [ ] Suggestions include `{practiceId, pillar, rationale}`
+- [ ] `GET /api/practices/suggestions` hydrates the persisted `suggestedPracticeIds` into full `Practice[]` records
+- [ ] Falls back to the static pillar-pick when an `ASSESS` record exists without `suggestedPracticeIds` (legacy)
+- [ ] Falls back to the static fallback when no `ASSESS` record exists at all
+- [ ] All returned `Practice` records include `mappedQuestionId` (v2 field)
+
+### 2.4 Practice lifecycle modes (`POST /api/practice`)
+- [ ] **`startPractice`** creates a new UPRACTICE (status active) when none exists
+- [ ] **`startPractice`** reactivates an inactive (or legacy paused/replaced) UPRACTICE
+- [ ] **`startPractice`** on an already-active UPRACTICE returns `200 { alreadyActive: true }` and writes nothing
+- [ ] **`reactivatePractice`** behaves identically to `startPractice` (alias)
+- [ ] **`makePracticeInactive`** flips an active UPRACTICE to inactive; returns `409 PRACTICE_NOT_ACTIVE` otherwise
+- [ ] **`switchToPractice`** atomically deactivates `deactivatePracticeId` and activates `practiceId`; returns `400 SAME_PRACTICE` if the two IDs match; returns `409 DEACTIVATE_PRACTICE_NOT_ACTIVE` if the target-to-deactivate isn't currently active
+- [ ] All other modes (legacy `add`, `replace`, `pause`, `resume`, `setFocus`, `startTrial`, `promoteTrial`, `discardTrial`) return `400 Unknown mode`
+
+### 2.5 Return logging
+- [ ] `POST /api/return` rejects with `409 PRACTICE_NOT_ACTIVE` when `practiceId` is not in `activePracticeIds`
+- [ ] Toggling `didIt` true → false → true updates counters by ±1 each time (delta-based, no double-counting same date)
+- [ ] Milestone triggers are idempotent (same milestone is not emitted twice)
 
 ---
 
-## 3) Caps & Warnings (LOCKED)
+## 3) Caps & switch flow
 
 ### 3.1 Free cap = 1
-- [ ] Free user can `add` 1 active practice
-- [ ] Free user cannot `add` a second active practice
-  - returns hard error or requiresReplace response (whatever your contract defines)
-- [ ] Free user can `replace` at cap successfully (count stays 1)
+- [ ] Free user can `startPractice` when 0 active
+- [ ] Free user at cap (1 active) → `startPractice` on a *different* practice returns `409 CAP_REACHED { cap: 1 }`
+- [ ] **Switch flow:** `switchToPractice` with the active practice as `deactivatePracticeId` succeeds; old practice becomes inactive, new one active
 
-### 3.2 Plus plan cap = 10 (hard stop; internal `PAID`)
-- [ ] Plus plan user can add up to 10 active practices
-- [ ] Plus plan user adding 11th is rejected (hard stop)
-  - ensure no data mutation occurred
+### 3.2 Paid cap = 10
+- [ ] Paid user can `startPractice` up to 10 active
+- [ ] Paid user adding 11th returns `409 CAP_REACHED { cap: 10 }`
+- [ ] **No 5+/7+ soft warnings** appear in the response — `warning` field is `undefined` regardless of active count
 
-### 3.3 Warnings at 5 and 7
-- [ ] When adding results in count == 5:
-  - response includes `warning` (soft)
-- [ ] When adding results in count == 7:
-  - response includes `warning` (strong)
-- [ ] Warnings do not block successful add
+### 3.3 `checkActiveCap` helper
+- [ ] Returns `{ allowed: true }` below cap
+- [ ] Returns `{ allowed: false, reason: 'CAP_REACHED', cap }` at cap
+- [ ] Lowercase `"paid"` is treated as PAID; lowercase `"free"` as FREE; `null`/`undefined` defaults to FREE
 
 ---
 
-## 4) Pause / Resume (Option 2) (LOCKED)
+## 4) Question ↔ practice mapping (v2 invariant)
 
-### 4.1 Pause removes from active list but preserves pointer
-- [ ] Pausing an active practice:
-  - removes practiceId from `activePracticeIds`
-  - preserves mapping pointer so resume can locate history record
-  - does not delete UPRACTICE history
-
-### 4.2 Resume is cap-checked and warning-aware
-- [ ] Resume adds it back if under cap
-- [ ] Resume triggers warning at 5 / 7 when applicable
-- [ ] Resume is rejected if at hard cap (Plus plan 10, Free plan 1)
+- [ ] Exactly **35 questions** and **35 practices** in the library
+- [ ] Exactly **5 of each per pillar** across all 7 pillars
+- [ ] Every `Practice.mappedQuestionId` resolves to a real question, and that question's `mappedPracticeId` points back (bidirectional)
+- [ ] Mapping is 1-to-1 — no two practices share a `mappedQuestionId`, no two questions share a `mappedPracticeId`
+- [ ] Mapped pairs always share the same pillar
+- [ ] `order` field is `[1, 2, 3, 4, 5]` within every pillar for both questions and practices
 
 ---
 
-## 5) Trial lifecycle (LOCKED distinctions)
+## 5) Recommendation logic (deterministic)
 
-### 5.1 Trials don’t consume cap
-- [ ] With Plus plan user at cap=10 active, `startTrial` still succeeds
-- [ ] Active count remains unchanged after `startTrial`
-
-### 5.2 Promote trial consumes cap
-- [ ] If under cap, `promoteTrial`:
-  - adds to active list
-  - marks TRIAL status promoted/ended
-- [ ] If at cap, `promoteTrial` fails (or returns requiresReplace)
-  - verify no partial mutation
-
-### 5.3 Discard trial
-- [ ] `discardTrial` ends trial without affecting active list
+- [ ] For a given assessment lowest pillar, `getSuggestedPractices(answers, lowestPillar)` returns 3 practices in a deterministic order
+- [ ] `no`-answer questions rank weaker than `yes`-answer questions; their mapped practices are picked first
+- [ ] Ties are broken by question `order` ascending
+- [ ] If fewer than 3 `no` answers exist in the pillar, the list is padded with `yes`-answer practices from the same pillar (still in `order` ascending)
+- [ ] Repeated calls with identical inputs return identical outputs (no randomness)
 
 ---
 
-## 6) Returns & Delta Counters (LOCKED)
+## 6) Returns & Delta Counters
 
 ### 6.1 Create return
-- [ ] `POST /api/return didIt=true` creates/updates return item
-- [ ] Counter increments by +1 for first-time true
+- [ ] `POST /api/return didIt=true` creates/updates the return item and increments the counter for first-time true
+- [ ] `POST /api/return didIt=false` creates the item but does not change counters (delta=0)
 
-### 6.2 Toggle support (true → false)
-- [ ] If day already `didIt=true`, sending `didIt=false`:
-  - updates the item
-  - decrements counters appropriately (undo)
-- [ ] Same in reverse: false → true increments
+### 6.2 Toggle support
+- [ ] `true → false` on a same-date record decrements the counter by 1
+- [ ] `false → true` increments by 1
+- [ ] No-op when value unchanged (returns `noop: true`)
 
-### 6.3 Trials count toward counters/milestones
-- [ ] Logging returns for a trial practice updates counters as normal
+### 6.3 Streak rule (v2)
+- [ ] Streak = count of consecutive days ending today with `didIt=true`
+- [ ] A gap in DailyReturn breaks the streak regardless of cause (skipped day OR paused practice)
+- [ ] Reactivating a practice with no recent returns yields `streak = 0` until the user logs a day
 
 ---
 
 ## 7) Progress endpoint
 
-### 7.1 `/api/progress` aggregation
-- [ ] Returns `counters` and `milestones`
-- [ ] Works when user has zero activity (empty-state safe)
-- [ ] Milestone triggers are idempotent:
-  - same milestone is not triggered twice for the same threshold
+- [ ] `GET /api/progress` returns `counters` + `milestones`
+- [ ] Robust to a user with zero activity (empty-state safe)
+- [ ] Milestone triggers are idempotent — same threshold is not emitted twice
 
 ---
 
-## 8) Routing / State Machine E2E Smokes (docs/canon/state-machine.md)
+## 8) Routing / State machine
 
-Use Playwright/Cypress (or similar). Keep these short and stable.
+Aligned to v2's `decideRoute` (`lib/decideRoute.ts`):
 
-### 8.1 First-time journey
-- [ ] New user → Auth → Assessment → Results
-- [ ] Start trial or add practice
-- [ ] Lands in Active Practices
-- [ ] Navigates to Today and logs a return
-- [ ] Progress shows counters updated
+### 8.1 `decideRoute` invariants
+- [ ] No `latestAssessmentId` → routes to `/onboarding`
+- [ ] Empty-string `latestAssessmentId` → treated as no assessment
+- [ ] Has `latestAssessmentId` → routes to `/today` regardless of active-practice count or focus state
+- [ ] `ProfileForRouting` type does not depend on `activePracticeIds`, `activeTrialCount`, or `todayFocusPracticeId`
 
-### 8.2 Guard enforcement
-- [ ] If no assessment, attempting to open Today redirects to Assessment
-- [ ] If assessment exists but no practices, Today redirects to Results (or Active Practices per your guard) and cannot log returns
+### 8.2 E2E smoke (Layer 3, `tests/e2e/authenticated.spec.ts`)
+- [ ] **`/today` always loads** — even with 0 active practices, renders the empty state (never redirects to `/results` or `/practices`)
+- [ ] **`/practices`** renders all 7 pillar headings and shows v2 CTAs (Start / Resume / View on Today + Pause); no v1 controls (Set focus, Replace, Promote, Discard, "Bring this back", "Make inactive", "Inactive" badge)
+- [ ] **`/results`** has no `Try this practice` text anywhere; the radar chart renders (selector: `svg[viewBox="0 0 500 420"]`)
 
 ### 8.3 Cap cannot be bypassed
-- [ ] Plus plan user at 10 active cannot add 11th via any UI path
-- [ ] Free user cannot exceed 1 active
+- [ ] Free user at 1 active cannot add another via any UI path — must use the switch flow
+- [ ] Paid user at 10 active cannot add an 11th via any UI path
 
 ---
 
-## 9) Regression “Red Flags” (add tests before refactors)
-If any of these change, you must update canon docs intentionally:
-- active practice caps (1 / 10)
-- warning thresholds (5 / 7)
-- trial counting rules (caps vs counters)
-- pause logic pointer strategy
-- deterministic routing prerequisites (auth → assessment → practices)
+## 9) Regression "Red Flags" (v2)
+
+If any of these change, canon docs must be updated intentionally:
+
+- Active practice caps (Free=1, Paid=10)
+- Soft cap warnings — currently **none** in v2; reintroducing them is a canon-level change
+- Question count (35) and practice count (35); the 1:1 mapping invariant
+- v2 UPRACTICE status enum (`active | inactive` only)
+- Lenient legacy-status reads (`paused` / `replaced` → inactive on read)
+- `decideRoute` shape: `(profile: { latestAssessmentId }) → "/onboarding" | "/today"`
+- Free-user switch-flow atomicity (deactivate-then-activate)
 
 ---
 
-## 10) Minimum test suite to ship v1 safely
-If time is tight, do at least:
-- Integration tests for `/api/practice` (caps, pause/resume, trials promote)
-- Integration tests for `/api/return` (toggle delta)
-- 2 E2E smokes:
-  - first-time journey
-  - cap enforcement
+## 10) Minimum test suite to ship safely
+
+If time is tight, the irreducible coverage is:
+
+**Unit (Layer 1):**
+- `tests/unit/practices/mapping.test.ts` — 35/35 1:1 invariant
+- `tests/unit/practices/suggestions.test.ts` — weakness-rank determinism
+- `tests/unit/api/practice.post.test.ts` — 4-mode coverage + legacy lenient read
+
+**Integration (Layer 2):**
+- `tests/integration/api/practice.test.ts` — full lifecycle + switch flow
+- `tests/integration/api/return.test.ts` — toggle + counter delta
+- `tests/integration/api/assessment.test.ts` — `suggestedPracticeIds` persisted
+
+**E2E (Layer 3):**
+- `tests/e2e/smoke.spec.ts` — auth redirect invariants
+- `tests/e2e/assessment.spec.ts` — 35-question flow + submit
+- `tests/e2e/authenticated.spec.ts` — `/today` always-loads + `/practices` v2 CTAs + switch dialog
+
+Run order in CI: `npm run test` (Layer 1) → `npm run test:integration` (Layer 2). Run Layer 3 against staging manually before promoting `staging → main`.


### PR DESCRIPTION
## Summary

Closes the last deferred item from Cut 5. Both manual checklists were carrying v1 content with Cut-1 supersede headers on top. This rewrites them end-to-end against the v2 UI and v2 invariants, and removes the supersede preambles — the v2 content IS the canon now.

**2 files changed, +227 / -188.** Doc-only.

### `_docs/canon/launch-checklist.md` (180 → 209 lines)

Sections kept (lifecycle-independent): 0 Pre-launch infra, 1 Auth, 2 Assessment, 6 Progress, 7 Account, 8 Navigation, 11 Mobile, 12 Performance, Sign-off table.

Rewritten:
- **§3 Results** — v2 CTAs (Start / Resume / View on Today), "Browse all 35 practices →" link, "Focus Pillar" copy. Explicit absence check for v1 vocab.
- **§4 Practices** — full rewrite as the 35-practice bank. 7 pillar sections × 5 cards each = 35. Per-card CTA per state. Switch dialog body verified.
- **§5 Today** — "Choose one practice to start." empty state, "/today is always reachable" invariant, no focus chip, no trial section.
- **§9 Plan gating** — switch dialog for Free at cap (replaces v1 "shows error"). No 5+/7+ Paid warnings.
- **§10 Copy & tone** — explicit v1-vocabulary-absent checklist (no `Try this practice`, no `Today's focus`, no `Inactive` as user-facing, etc.)

### `_docs/canon/testing-checklist.md` (198 → 208 lines)

Removed entirely (gone-in-v2):
- §1.3 Trial policy persistence
- §4 Pause/Resume (Option 2)
- §5 Trial lifecycle
- §6.3 Trials count toward counters

Rewritten/added:
- **§1 Storage shape** — UPRACTICE v2 fields (`firstStartedAt`, `lastActivatedAt`, etc.); TRIAL items not written; dead PROFILE fields not returned; ASSESS gains `suggestedPracticeIds`/`lowestPillarId`
- **§2 API contract** — 4-mode `/api/practice` coverage; suggestions hydration from latest ASSESS; assessment response shape; `/api/return` rejects with `PRACTICE_NOT_ACTIVE`
- **§3 Caps** — Free=1, Paid=10, no soft warnings; switch flow
- **§4 (new)** Question ↔ practice mapping — 35/35 bidirectional invariant
- **§5 (new)** Recommendation determinism — `no` first, ties by `order`
- **§6.3 (new)** Streak rule — pure rolling, lifecycle-agnostic
- **§8 Routing** — `decideRoute` shape, E2E smoke selectors (incl. the radar chart `viewBox="0 0 500 420"` selector that came up during the Layer 3 rewrite)
- **§9 Regression red flags** — caps (1/10), mapping invariant, lenient legacy reads, switch-flow atomicity. Items no longer red-flagged: warning thresholds, trial counting, pause logic
- **§10 Minimum test suite** — names the three irreducible files per layer

## Test plan

- [ ] Read both files top-to-bottom on the PR diff view — verify wording matches your understanding of staging.
- [ ] Spot-check 2-3 manual items from the rewritten launch-checklist against the staging URL (e.g., §4 the 35-practice bank actually renders 5 cards per pillar; §5 `/today` empty state actually says "Choose one practice to start.").

No code, no test runs needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)