### PR TITLE
fix(auth): route Cognito verification emails via SES

### DIFF
--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -33,6 +33,12 @@ export const auth = defineAuth({
       ],
     },
   },
+  senders: {
+    email: {
+      fromEmail: 'no-reply@friendsintelligence.net',
+      fromName: 'Friends Intelligence',
+    },
+  },
   triggers: {
     preSignUp: preSignUpTrigger,
   },


### PR DESCRIPTION
## Summary
- Adds `senders.email` to `defineAuth` so Cognito sends verification codes via SES from `no-reply@friendsintelligence.net` instead of the spam-filtered default `no-reply@verificationemail.com`.
- Fixes prod bug where new Gmail signups silently missed their verification email (delivered to spam, or not at all).

## AWS prerequisites already in place
- SES domain identity `friendsintelligence.net` — Verified, DKIM Successful
- SES email identity `no-reply@friendsintelligence.net` — Verified (workaround for [amplify-backend#3134](https://github.com/aws-amplify/amplify-backend/issues/3134) — domain-only verification triggers `"Email address is not verified"` deploy failure because Amplify generates an email-level ARN)
- DNS (Route 53): 3 DKIM CNAMEs (SES auto-published), SPF TXT merged with ImprovMX, DMARC TXT (`p=none`)
- ImprovMX catch-all forwarding `*@friendsintelligence.net` → `qianhaopower@gmail.com` (so the no-reply mailbox can receive AWS verification mail)
- SES production access request: submitted, awaiting AWS approval (~24h)

## Test plan
- [ ] Amplify Hosting staging build succeeds (watch for `"Email address is not verified"` in CFN log — would indicate #3134 surfaced)
- [ ] Sign up at https://staging.d3nyg9qvz1tj5n.amplifyapp.com/auth with `qianhaopower+sestest@gmail.com` (or any verified-recipient alias, while SES is still in sandbox)
- [ ] Verification email arrives in inbox (not spam), `From: Friends Intelligence <no-reply@friendsintelligence.net>`, DKIM-signed
- [ ] Code entry completes signup; full auth flow works end-to-end
- [ ] Google sign-in still works (unrelated to SES, but covered by this auth change touching `defineAuth`)
- [ ] **DO NOT** promote staging → main until SES production access is granted — until then, sign-ups from unverified Gmail addresses will silently fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)