### PR TITLE
docs: post-v2 cleanup — TODO + canon supersede headers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,91 +1,31 @@
 # FIApp v1 — Remaining Work
 
-Last updated: 2026-05-13
+Last updated: 2026-05-13 (after v2 ship)
 
 ---
 
-## V2 Business-Logic Refactor (in progress)
+## ✅ V2 Business-Logic Refactor — shipped 2026-05-13
 
-Tracking against the staged plan in [_docs/canon/business-logic-v2.md](_docs/canon/business-logic-v2.md). Each Cut ships as its own `feat/*` PR to `staging`.
+Full refactor (5 Cuts) merged to `main` via PR #375. Canonical spec: [_docs/canon/business-logic-v2.md](_docs/canon/business-logic-v2.md).
 
-### Cut 1 — Content + mapping ✅
+Headline changes:
+- 35 practices (5 per pillar), with a stable 1:1 question↔practice mapping
+- Lifecycle simplified to `active | inactive` only — trial / pause-as-state / replace / promote / discard / focus all removed
+- `/today` is always accessible; `decideRoute` is a pure function of `latestAssessmentId`
+- `/api/practice` collapsed to 4 modes; deterministic weakest-answer recommendations
+- Free=1, Paid=10 hard caps; no 5+/7+ soft warnings
+- Free-user "switch dialog" replaces the v1 replace flow
+- Storage stays `status: "inactive"` but UI shows "Paused" / "Resume" / "Pause"
 
