### PR TITLE
docs(canon): document the SES migration + password policy change

### DIFF
--- a/_docs/canon/cognito-and-environments.md
+++ b/_docs/canon/cognito-and-environments.md
@@ -2,9 +2,11 @@
 
 This document captures how authentication, data, and environment configuration
 work across local / staging / production, plus the lessons learned from the
-2026-05-09 incident where the production Cognito user pool was accidentally
-deleted. Read this before making changes to anything in `amplify/` or before
-deleting AWS resources directly.
+2026-05-09 incident (production Cognito user pool accidentally deleted) and
+the 2026-05-16 SES email migration (Cognito verification codes were being
+spam-filtered by Gmail; switched to SES with DKIM/SPF/DMARC, and dropped the
+password symbol requirement at the same time). Read this before making
+changes to anything in `amplify/` or before deleting AWS resources directly.
 
 **For a short "how do I get `npm run dev` running on a fresh checkout" recipe,
 see [local-dev.md](./local-dev.md).** This doc is the deep reference; that one
@@ -347,7 +349,7 @@ table now outlives the stack permanently.
 
 ---
 
-## 8. Quick reference: AWS resources as of 2026-05-09
+## 8. Quick reference: AWS resources as of 2026-05-16
 
 ### Cognito user pools
 
@@ -382,6 +384,29 @@ tables. Access keys live in:
 
 The user has at most 2 active access keys at a time; rotate by deactivating
 old + creating new.
+
+### SES identities (added 2026-05-16, see § 11)
+
+All in `ap-southeast-2`:
+
+| Identity | Type | Status | Purpose |
+|---|---|---|---|
+| `friendsintelligence.net` | Domain | Verified, DKIM Successful | DKIM signs all Cognito outbound mail |
+| `no-reply@friendsintelligence.net` | Email | Verified | **Load-bearing** — workaround for amplify-backend#3134 |
+| `qianhaopower@gmail.com` | Email | Verified | (Optional) Leftover from sandbox-era testing; safe to keep or delete |
+
+SES production access: **granted** in `ap-southeast-2` on 2026-05-16
+(per-region; if region changes, must be requested again).
+
+### Third-party email forwarding (ImprovMX)
+
+ImprovMX free-tier handles inbound mail for `friendsintelligence.net`:
+- Catch-all alias `*@friendsintelligence.net` → `qianhaopower@gmail.com`
+- MX records in Route 53 point to `mx1.improvmx.com` / `mx2.improvmx.com`
+- Used so the `no-reply@` mailbox can receive SES verification emails
+
+Dashboard: improvmx.com. Free tier is generous (25 aliases, unlimited
+forwarding) so no cost concern.
 
 ---
 
@@ -432,6 +457,21 @@ to add a "set password" flow.
 CI workflow should already do this; if it doesn't, the workflow file got
 out of sync.
 
+### Signup verification email never arrives (post-2026-05-16)
+
+→ See § 11. Check, in order: (1) Gmail spam folder, (2) SES sending stats
+in the SES console for failed/bounced messages, (3) that SES is still out
+of sandbox in `ap-southeast-2`, (4) that both `friendsintelligence.net`
+(domain) and `no-reply@friendsintelligence.net` (email) identities are
+still verified in SES.
+
+### CloudFormation deploy fails with "Email address is not verified"
+
+→ The amplify-backend#3134 bug surfacing. Means the SES email-address
+identity `no-reply@friendsintelligence.net` got deleted, expired, or was
+never created. Recreate it in SES (`ap-southeast-2`); domain verification
+alone is not enough — see § 11 for why.
+
 ---
 
 ## 10. Related PRs and where to look
@@ -440,11 +480,16 @@ out of sync.
 - **PR #343** — import `FIAPP_RETURNS` in production
 - **PR #350** — untrack `amplify_outputs.json` + add CI stub script
 - **PR #353** — staging → main sync (after #350 caused conflict)
+- **PR #366** — fix middleware/Identity-Pool auth-hang loop (see [related project memory])
+- **PR #379** — Cognito verification emails now sent via SES (the headline of the 2026-05-16 migration)
+- **PR #380** — staging → main promotion shipping #379 + #382 (the actual prod cutover)
+- **PR #382** — drop Cognito password symbol requirement (CDK escape hatch)
 
 Source of truth files:
