### PR TITLE
Progress page polish: milestone badges + dedupe Coming up + softer onboarding copy

### DIFF
--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -15,7 +15,9 @@ import {
   TOTAL_MILESTONES,
   PRACTICE_MILESTONES,
   makeMilestoneSK,
+  getMilestoneDef,
 } from '@/lib/milestones/milestones'
+import { practicesById } from '@/lib/practices/library'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -86,8 +88,9 @@ export async function GET(req: Request) {
     const achievedSKs = new Set(milestones.map((m) => m.SK))
 
     type NextMilestone = {
-      type: string; threshold: number; practiceId?: string
+      type: string; threshold: number; practiceId?: string; practiceTitle?: string
       title: string; description: string; progress: number; remaining: number
+      icon: string; tier: string
     }
     const nextMilestones: NextMilestone[] = []
 
@@ -98,20 +101,26 @@ export async function GET(req: Request) {
           type: 'total', threshold: def.threshold,
           title: def.title, description: def.description,
           progress: totalReturns, remaining: def.threshold - totalReturns,
+          icon: def.icon, tier: def.tier,
         })
         break
       }
     }
 
-    // Next practice milestone per active practice
+    // Next practice milestone per active practice — only surface practices the
+    // user has at least one check-in on, so the section doesn't get padded with
+    // visually-identical 0/7 cards for every untouched active practice.
     for (const practiceId of activePracticeIds) {
       const practiceCount = counters[practiceId] ?? 0
+      if (practiceCount === 0) continue
       for (const def of PRACTICE_MILESTONES) {
         if (!achievedSKs.has(makeMilestoneSK('practice', def.threshold, practiceId))) {
           nextMilestones.push({
             type: 'practice', threshold: def.threshold, practiceId,
+            practiceTitle: practicesById.get(practiceId)?.title,
             title: def.title, description: def.description,
             progress: practiceCount, remaining: def.threshold - practiceCount,
+            icon: def.icon, tier: def.tier,
           })
           break
         }
@@ -125,15 +134,20 @@ export async function GET(req: Request) {
       currentStreak,
       longestStreak,
       nextMilestones,
-      milestones: milestones.map((m) => ({
-        sk: m.SK,
-        type: m.type,
-        threshold: m.threshold,
-        practiceId: m.practiceId,
-        title: m.title,
-        description: m.description,
-        achievedAt: m.achievedAt,
-      })),
+      milestones: milestones.map((m) => {
+        const def = getMilestoneDef(m.type, m.threshold)
+        return {
+          sk: m.SK,
+          type: m.type,
+          threshold: m.threshold,
+          practiceId: m.practiceId,
+          title: m.title,
+          description: m.description,
+          achievedAt: m.achievedAt,
+          icon: def?.icon,
+          tier: def?.tier,
+        }
+      }),
     })
   })
 }

--- a/app/api/return/route.ts
+++ b/app/api/return/route.ts
@@ -131,7 +131,14 @@ export async function POST(req: Request) {
             }
             const isNew = await mainClient.putItemIfNotExists(item)
             if (!isNew) return null