-Done on `feat/practice-library-35-mapping` (4 commits, not yet pushed):
-- [x] Expand library 21 → 35 practices
-- [x] Add `mappedPracticeId` / `mappedQuestionId` fields on questions and practices
-- [x] Invariant test for the 1:1 mapping (35/35, bidirectional, pillar-aligned, deterministic order)
-- [x] Canon audit: supersede headers on state-machine / routing-table / practice-caps-and-trials / api-contract / db-schema / execution-plan / launch-checklist / testing-checklist; one-line edit in product-philosophy
-- [x] v2 internal consistency fixes (`totalCompletions` backing, answer-weakness definition, `/auth` + `/onboarding` in route table, 4-modes-3-ops framing)
-
-### Decisions for Cut 3 ✅ (answered 2026-05-13)
-
-- [x] **Q5** — Free-user switch flow: direct switch dialog. Copy: *"Switch to "[new]"? "[old]" will move to your practice bank. You can bring it back anytime."* [Switch] [Cancel]
-- [x] **Q6** — Streak: pure rolling, derived from DailyReturn. Lifecycle-agnostic. Gap of missed days breaks the streak.
-- [x] **Q7** — Drop both 5+/7+ soft warnings. Hard cap at 10 only.
-
-### Cut 2 — Recommendation rewrite ✅
-
-Done on `feat/practice-library-35-mapping` (commit 5b5f8c0):
-- [x] Rewrite `lib/practices/suggestions.ts` to weakest-answer mapped logic
-- [x] Update `app/api/practices/suggestions/route.ts` to hydrate from latest ASSESS (with legacy fallback)
-- [x] Update `app/api/assessment/route.ts` to compute and persist `lowestPillarId` + `suggestedPracticeIds`
-- [x] Update `app/api/assessment/latest/route.ts` type to include the new fields
-- [x] Results page consumes the new suggestion data with no code change (Practice[] shape preserved, extra fields ignored)
-- [x] Tests updated: `tests/unit/practices/suggestions.test.ts` (10 tests), `tests/unit/api/practices.suggestions.get.test.ts` (6 tests), `tests/integration/api/suggestions.test.ts` (5 tests), `tests/unit/api/assessment.post.test.ts` + `tests/integration/api/assessment.test.ts` (assertions on new fields)
-
-### Cut 3 — Lifecycle simplification ✅
-
-Backend phase done (commit 99fd0c9):
-- [x] Rewrite `app/api/practice/route.ts` to 4 modes (`startPractice`, `makePracticeInactive`, `reactivatePractice`, `switchToPractice`)
-- [x] Stop creating `TRIAL#` items; ignore existing on read
-- [x] Lenient read of legacy `paused`/`replaced` UPRACTICE statuses (treat as `inactive`)
-- [x] Server-side cap check using new statuses (Free=1, Paid=10; no soft warnings per Q7)
-- [x] `/api/me`: stop reading TRIAL#; `/api/return`: stop accepting trials, error code is `PRACTICE_NOT_ACTIVE`
-- [x] `checkActiveCap` simplified (no warning paths)
-- [x] Rewrite `tests/unit/api/practice.post.test.ts`, `tests/integration/api/practice.test.ts`
-- [x] Delete `tests/unit/api/practice.e6.test.ts` (tested removed setFocus mode)
-- [x] Update tests for `/api/me` and `/api/return` (no trial paths)
-
-UI phase done (commit 9228f33):
-- [x] `/api/practices/active`: return `inactivePractices` (renamed from `pausedPractices`), drop TRIAL query
-- [x] `/today`: render all active practices as cards; remove focus-practice concept; remove trial sections; empty state for 0 active
-- [x] `/practices`: full rewrite as practice bank — 35 practices grouped by pillar, per-card CTA, switch dialog
-- [x] `/results`: "Try this practice" → v2 CTA logic (Start / Bring this back / View on Today); switch dialog
-- [x] Switch dialog with Q5 copy in both /practices and /results
-
-### Cut 4 — Routing ✅
-
-Done on `feat/v2-routing-strip-focus` (commit pending):
-- [x] Strip `todayFocusPracticeId` branch from `lib/decideRoute.ts` (now 2 branches: `/onboarding` if no assessment, otherwise `/today`)
-- [x] `/today` empty-state UI verified — already built in Cut 3 UI
-- [x] "Set as today's focus" CTAs — already removed in Cut 3 UI
-- [x] `todayFocusPracticeId` kept as a stored PROFILE field for display-only use; routing no longer reads it. Final delete deferred to Cut 5.
-- [x] `tests/unit/decideRoute.test.ts` rewritten for the 2-branch logic
-- [x] `tests/unit/decideRouteClient.test.tsx` rewritten — covers /onboarding, /today (with and without focus), /auth paths
-
-### Cut 5 — Cleanup ✅ (mostly)
-
-Done on `feat/v2-cleanup` (commit pending):
-- [x] Rename `lib/practices/trial.ts` → `lib/practices/caps.ts`; trim to just cap helpers + `makeUPracticeSK` + `ProfileData`. Trial helpers (isTrialActive, TrialItem, makeTrialSK, TRIAL_DURATION_DAYS, MAX_CONCURRENT_TRIALS) deleted.
-- [x] Drop `activePracticeSkById` from `/api/practice` writes and `ProfileData` — SK is now derived directly from `practiceId`
-- [x] Drop dead PROFILE fields from `/api/me` defaults and response: `activePracticeSkById`, `practiceCounters`, `todayFocusPracticeId`, `activeTrialCount`. Legacy stored items still tolerated on read.
-- [x] Drop `seedTrial` from `tests/integration/seeds.ts`; drop dead fields from `seedProfile`/`seedActivePractice`
-- [x] Delete `tests/unit/practices/trial.test.ts`
-- [x] Update unit + integration tests for the new shape (`me`, `return`, `practice.post`)
-- [x] Delete 4 fully-superseded canon docs (state-machine, routing-table, api-contract, practice-caps-and-trials)
-- [x] Remove dead links to those docs from `business-logic-v2.md`
-
-Deferred to a separate "v2 docs cleanup" follow-up:
-- [ ] Full rewrite of `_docs/canon/launch-checklist.md` against v2 UX (currently has supersede header + v1 content)
-- [ ] Full rewrite of `_docs/canon/testing-checklist.md` against v2 invariants (same)
+Follow-up PRs after the main merge: #376 (manual checklist rewrites against v2) and a small doc-cleanup PR (supersede-header refresh + TODO tidy). Decisions Q5/Q6/Q7 are recorded in the v2 doc. See [_docs/canon/business-logic-v2.md](_docs/canon/business-logic-v2.md) for the full spec.
 
 ---
 
 ## Code Gaps (post-epic audit)
 
 - [ ] **Gap 4** — Show next-up milestones on Progress page. Users can't see what they're working toward. Compute next unachieved milestone from `returnCounters` vs thresholds in `lib/milestones/milestones.ts`. Add `nextMilestones` to `GET /api/progress` and render a "Coming up" section on the progress page.
-- [ ] ~~**Gap 3** — `practiceCounters` PROFILE field is never written anywhere. Likely superseded by `returnCounters`. Formally deprecate it in `_docs/canon/db-schema.md`.~~ → folded into v2 Cut 5 (drop dead PROFILE fields).
 - [ ] **Gap 5** *(optional)* — Individual assessment answers not stored. After writing `ASSESS#<id>`, batch-write `ANS#<assessmentId>#<questionId>` items. No user-facing impact right now.
+- [x] ~~**Gap 3** — `practiceCounters` PROFILE field is never written~~ → closed by v2 Cut 5.
 
 ---
 
@@ -97,9 +37,9 @@ Deferred to a separate "v2 docs cleanup" follow-up:
 
 ## Product
 
-- [ ] **Onboarding flow** — First-time users jump straight to the assessment with no warm welcome. Consider a brief intro screen after signup that explains the core loop (assess → focus → practice → check in daily) before routing to `/assessment`.
 - [ ] **Email notifications** — No emails sent at all currently. Key candidates: daily check-in reminder, milestone celebration, weekly summary. Needs an email provider (e.g. SES, Resend).