-- [amplify/backend.ts](../../amplify/backend.ts) — table imports vs creates
-- [amplify/auth/resource.ts](../../amplify/auth/resource.ts) — Cognito config
+- [amplify/backend.ts](../../amplify/backend.ts) — table imports vs creates; CDK escape hatch for password policy
+- [amplify/auth/resource.ts](../../amplify/auth/resource.ts) — Cognito config, including `senders.email`
 - [amplify/auth/pre-sign-up-trigger/handler.ts](../../amplify/auth/pre-sign-up-trigger/handler.ts) — account linking logic
+- [components/AuthenticatorWrapper.tsx](../../components/AuthenticatorWrapper.tsx) — client-side `passwordSettings` and UI help text (must mirror the server policy)
 - [utils/dynamoClient.ts](../../utils/dynamoClient.ts) — direct DynamoDB SDK
 - [utils/amplifyServerUtils.ts](../../utils/amplifyServerUtils.ts) — AppSync server runner
 - [scripts/create-amplify-stub.mjs](../../scripts/create-amplify-stub.mjs) — CI stub generator
@@ -452,3 +497,153 @@ Source of truth files:
 - [scripts/backup-amplify-outputs.mjs](../../scripts/backup-amplify-outputs.mjs) — `npm run backup:amplify`
 - [scripts/restore-amplify-outputs.mjs](../../scripts/restore-amplify-outputs.mjs) — `npm run restore:amplify`
 - [amplify.yml](../../amplify.yml) — Amplify Hosting build pipeline