-            const m: NewMilestone = { type: def.type, threshold: def.threshold, title: def.title, description: def.description }
+            const m: NewMilestone = {
+              type: def.type,
+              threshold: def.threshold,
+              title: def.title,
+              description: def.description,
+              icon: def.icon,
+              tier: def.tier,
+            }
             if (hit.practiceId) m.practiceId = hit.practiceId
             return m
           })

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -49,7 +49,7 @@ export default function OnboardingPage() {
               7 areas of your life
             </h1>
             <p className="text-sm text-muted-foreground leading-relaxed">
-              Friends Intelligence is a framework for building the habits that matter most across seven areas of a well-lived life. You&apos;ll get a score for each — the one with the most room to grow becomes your starting focus.
+              Friends Intelligence is a framework for building the habits that matter most across seven areas of a well-lived life. You&apos;ll get a quick snapshot of how each area feels today — and we&apos;ll pick one to focus on first.
             </p>
           </div>
 

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { DashboardPage } from '@/components/layout';
 import { StatCard, EmptyState, Card, Button, Loading, ErrorState } from '@/components/ui';
+import { MilestoneBadge } from '@/components/MilestoneBadge';
+import type { MilestoneIcon, MilestoneTier } from '@/lib/milestones/milestones';
 
 type Milestone = {
   sk: string
@@ -13,16 +15,21 @@ type Milestone = {
   title: string
   description: string
   achievedAt: string
+  icon?: MilestoneIcon
+  tier?: MilestoneTier
 }
 
 type NextMilestone = {
   type: string
   threshold: number
   practiceId?: string
+  practiceTitle?: string
   title: string
   description: string
   progress: number
   remaining: number
+  icon: MilestoneIcon
+  tier: MilestoneTier
 }
 
 type ProgressData = {
@@ -94,19 +101,26 @@ export default function ProgressPage() {
                 const pct = Math.min(100, Math.round((m.progress / m.threshold) * 100))
                 return (
                   <Card key={`${m.type}-${m.threshold}-${m.practiceId ?? ''}`} variant="subtle">
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between">
-                        <p className="font-semibold text-foreground text-sm">{m.title}</p>
-                        <p className="text-xs text-muted-foreground">{m.progress}/{m.threshold}</p>
+                    <div className="flex items-start gap-3">
+                      <MilestoneBadge icon={m.icon} tier={m.tier} achieved={false} size="sm" />
+                      <div className="flex-1 space-y-2">
+                        <div className="flex items-center justify-between">
+                          <p className="font-semibold text-foreground text-sm">
+                            {m.practiceTitle ?? m.title}
+                          </p>
+                          <p className="text-xs text-muted-foreground">{m.progress}/{m.threshold}</p>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {m.practiceTitle ? `${m.title} — ${m.description}` : m.description}
+                        </p>
+                        <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                          <div
+                            className="h-1.5 rounded-full bg-primary transition-all"
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                        <p className="text-xs text-muted-foreground">{m.remaining} more to go</p>
                       </div>
-                      <p className="text-xs text-muted-foreground">{m.description}</p>
-                      <div className="h-1.5 rounded-full bg-muted overflow-hidden">
-                        <div
-                          className="h-1.5 rounded-full bg-primary transition-all"
-                          style={{ width: `${pct}%` }}
-                        />
-                      </div>
-                      <p className="text-xs text-muted-foreground">{m.remaining} more to go</p>
                     </div>
                   </Card>
                 )
@@ -126,9 +140,13 @@ export default function ProgressPage() {
             <div className="space-y-3">
               {data.milestones.map((m) => (
                 <Card key={m.sk} variant="subtle" className="flex items-start gap-4">
-                  <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>
-                  </div>
+                  {m.icon && m.tier ? (
+                    <MilestoneBadge icon={m.icon} tier={m.tier} achieved size="md" />
+                  ) : (
+                    <div className="h-9 w-9 rounded-full bg-primary/10 flex items-center justify-center text-primary shrink-0">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>
+                    </div>
+                  )}
                   <div>
                     <p className="font-semibold text-foreground">{m.title}</p>
                     <p className="text-sm text-muted-foreground">{m.description}</p>

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { HelpTooltip } from '@/components/HelpTooltip';
 import { NarrowFormPage } from '@/components/layout';
 import { Card, Button, Loading, ErrorState } from '@/components/ui';
+import { MilestoneBadge } from '@/components/MilestoneBadge';
 import { pillarColors } from '@/lib/design/pillarColors';
 import { pillarLabels } from '@/lib/assessment/pillars';
 import type { Pillar } from '@/lib/assessment/pillars';
@@ -157,9 +158,15 @@ export default function TodayPage() {
             <div className="space-y-2">
               <p className="text-sm font-semibold text-primary">Milestone unlocked!</p>
               {newMilestones.map((m) => (
-                <div key={`${m.type}-${m.threshold}-${m.practiceId ?? 'total'}`}>
-                  <p className="text-sm font-medium text-foreground">{m.title}</p>
-                  <p className="text-xs text-muted-foreground">{m.description}</p>
+                <div
+                  key={`${m.type}-${m.threshold}-${m.practiceId ?? 'total'}`}
+                  className="flex items-start gap-3"
+                >
+                  <MilestoneBadge icon={m.icon} tier={m.tier} achieved size="sm" />
+                  <div>
+                    <p className="text-sm font-medium text-foreground">{m.title}</p>
+                    <p className="text-xs text-muted-foreground">{m.description}</p>
+                  </div>
                 </div>
               ))}
               <button

--- a/components/MilestoneBadge.tsx
+++ b/components/MilestoneBadge.tsx
@@ -1,0 +1,105 @@
+import type { MilestoneIcon, MilestoneTier } from '@/lib/milestones/milestones'
+
+type Props = {
+  icon: MilestoneIcon
+  tier: MilestoneTier
+  achieved?: boolean
+  size?: 'sm' | 'md'
+  className?: string
+}
+
+const tierStyles: Record<MilestoneTier, { achieved: string; pending: string }> = {
+  bronze: {
+    achieved: 'bg-amber-100 text-amber-700 ring-1 ring-amber-200',
+    pending:  'bg-amber-50 text-amber-400 ring-1 ring-amber-100',
+  },
+  silver: {
+    achieved: 'bg-slate-200 text-slate-700 ring-1 ring-slate-300',
+    pending:  'bg-slate-100 text-slate-400 ring-1 ring-slate-200',
+  },
+  gold: {
+    achieved: 'bg-yellow-100 text-yellow-700 ring-1 ring-yellow-300',
+    pending:  'bg-yellow-50 text-yellow-400 ring-1 ring-yellow-200',
+  },
+}
+
+const sizeMap = {
+  sm: { box: 'h-8 w-8', stroke: 16 },
+  md: { box: 'h-10 w-10', stroke: 20 },
+}
+
+export function MilestoneBadge({ icon, tier, achieved = true, size = 'md', className }: Props) {
+  const tone = tierStyles[tier][achieved ? 'achieved' : 'pending']
+  const { box, stroke } = sizeMap[size]
+
+  return (
+    <div
+      aria-hidden="true"
+      className={`${box} rounded-full flex items-center justify-center shrink-0 ${tone} ${className ?? ''}`}
+    >
+      <IconGlyph icon={icon} size={stroke} />
+    </div>
+  )
+}
+
+function IconGlyph({ icon, size }: { icon: MilestoneIcon; size: number }) {
+  const common = {
+    width: size,
+    height: size,
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: 2,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+  }
+
+  switch (icon) {
+    case 'sprout':
+      return (
+        <svg {...common}>
+          <path d="M7 20h10" />
+          <path d="M10 20c5.5-2.5.8-6.4 3-10" />
+          <path d="M9.5 9.4c1.1.8 1.8 2.2 2.3 3.7-2 .4-3.5.4-4.8-.3-1.2-.6-2.3-1.9-3-4.2 2.8-.5 4.4 0 5.5.8z" />
+          <path d="M14.1 6a7 7 0 0 0-1.1 4c1.9-.1 3.3-.6 4.3-1.4 1-1 1.6-2.3 1.7-4.6-2.7.1-4 1-4.9 2z" />
+        </svg>
+      )
+    case 'calendar':
+      return (
+        <svg {...common}>
+          <rect width="18" height="18" x="3" y="4" rx="2" />
+          <path d="M16 2v4" />
+          <path d="M8 2v4" />
+          <path d="M3 10h18" />
+        </svg>
+      )
+    case 'flame':
+      return (
+        <svg {...common}>
+          <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z" />
+        </svg>
+      )
+    case 'trophy':
+      return (
+        <svg {...common}>
+          <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
+          <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
+          <path d="M4 22h16" />
+          <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
+          <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
+          <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
+        </svg>
+      )
+    case 'medal':
+      return (
+        <svg {...common}>
+          <path d="M7.21 15 2.66 7.14a2 2 0 0 1 .13-2.2L4.4 2.8A2 2 0 0 1 6 2h12a2 2 0 0 1 1.6.8l1.6 2.14a2 2 0 0 1 .14 2.2L16.79 15" />
+          <path d="M11 12 5.12 2.2" />
+          <path d="m13 12 5.88-9.8" />
+          <path d="M8 7h8" />
+          <circle cx="12" cy="17" r="5" />
+          <path d="M11 17l1 1 2-2" />
+        </svg>
+      )
+  }
+}

--- a/lib/milestones/milestones.ts
+++ b/lib/milestones/milestones.ts
@@ -1,10 +1,14 @@
 export type MilestoneType = 'total' | 'practice'
+export type MilestoneTier = 'bronze' | 'silver' | 'gold'
+export type MilestoneIcon = 'sprout' | 'calendar' | 'flame' | 'trophy' | 'medal'
 
 export type MilestoneDef = {
   type: MilestoneType
   threshold: number
   title: string
   description: string
+  icon: MilestoneIcon
+  tier: MilestoneTier
 }
 
 export type MilestoneItem = {
@@ -20,18 +24,20 @@ export type MilestoneItem = {
 
 export type NewMilestone = Pick<MilestoneItem, 'type' | 'threshold' | 'title' | 'description'> & {
   practiceId?: string
+  icon: MilestoneIcon
+  tier: MilestoneTier
 }
 
 export const TOTAL_MILESTONES: MilestoneDef[] = [
-  { type: 'total', threshold: 1,   title: 'First check-in',  description: 'Logged your very first practice.' },
-  { type: 'total', threshold: 7,   title: 'One week in',     description: 'Seven check-ins logged.' },
-  { type: 'total', threshold: 30,  title: 'Monthly habit',   description: '30 check-ins across your practices.' },
-  { type: 'total', threshold: 100, title: 'Century',         description: '100 total check-ins. Remarkable.' },
+  { type: 'total', threshold: 1,   title: 'First check-in',  description: 'Logged your very first practice.',     icon: 'sprout',   tier: 'bronze' },
+  { type: 'total', threshold: 7,   title: 'One week in',     description: 'Seven check-ins logged.',              icon: 'calendar', tier: 'bronze' },
+  { type: 'total', threshold: 30,  title: 'Monthly habit',   description: '30 check-ins across your practices.',  icon: 'flame',    tier: 'silver' },
+  { type: 'total', threshold: 100, title: 'Century',         description: '100 total check-ins. Remarkable.',     icon: 'trophy',   tier: 'gold' },
 ]
 
 export const PRACTICE_MILESTONES: MilestoneDef[] = [
-  { type: 'practice', threshold: 7,  title: '7-day practice',  description: '7 check-ins for a single practice.' },
-  { type: 'practice', threshold: 30, title: 'Practice master', description: '30 check-ins for a single practice.' },
+  { type: 'practice', threshold: 7,  title: '7-day practice',  description: '7 check-ins for a single practice.',  icon: 'calendar', tier: 'bronze' },
+  { type: 'practice', threshold: 30, title: 'Practice master', description: '30 check-ins for a single practice.', icon: 'medal',    tier: 'silver' },
 ]
 
 export const ALL_MILESTONE_DEFS = [...TOTAL_MILESTONES, ...PRACTICE_MILESTONES]


### PR DESCRIPTION
## Summary

Three small UI improvements bundled together:

- **Softer onboarding copy.** Replaced "you'll get a score for each — the one with the most room to grow becomes your starting focus" with a less judgmental snapshot framing: "you'll get a quick snapshot of how each area feels today — and we'll pick one to focus on first."
- **Dedupe Progress → "Coming up".** Every active practice without a crossed milestone was producing its own visually-identical "7-day practice" card, flooding the section. Now we only surface a practice card once the user has at least one check-in on it, and each card shows the practice name so siblings are distinguishable.
- **Milestone tier badges.** Each milestone def now declares an `icon` (sprout / calendar / flame / trophy / medal) and a `tier` (bronze / silver / gold). A new `MilestoneBadge` component renders a colored circular chip with an inline Lucide-style SVG icon — no images, no assets. Used in the Coming-up cards (muted), the achieved milestones list (filled), and the Today "Milestone unlocked!" banner.

Visual identity lives on the milestone def so every surface stays in sync; the API enriches both `nextMilestones` and the achieved milestones list via `getMilestoneDef`.

## Test plan

- [ ] Visit `/onboarding` — verify the welcome copy reads with the snapshot framing
- [ ] Visit `/progress` — verify "Coming up" no longer shows duplicate-looking 7-day-practice cards for untouched practices; cards with progress show the practice name
- [ ] Verify each Coming-up card and each achieved milestone has a tier-colored badge with the right icon
- [ ] Check in on a practice that crosses a milestone — verify the "Milestone unlocked!" banner on `/today` shows the badge
- [ ] Run `npm run test:all` locally (covered: 294 unit + 59 integration, all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)