-- [ ] ~~**Practice library depth** — Audit whether each of the 7 pillars has enough practices to keep users engaged across multiple trial/promote cycles. Aim for at least 8–10 per pillar.~~ → obsoleted by v2 (locked at 5 practices/pillar, 35 total; trial concept removed).
+- [x] ~~**Onboarding flow** — brief intro screen explaining the core loop~~ → redesigned 2026-05-13 (commit 99f3e36 — collapsed 3-screen intro to 1 with pillars + radar).
+- [x] ~~**Practice library depth** — aim for 8–10 per pillar~~ → obsoleted by v2 (locked at 5 practices/pillar, 35 total).
 
 ---
 
@@ -119,7 +59,7 @@ Deferred to a separate "v2 docs cleanup" follow-up:
 ## Open GitHub Epics
 
 ### EPIC 12 — Core Regression Guardrails (issue #172)
-25 tickets. Build a layered test system: unit tests for pure logic, API/integration tests for backend rules, E2E smoke suite for CI, full staging regression suite for releases, and a manual launch checklist. Covers auth, routing, assessment, practices, trials, returns, progress, account, and plan caps.
+25 tickets. Build a layered test system: unit tests for pure logic, API/integration tests for backend rules, E2E smoke suite for CI, full staging regression suite for releases, and a manual launch checklist. Covers auth, routing, assessment, practices, returns, progress, account, and plan caps. (Trials are gone in v2; epic scope adjusted.)
 
 ### EPIC 13 — Staging Environment & Deployment Readiness (issue #198)
 15 tickets. Create a production-like staging environment on Amplify with separate env vars, separate DynamoDB resources, seeded/resettable test data, staging health checks, deployment checklist, rollback process, and a release readiness runbook.

--- a/_docs/canon/db-schema.md
+++ b/_docs/canon/db-schema.md
@@ -1,19 +1,18 @@
 # docs/canon/db-schema.md
 # FIApp v1 — DynamoDB Canonical Schema
 
