### PR TITLE
fix(auth): drop Cognito password symbol requirement

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -55,3 +55,12 @@ backend.preSignUpTrigger.resources.lambda.addToRolePolicy(
     resources: [`arn:aws:cognito-idp:${Aws.REGION}:${Aws.ACCOUNT_ID}:userpool/*`],
   })
 );
+
+// Amplify Gen 2 defaults the Cognito password policy to require symbols, but
+// browser-suggested passwords often omit them, causing confusing signup failures.
+// Drop the symbol requirement via CDK escape hatch (defineAuth does not expose
+// passwordPolicy as a public option).
+backend.auth.resources.cfnResources.cfnUserPool.addPropertyOverride(
+  "Policies.PasswordPolicy.RequireSymbols",
+  false,
+);

--- a/components/AuthenticatorWrapper.tsx
+++ b/components/AuthenticatorWrapper.tsx
@@ -13,14 +13,12 @@ const passwordSettings = {
   requireLowercase: true,
   requireUppercase: true,
   requireNumbers: true,
-  requireSpecialCharacters: true,
 };
 
 function PasswordRequirements() {
   return (
     <p className="mt-2 text-xs leading-5 text-muted-foreground">
-      Passwords need 8+ characters with uppercase, lowercase, a number, and a
-      symbol.
+      Passwords need 8+ characters with uppercase, lowercase, and a number.
     </p>
   );
 }


### PR DESCRIPTION
## Summary
- Removes the \"symbol required\" rule from the Cognito user pool password policy and the matching client-side validation in the Amplify Authenticator.
- Motivation: Chrome (and other browsers) suggest passwords that often omit special characters, leading to confusing signup failures where the autofilled password is rejected.
- Existing user passwords are unaffected; this only relaxes validation for new signups and password resets.

## Implementation
- **Server-side** (Cognito policy): CDK escape hatch in `amplify/backend.ts`. Amplify Gen 2's `defineAuth` does not expose `passwordPolicy` as a public option, so the property override is the documented workaround.
- **Client-side** (UI validation + help text): Drop `requireSpecialCharacters` from `passwordSettings` and update the requirements string in `components/AuthenticatorWrapper.tsx`.

## Resulting policy
- Min length: 8
- Requires: lowercase, uppercase, number
- Does NOT require: symbol

## Note on PR #380
PR #380 (\`staging → main\` promotion) is currently open. Once this PR merges to staging, PR #380's diff updates to include this commit automatically. Both auth changes (SES sender + password policy) will ship together when PR #380 merges.

## Test plan
- [ ] Staging CI passes (typecheck, unit, integration)
- [ ] Amplify staging build deploys successfully (will redeploy Cognito with the new policy)
- [ ] On staging, sign up with a Chrome-suggested password that has no symbol → should succeed
- [ ] Sign up with a password missing uppercase → should still fail (other requirements intact)
- [ ] Help text on /auth shows new requirements (no \"symbol\" mention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)