+
+---
+
+## 11. Email delivery via SES (added 2026-05-16)
+
+The Cognito user pool sends signup verification codes, password reset codes,
+and email-change confirmations. Until 2026-05-16, these went through
+Cognito's default sender (`no-reply@verificationemail.com`), which Gmail
+aggressively spam-filtered — many new users never saw their verification
+email. This section is the deep reference for the SES setup we migrated to.
+
+### 11.1 What changed in code
+
+[amplify/auth/resource.ts](../../amplify/auth/resource.ts):
+
+```ts
+export const auth = defineAuth({
+  loginWith: { email: true, externalProviders: { ... } },
+  senders: {
+    email: {
+      fromEmail: 'no-reply@friendsintelligence.net',
+      fromName: 'Friends Intelligence',
+    },
+  },
+  triggers: { preSignUp: preSignUpTrigger },
+});
+```
+
+That single `senders.email` block routes all Cognito outbound mail through
+SES from the verified domain identity. Gmail sees a DKIM-signed message
+from a verified domain and delivers to inbox (the `mailed-by:
+ap-southeast-2.amazonses.com` + `signed-by: friendsintelligence.net`
+headers are the textbook signals).
+
+### 11.2 Required SES identities — both must exist
+
+| Identity | Type | Region | Purpose |
+|---|---|---|---|
+| `friendsintelligence.net` | Domain | ap-southeast-2 | DKIM signing (Easy DKIM, RSA_2048_BIT) |
+| `no-reply@friendsintelligence.net` | Email | ap-southeast-2 | Workaround for amplify-backend#3134 |
+
+**Both identities are load-bearing.** If either is deleted, deploys break
+or signups silently fail. The duplication is required until AWS fixes
+[amplify-backend#3134](https://github.com/aws-amplify/amplify-backend/issues/3134)
+(see § 11.3).
+
+### 11.3 The #3134 dual-identity workaround
+
+The Amplify Gen 2 SDK has an open bug: when you specify
+`senders.email.fromEmail = 'no-reply@example.com'`, Amplify generates a
+CloudFormation `EmailConfiguration.SourceArn` pointing at the
+**email-level** identity ARN (`...identity/no-reply@example.com`) — NOT
+the **domain-level** identity ARN (`...identity/example.com`). If you only
+verified the domain in SES, deploys fail with:
+
+> Email address is not verified. The following identities failed the check
+> in region AP-SOUTHEAST-2:
+> arn:aws:ses:ap-southeast-2:...:identity/no-reply@friendsintelligence.net
+
+The error message is misleading — the identity *is* verified, just at a
+different ARN.
+
+**Workaround:** verify BOTH the domain (for DKIM signing) AND the specific
+email address (for the ARN that Amplify generates). SES picks the most
+specific verified identity when signing, so DKIM still comes from the
+domain identity. Two identities; one outcome.
+
+If AWS ever fixes #3134, the email-address identity becomes redundant and
+can be deleted. Until then it must stay verified or deploys break.
+
+### 11.4 DNS records on `friendsintelligence.net` (Route 53)
+
+| Type | Name | Value | Source |
+|---|---|---|---|
+| CNAME × 3 | `<token>._domainkey.friendsintelligence.net` | `<token>.dkim.amazonses.com` | SES auto-published (DKIM) |
+| TXT | `friendsintelligence.net` (apex) | `v=spf1 include:amazonses.com include:spf.improvmx.com ~all` | Manually added (SPF — must merge SES + ImprovMX) |
+| TXT | `_dmarc.friendsintelligence.net` | `v=DMARC1; p=none; rua=mailto:...` | SES auto-published (DMARC) |
+| MX × 2 | `friendsintelligence.net` (apex) | `10 mx1.improvmx.com`, `20 mx2.improvmx.com` | Manually added (ImprovMX forwarding) |
+
+**SPF gotcha:** Only one SPF record is permitted per domain. If ImprovMX
+already published `v=spf1 include:spf.improvmx.com ~all`, edit the
+existing record to merge in `include:amazonses.com` rather than creating
+a second TXT record.
+
+### 11.5 ImprovMX (inbound mail)
+
+We don't run a real mailbox on `friendsintelligence.net`. ImprovMX
+free-tier catch-all `*@friendsintelligence.net` → `qianhaopower@gmail.com`
+lets the `no-reply@` address receive SES verification emails (needed for
+the email-identity verification step that satisfies #3134) without
+running our own mail server.
+
+Free tier covers any future address (`hello@`, `support@`, etc.) at zero
+cost, no configuration changes needed.
+
+### 11.6 SES production access — per-region
+
+SES starts every region in sandbox mode: 200/day cap, can only send to
+verified recipients. **Production access was granted in `ap-southeast-2`
+on 2026-05-16**, lifting these restrictions for Cognito.
+
+If we ever move regions (e.g. add a US-region Cognito pool), production
+access must be requested again — it does not transfer between regions.
+Submit the request via SES console → Account dashboard → Request
+production access; AWS reviews within ~24h.
+
+### 11.7 Password policy — symbol requirement dropped
+
+Same migration also relaxed the Cognito password policy. Default Amplify
+Gen 2 policy requires symbols, which rejects Chrome-autofilled passwords
+that omit them (a common Chrome behavior). `defineAuth` doesn't expose
+`passwordPolicy` as a public option, so we use a CDK escape hatch in
+[amplify/backend.ts](../../amplify/backend.ts):
+
+```ts
+backend.auth.resources.cfnResources.cfnUserPool.addPropertyOverride(
+  "Policies.PasswordPolicy.RequireSymbols",
+  false,
+);
+```
+
+The client-side validation in
+[components/AuthenticatorWrapper.tsx](../../components/AuthenticatorWrapper.tsx)
+must mirror this — if they diverge, the UI displays one rule and Cognito
+enforces another, and users see confusing rejection errors after a UI
+that said the password was fine.
+
+**Effective policy:** min 8 chars, requires lowercase + uppercase + digit.
+Symbols allowed but not required.
+
+### 11.8 Lessons
+
+1. **Always verify both domain and email when using `senders.email`** —
+   until AWS fixes #3134, this is the only way to get past CFN deploy.
+2. **SES domain verification alone is not enough for Gmail inbox
+   delivery.** SPF (`include:amazonses.com`) and DMARC (even `p=none`)
+   must also be in DNS. SES auto-publishes DKIM CNAMEs + DMARC to Route
+   53 if "Publish DNS records to Route 53" is checked at identity
+   creation; SPF must be added manually.
+3. **Merging SPF records is non-obvious.** If something already has an
+   SPF record at the apex (ImprovMX, Google Workspace, etc.), edit it to
+   merge the new include rather than creating a second TXT record.
+   Multiple SPF records is a protocol violation.
+4. **Production access is per-region.** Don't assume sandbox status from
+   one region applies to another.
+5. **CDK escape hatches are required for password policy.** `defineAuth`
+   doesn't expose `passwordPolicy`; use `cfnUserPool.addPropertyOverride`.
+6. **Client-side and server-side password policy must agree.** If you
+   change one, change the other in the same PR. They're in different
+   files but conceptually the same rule.

--- a/_docs/canon/hard-bugs.md
+++ b/_docs/canon/hard-bugs.md
@@ -38,6 +38,129 @@ evidence matter more than narrative.
 
 ## Bugs
 
+### 2026-05-16 — Cognito verification emails silently lost to Gmail spam, plus the `amplify-backend#3134` deploy trap
+
+**Symptom (what users / monitoring saw):**
+New users signing up on `friendsintelligence.net` never received their
+verification code email. Cognito User Pool logs showed the signup
+attempt succeeded and the email was "sent." No error anywhere; users
+just disappeared between hitting Submit on the signup form and never
+returning. Discovered when the developer tested their own signup flow
+and noticed the email arriving in Gmail spam — meaning earlier testers
+had likely missed the verification email entirely.
+
+**Why it was hard to diagnose:**
+- Two stacked issues that looked like one. The visible problem (no
+  email) had a mundane cause (Cognito's default sender from
+  `no-reply@verificationemail.com` lands in Gmail spam). But the
+  obvious fix — switch to SES via `senders.email` in `defineAuth` —
+  hit a second, much weirder problem: an open Amplify Gen 2 bug
+  ([#3134](https://github.com/aws-amplify/amplify-backend/issues/3134))
+  with a misleading error message.
+- The #3134 error reads:
+  > Email address is not verified. The following identities failed
+  > the check in region AP-SOUTHEAST-2:
+  > arn:aws:ses:ap-southeast-2:...:identity/no-reply@friendsintelligence.net
+  …which is wrong in a specific way: the *domain*
+  `friendsintelligence.net` *was* verified in SES, just not the
+  email-address-form identity that Amplify Gen 2 silently builds the
+  `SourceArn` for at synth time.
+- The plan looked clean on paper: verify SES domain, configure
+  `senders.email`, deploy. We caught #3134 only by doing deliberate
+  web research on the plan before executing — the official Amplify
+  docs do not mention the bug.
+
+**Root cause (two layers):**
+1. **Surface-level:** Cognito's default email sender
+   (`no-reply@verificationemail.com`) is aggressively spam-filtered
+   by Gmail. The domain has no DKIM keys aligned with the recipient
+   inbox provider's expectations, SPF is broken on it, and the
+   sender has no reputation history with the recipient. Result: spam
+   folder or silent drop.
+2. **Hidden trap:** Amplify Gen 2's `senders.email` block in
+   `defineAuth` constructs the SES `SourceArn` from `fromEmail` as
+   an *email-level* identity ARN
+   (`arn:aws:ses:...:identity/no-reply@friendsintelligence.net`).
+   If only the *domain* is verified in SES (which gives you a
+   *domain-level* ARN of `...:identity/friendsintelligence.net`),
+   the deploy fails because the email-level ARN does not exist as
+   a verified identity. The error sounds like "you didn't verify
+   your email," but you did — just not in the form Amplify
+   expected.
+
+**Fix:** Shipped via PRs #379 + #382 (promoted to main as #380).
+- Verified the SES *domain* `friendsintelligence.net` (Easy DKIM,
+  RSA_2048_BIT) for actual mail signing.
+- Verified the SES *email address* `no-reply@friendsintelligence.net`
+  purely to satisfy the ARN that Amplify generates at deploy time.
+  DKIM signing still comes from the domain identity (SES picks the
+  most specific verified identity when signing).
+- Added DNS records on `friendsintelligence.net` (Route 53): 3 DKIM
+  CNAMEs (SES auto-published), merged SPF TXT
+  (`v=spf1 include:amazonses.com include:spf.improvmx.com ~all` —
+  one record, two includes), DMARC TXT (`p=none`).
+- Set up ImprovMX free-tier catch-all forwarding
+  `*@friendsintelligence.net → qianhaopower@gmail.com` so the
+  `no-reply@` mailbox can receive the SES verification link
+  required for the email-identity verification step.
+- Submitted and got granted SES production access for
+  `ap-southeast-2` (per-region — separate from sandbox status in
+  any other region).
+- While we were touching Cognito, also dropped the password
+  `requireSymbols` policy via CDK escape hatch in
+  `amplify/backend.ts` (Amplify Gen 2's `defineAuth` doesn't expose
+  `passwordPolicy` as a public option), because Chrome-suggested
+  passwords often omit symbols, causing rejected-after-autofill
+  confusion.
+
+**Lessons / what to check next time:**
+- **`senders.email` + domain-only verification is a deploy trap.**
+  When configuring Cognito to send via SES in Amplify Gen 2, always
+  verify *both* the domain (for DKIM) AND the specific email
+  address used in `fromEmail` (for the ARN Amplify generates).
+  Until AWS fixes #3134, both identities are mandatory.
+- **CFN error messages can be precisely wrong.** "Email address is
+  not verified" sounds like a user error; it was actually a library
+  bug. Be ready to read the ARN in the error carefully and ask "is
+  this the ARN I think it is?"
+- **Gmail wants DKIM + SPF + DMARC, not just one.** SES
+  auto-publishes DKIM CNAMEs and DMARC to Route 53 (if you check
+  "Publish DNS records to Route 53" at identity creation); SPF
+  must be added manually. Don't ship until all three are in DNS.
+- **Single SPF record per domain.** If something else (ImprovMX,
+  Google Workspace) already published one, edit it to merge
+  includes rather than creating a second TXT. Multiple SPF records
+  is a protocol violation.
+- **SES sandbox is per-region.** Production access in `us-east-1`
+  does not grant it in `ap-southeast-2`. Submit separately.
+- **Do web research on Amplify Gen 2 changes before executing.**
+  The official Amplify docs do not surface open bugs; GitHub
+  issues do. 20 minutes of search can save hours of failed deploys
+  plus the context-switch cost of debugging a misleading error.
+- **`defineAuth` doesn't expose `passwordPolicy`.** Use the CDK
+  escape hatch (`cfnUserPool.addPropertyOverride(...)`). Same
+  pattern applies to any Cognito property Amplify Gen 2's public
+  API hides.
+- **Client-side and server-side password policy must agree.**
+  `passwordSettings` in `AuthenticatorWrapper.tsx` and the CDK
+  override in `backend.ts` must say the same thing, otherwise the
+  UI accepts a password Cognito will reject.
+
+**References:**
+- PRs [#379](https://github.com/qianhaopower/fiappV1/pull/379),
+  [#380](https://github.com/qianhaopower/fiappV1/pull/380),
+  [#382](https://github.com/qianhaopower/fiappV1/pull/382),
+  [#384](https://github.com/qianhaopower/fiappV1/pull/384) (this doc)
+- Full setup reference:
+  [`cognito-and-environments.md` §11](./cognito-and-environments.md)
+- Amplify bug:
+  [aws-amplify/amplify-backend#3134](https://github.com/aws-amplify/amplify-backend/issues/3134)
+  (open, no fix yet as of 2026-05-16)
+- Memory:
+  `~/.claude/projects/-Users-haoqian-Documents-fiappv1/memory/project_cognito_ses_migration.md`
+
+---
+
 ### 2026-05-13 — New users stuck on `/auth` (Cognito Identity Pool credential exchange failing)
 
 **Symptom:** Brand-new users signing up on `friendsintelligence.net` got

--- a/_docs/canon/launch-checklist.md
+++ b/_docs/canon/launch-checklist.md
@@ -2,7 +2,7 @@
 
 Run this end-to-end before any public launch or major release. Use a real device (phone + desktop). Automated tests cover rules; this covers the human experience.
 
-Last revised: 2026-05-13 (v2 business-logic refactor).
+Last revised: 2026-05-16 (added SES email delivery + password policy checks).
 
 **Sign in as a real test user with a populated account before starting sections 2–8.**
 
@@ -14,17 +14,25 @@ Last revised: 2026-05-13 (v2 business-logic refactor).
 - [ ] Amplify environment variables are set (`FIAPP_AWS_ACCESS_KEY_ID`, `FIAPP_AWS_SECRET_ACCESS_KEY`, `FIAPP_AWS_REGION`, `FIAPP_RETURNS_TABLE`, `FIAPP_MAIN_TABLE`)
 - [ ] CI is green on `main` branch (lint + typecheck + unit + Layer 3 E2E smoke)
 - [ ] No open `P0` GitHub issues
+- [ ] SES email delivery healthy (see [cognito-and-environments.md §11](./cognito-and-environments.md)):
+  - SES `ap-southeast-2` is **out of sandbox** (Account dashboard → no yellow banner)
+  - Both SES identities verified: `friendsintelligence.net` (Domain, DKIM Successful) **and** `no-reply@friendsintelligence.net` (Email) — second one is the `amplify-backend#3134` workaround and is load-bearing
+  - SES sending stats show no recent bounce/complaint spikes
+- [ ] DNS for `friendsintelligence.net` still in place (Route 53): 3 DKIM CNAMEs, merged SPF TXT (`include:amazonses.com include:spf.improvmx.com`), DMARC TXT, ImprovMX MX records
+- [ ] ImprovMX dashboard shows the catch-all alias `*@friendsintelligence.net → qianhaopower@gmail.com` is still **Active**
 
 ---
 
 ## 1. Auth flow
 
 - [ ] `/auth` loads — Friends Intelligence logo, sign in tab visible, no layout breaks
-- [ ] Sign up: create a new account with email + password — confirmation email received
+- [ ] Sign up: create a new account with email + password — confirmation email arrives **in Gmail inbox (not spam)** from `Friends Intelligence <no-reply@friendsintelligence.net>`, **DKIM-signed by `friendsintelligence.net`** (Gmail "show original" shows `signed-by: friendsintelligence.net`, `mailed-by: ap-southeast-2.amazonses.com`)
+- [ ] Sign up with a **Chrome-suggested password (no special character)** — accepted. Effective policy is 8+ chars, lowercase + uppercase + digit; symbols allowed but not required (see [cognito-and-environments.md §11.7](./cognito-and-environments.md))
+- [ ] Help text under password field reads "Passwords need 8+ characters with uppercase, lowercase, and a number." (no mention of symbol)
 - [ ] Confirm email → redirected into app (lands on `/onboarding` for new users, `/today` for returning users with assessment)
 - [ ] Sign in with confirmed account → lands on correct page per `decideRoute` (auth → `/auth`; authed without assessment → `/onboarding`; authed with assessment → `/today`)
 - [ ] Wrong password → error message visible, not cryptic
-- [ ] "Forgot password" flow — email sent, reset works
+- [ ] "Forgot password" flow — email sent (same `no-reply@friendsintelligence.net` sender), reset works
 - [ ] Sign out → redirected to `/auth`, cannot navigate back to protected pages
 - [ ] **Mobile**: auth form not cut off, keyboard doesn't obscure input fields
 


### PR DESCRIPTION
## Summary
Documents the 2026-05-16 SES migration across three canon docs so future work touching Cognito email or password policy doesn't re-discover the gotchas we hit.

## Files updated

### `_docs/canon/cognito-and-environments.md` (commit 1)
- **New § 11 — "Email delivery via SES (added 2026-05-16)"** — full deep reference with 8 subsections: code change, dual-identity #3134 workaround, DNS records, ImprovMX, production access, password policy CDK escape hatch, lessons.
- **§ 8 (Quick reference)** — added SES identities + ImprovMX subsections; bumped "as of" date to 2026-05-16.
- **§ 9 (Common gotchas)** — added two new gotchas: "verification email never arrives" + "Email address is not verified" deploy error.
- **§ 10 (Related PRs)** — added #366, #379, #380, #382; added `components/AuthenticatorWrapper.tsx` to source-of-truth file list.
- **Intro** — mentions 2026-05-16 work alongside the existing 2026-05-09 incident reference.

### `_docs/canon/launch-checklist.md` (commit 2)
- **§ 0 (Pre-launch infra)** — added SES infra checks (production access, both identities verified, DNS records intact, ImprovMX catch-all active).
- **§ 1 (Auth flow)** — tightened signup-email check (Gmail inbox, DKIM-signed, correct From line), added Chrome-suggested password check, added help-text wording assertion.
- Bumped "Last revised" date.

### `_docs/canon/hard-bugs.md` (commit 2)
- Added 2026-05-16 incident entry as the new top entry. Documents the stacked-bug situation: surface-level spam filter + hidden Amplify Gen 2 #3134 deploy trap. Covers symptom, why hard, two-layer root cause, full fix, and 8 lessons including the CDK escape hatch pattern.

## Stats
- 3 files changed, 335 insertions(+), 9 deletions(-)
- 2 commits on this branch

## Test plan
- [ ] Docs render correctly on GitHub (tables, code blocks, section anchors)
- [ ] All file paths and section links resolve
- [ ] No CI breakage (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)