-> **PARTIALLY SUPERSEDED 2026-05-13 by [business-logic-v2.md](business-logic-v2.md)** (see its "Storage notes (DynamoDB)" section).
+> **PARTIALLY SUPERSEDED.** v2 shipped to production 2026-05-13 (PR #375). The active spec is [business-logic-v2.md](business-logic-v2.md) (see its "Storage notes (DynamoDB)" section).
 >
-> Still authoritative in v2: table layout (FIAPP_MAIN + FIAPP_RETURNS), PROFILE/ASSESS/ANS/MILESTONE item shapes (with v2 additions), key access patterns.
+> Still authoritative below: table layout (FIAPP_MAIN + FIAPP_RETURNS), ASSESS/ANS/MILESTONE item shapes, key access patterns.
 >
-> Superseded by v2:
-> - **UPRACTICE status enum** is `"active" | "inactive"` only — the `"paused" | "ended"` values and the "must support pause/resume" invariant are gone.
-> - **UPRACTICE SK** uses `UPRACTICE#<practiceId>` (no `<startedAt>` prefix) — one record per `userId + practiceId`.
-> - **TRIAL items** (§1.2.F) — entire item type is removed; v2 does not create them. The "trials don't count toward caps, do count toward counters" policy (§3.2, §5) is gone.
-> - **PROFILE.`todayFocusPracticeId`** — kept as a field but demoted to display-only; not a routing input in v2.
-> - **PROFILE.`focusPillar`** — clients should prefer `lowestPillarId` (v2 naming).
-> - **PROFILE.`practiceCounters`** — never written in practice; treat as deprecated.
-> - **ASSESS** items in v2 also store `pillarScores`, `lowestPillarId`, and `suggestedPracticeIds`.
-> - **Cap warnings** — 5/7 thresholds are optional in v2 (not mandatory); 1 / 10 hard caps remain.
+> What changed in v2:
+> - **UPRACTICE status enum** is now `"active" | "inactive"` only. Legacy `"paused"`/`"replaced"` values are read leniently (treated as inactive) but never written.
+> - **UPRACTICE SK** is `UPRACTICE#<practiceId>` — one record per `userId + practiceId`. The v1 `UPRACTICE#<startedAt>#<practiceId>` form was never actually shipped to prod.
+> - **TRIAL items** are gone — v2 doesn't write them, reads ignore any legacy ones.
+> - **PROFILE** no longer carries `activePracticeSkById`, `practiceCounters`, `activeTrialCount`, or `todayFocusPracticeId`. `/api/me` doesn't return them either. Reads tolerate legacy items that still have them.
+> - **PROFILE** adds `lowestPillarId` (preferred) alongside legacy `focusPillar`.
+> - **ASSESS** items now store `pillarScores`, `lowestPillarId`, `suggestedPracticeIds[]`.
+> - **Cap warnings** at 5+/7+ active are gone. Hard caps remain (Free=1, Paid=10).
 
 **Status:** Partially canonical (see supersede note above)
 **Tables:** 2 (FIAPP_MAIN + FIAPP_RETURNS)  

--- a/_docs/canon/execution-plan.md
+++ b/_docs/canon/execution-plan.md
@@ -1,12 +1,12 @@
 # docs/canon/execution-plan.md
 # FIApp v1 — Canonical Execution Plan
 
-> **PARTIALLY SUPERSEDED 2026-05-13 by [business-logic-v2.md](business-logic-v2.md).**
+> **PARTIALLY SUPERSEDED.** v2 shipped to production 2026-05-13 (PR #375). Active spec: [business-logic-v2.md](business-logic-v2.md).
 >
-> - **EPIC 5 — Trial Practices (Activation Engine)**: removed in v2. The trial concept is gone; reactivation of an inactive practice ("Bring this back") replaces it.
-> - **EPIC 9 — Routing & State Machine Hardening**: routing rules reworked in v2 — `/today` is always accessible, `todayFocusPracticeId` is no longer a routing input.
+> - **EPIC 5 — Trial Practices (Activation Engine)**: removed. The trial concept is gone in v2; resuming a paused practice is the new model.
+> - **EPIC 9 — Routing & State Machine Hardening**: routing rules reworked — `/today` is always accessible, `decideRoute` is a pure function of `latestAssessmentId`, and `todayFocusPracticeId` is no longer a routing input.
 >
-> Other epics (0 Foundations, 1 Identity, 2 Core Screens, 3 Assessment, 4 Practice Library, 6 Active Practice Management, 7 Daily Returns, 8 Counters & Milestones, 10 Production Readiness) are unaffected by v2 as objectives. Specific tickets within them that touched trial/pause/replace/focus state will be reworked in v2 Cuts 3-5.
+> Other epics (0 Foundations, 1 Identity, 2 Core Screens, 3 Assessment, 4 Practice Library, 6 Active Practice Management, 7 Daily Returns, 8 Counters & Milestones, 10 Production Readiness) are still relevant as objectives. The specific tickets that touched trial/pause/replace/focus state were reworked in v2's Cuts 3-5 (all shipped).
 
 **Purpose:** Preserve build order, intent, and scope discipline.
 

--- a/_docs/canon/product-philosophy.md
+++ b/_docs/canon/product-philosophy.md
@@ -41,9 +41,8 @@ The app is intentionally designed to:
 - prefer depth over breadth
 
 This is why:
-- active practice caps exist
-- warnings are progressive
-- practices can be made inactive and brought back later without losing history, so the active list stays small
+- active practice caps exist (Free=1, Paid=10)
+- practices can be paused and resumed later without losing history, so the active list stays small
 
 Mental sustainability is more important than theoretical completeness.
 


### PR DESCRIPTION
## Summary

Small post-v2-ship tidy. **4 files changed, +35 / -97** — net deletion. Doc-only, no tests.

### `TODO.md` (132 → 71 lines)

The V2 Refactor section took up ~75 lines of done-Cut checklists. Compressed to a 10-line "shipped 2026-05-13 via PR #375" summary that links to `business-logic-v2.md`. The pre-existing backlog is unchanged and now the primary content.

Also marked the **Onboarding flow** item as done (commit `99f3e36` collapsed the 3-screen intro into 1 with pillars + radar).

### `_docs/canon/db-schema.md` supersede header

- Past tense ("v2 shipped 2026-05-13" not "Cuts 3-5 work")
- Corrected the dead-fields list: `activePracticeSkById` / `practiceCounters` / `activeTrialCount` / `todayFocusPracticeId` were all **fully dropped** in Cut 5, not just "demoted" or "deprecated" as the old header said
- Added that `lowestPillarId` is preferred over legacy `focusPillar`

### `_docs/canon/execution-plan.md` supersede header

- Past tense; reflects that Epic 5 (Trial) is gone for good
- Notes `decideRoute` is now pure
- Uses "resumed" (not "brought back") per v2 vocab

### `_docs/canon/product-philosophy.md` §3

- Drops `warnings are progressive` — v2 has no 5+/7+ soft warnings
- `made inactive and brought back` → `paused and resumed` to match v2 UI vocab

## Not touched

`_docs/plans/epic2-profile-defaults.md` + `_docs/layer1-gaps.md` + `_docs/layer2-gaps.md` are historical planning artifacts that reference deleted v1 canon docs and dead PROFILE fields. They documented work that has long since shipped. Leaving them alone — git history preserves them and they're not actively misleading anyone who's already reading v2 spec.

## Test plan

Reading the diff is the test plan. No code, no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)