### PR TITLE
fix(practice): cap check reads UPRACTICE truth, reconciles PROFILE

### DIFF
--- a/app/api/practice/route.ts
+++ b/app/api/practice/route.ts
@@ -35,6 +35,19 @@ type Body = {
 
 type Client = ReturnType<typeof createDynamoClient>
 
+// Single source of truth for "what counts as active." Matches the lenient read in
+// /api/practices/active: missing status defaults to active; paused/replaced/inactive do not.
+function isActiveUPractice(up: UPracticeItem): boolean {
+  return !up.status || up.status === 'active'
+}
+
+async function queryUPractices(client: Client, pk: string): Promise<UPracticeItem[]> {
+  return client.query<UPracticeItem>({
+    KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+    ExpressionAttributeValues: { ':pk': pk, ':prefix': 'UPRACTICE#' },
+  })
+}
+
 export async function POST(req: Request) {
   return withAuth(req, async (user) => {
     if (!checkRateLimit(`practice:${user.userId}`, 20)) return rateLimitedResponse()
@@ -86,11 +99,16 @@ async function handleStartOrReactivate(args: {
     return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
   }
 
+  // PROFILE provides subscriptionStatus for the cap; UPRACTICE# items are the source
+  // of truth for which practices are active. PROFILE.activePracticeIds is a
+  // denormalized cache that can drift, so we don't read it for cap enforcement.
   const sk = makeUPracticeSK(practiceId)
-  const [profile, existing] = await Promise.all([
+  const [profile, upractices] = await Promise.all([
     client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
-    client.getItem<UPracticeItem>({ PK: pk, SK: sk }),
+    queryUPractices(client, pk),
   ])
+
+  const existing = upractices.find((up) => up.practiceId === practiceId)
 
   // Already active — idempotent no-op (200 instead of 409)
   if (existing?.status === 'active') {
@@ -100,15 +118,18 @@ async function handleStartOrReactivate(args: {
     )
   }
 
-  const activePracticeIds = profile?.activePracticeIds ?? []
+  const otherActiveIds = upractices
+    .filter((up) => up.practiceId !== practiceId && isActiveUPractice(up))
+    .map((up) => up.practiceId)
 
-  const capCheck = checkActiveCap(profile?.subscriptionStatus, activePracticeIds.length)
+  const capCheck = checkActiveCap(profile?.subscriptionStatus, otherActiveIds.length)
   if (!capCheck.allowed) {
     return NextResponse.json({ error: capCheck.reason, cap: capCheck.cap }, { status: 409 })
   }
 
   const now = new Date().toISOString()
-  const newIds = [...activePracticeIds, practiceId]
+  // Reconcile PROFILE.activePracticeIds from the UPRACTICE source of truth on every write.
+  const newIds = [...otherActiveIds, practiceId]
 
   if (!existing) {
     await Promise.all([
@@ -157,16 +178,17 @@ async function handleMakeInactive(args: {
   const { pk, client, practiceId } = args
 
   const sk = makeUPracticeSK(practiceId)
-  const [profile, existing] = await Promise.all([
-    client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
-    client.getItem<UPracticeItem>({ PK: pk, SK: sk }),
-  ])
+  const upractices = await queryUPractices(client, pk)
+  const existing = upractices.find((up) => up.practiceId === practiceId)
 
   if (!existing || existing.status !== 'active') {
     return NextResponse.json({ error: 'PRACTICE_NOT_ACTIVE' }, { status: 409 })
   }
 
-  const activePracticeIds = (profile?.activePracticeIds ?? []).filter((id) => id !== practiceId)
+  // Reconcile from UPRACTICE truth, excluding the one being deactivated.
+  const remainingActiveIds = upractices
+    .filter((up) => up.practiceId !== practiceId && isActiveUPractice(up))
+    .map((up) => up.practiceId)
 
   const now = new Date().toISOString()
   await Promise.all([
@@ -179,7 +201,7 @@ async function handleMakeInactive(args: {
     client.updateItem({
       Key: { PK: pk, SK: 'PROFILE' },
       UpdateExpression: 'SET activePracticeIds = :ids',
-      ExpressionAttributeValues: { ':ids': activePracticeIds },
+      ExpressionAttributeValues: { ':ids': remainingActiveIds },
     }),
   ])
 
@@ -205,11 +227,10 @@ async function handleSwitch(args: {
 
   const oldSk = makeUPracticeSK(deactivatePracticeId)
   const newSk = makeUPracticeSK(practiceId)
-  const [profile, oldExisting, newExisting] = await Promise.all([
-    client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
-    client.getItem<UPracticeItem>({ PK: pk, SK: oldSk }),
-    client.getItem<UPracticeItem>({ PK: pk, SK: newSk }),
-  ])
+
+  const upractices = await queryUPractices(client, pk)
+  const oldExisting = upractices.find((up) => up.practiceId === deactivatePracticeId)
+  const newExisting = upractices.find((up) => up.practiceId === practiceId)
 
   if (!oldExisting || oldExisting.status !== 'active') {
     return NextResponse.json({ error: 'DEACTIVATE_PRACTICE_NOT_ACTIVE' }, { status: 409 })
@@ -218,8 +239,15 @@ async function handleSwitch(args: {
     return NextResponse.json({ error: 'PRACTICE_ALREADY_ACTIVE' }, { status: 409 })
   }
 
-  const activePracticeIds = (profile?.activePracticeIds ?? [])
-    .filter((id) => id !== deactivatePracticeId)
+  // Reconcile from UPRACTICE truth: drop the deactivated id, add the new one.
+  const activePracticeIds = upractices
+    .filter(
+      (up) =>
+        up.practiceId !== deactivatePracticeId &&
+        up.practiceId !== practiceId &&
+        isActiveUPractice(up),
+    )
+    .map((up) => up.practiceId)
     .concat(practiceId)
 
   const now = new Date().toISOString()

--- a/tests/integration/api/practice.test.ts
+++ b/tests/integration/api/practice.test.ts
@@ -90,6 +90,29 @@ describe("mode=startPractice", () => {
     expect(profile?.activePracticeIds).toHaveLength(1);
   });
 
+  // Regression: PROFILE.activePracticeIds and UPRACTICE.status are two writes that can
+  // diverge if a Promise.all step fails. The cap check must trust UPRACTICE (the source
+  // of truth used by /api/practices/active), not the cached PROFILE array.
+  it("recovers when PROFILE.activePracticeIds is stale but no UPRACTICE is active", async () => {
+    const userId = randomUUID();
+    // PROFILE wrongly says the cap is full, but there's no active UPRACTICE.
+    await seedProfile(userId, {
+      activePracticeIds: ["financial-label-decision"],
+      subscriptionStatus: "FREE",
+    });
+
+    asUser(userId);
+    const res = await post({ mode: "startPractice", practiceId: "sleep-consistent-bedtime" });
+    expect(res.status).toBe(201);
+
+    const client = createDynamoClient();
+    const profile = await client.getItem<{ activePracticeIds: string[] }>({
+      PK: `USER#${userId}`, SK: "PROFILE",
+    });
+    // PROFILE is reconciled from UPRACTICE truth on the write.
+    expect(profile?.activePracticeIds).toEqual(["sleep-consistent-bedtime"]);
+  });
+
   it("PAID user can add up to 10 practices with no warnings", async () => {
     const userId = randomUUID();
     const practiceIds = [
@@ -122,7 +145,8 @@ describe("mode=startPractice", () => {
       "information-phone-away-think", "information-learn-in-chunks", "information-check-source",
       "emotional-name-before-reacting",
     ];
-    await seedProfile(userId, { subscriptionStatus: "PAID", activePracticeIds: practiceIds });
+    await seedProfile(userId, { subscriptionStatus: "PAID" });
+    for (const pid of practiceIds) await seedActivePractice(userId, pid);
 
     asUser(userId);
     const res = await post({ mode: "startPractice", practiceId: "emotional-now-or-echo" });

--- a/tests/unit/api/practice.post.test.ts
+++ b/tests/unit/api/practice.post.test.ts
@@ -4,12 +4,14 @@ import { POST } from '@/app/api/practice/route'
 const getItemMock = vi.fn()
 const putItemMock = vi.fn()
 const updateItemMock = vi.fn()
+const queryMock = vi.fn()
 
 vi.mock('@/utils/dynamoClient', () => ({
   createDynamoClient: () => ({
     getItem: getItemMock,
     putItem: putItemMock,
     updateItem: updateItemMock,
+    query: queryMock,
   }),
 }))
 
@@ -44,8 +46,16 @@ function mockStore(
 ) {
   getItemMock.mockImplementation(async ({ SK }: { SK: string }) => {
     if (SK === 'PROFILE') return profile
-    if (SK.startsWith('UPRACTICE#')) return uprBySK[SK] ?? null
     return null
+  })
+  queryMock.mockImplementation(async () => {
+    return Object.entries(uprBySK)
+      .filter(([, v]) => v !== null)
+      .map(([sk, v]) => ({
+        SK: sk,
+        practiceId: (v as Record<string, unknown>)?.practiceId ?? sk.replace('UPRACTICE#', ''),
+        ...(v as Record<string, unknown>),
+      }))
   })
 }
 
@@ -54,6 +64,7 @@ beforeEach(() => {
   getItemMock.mockReset()
   putItemMock.mockReset()
   updateItemMock.mockReset()
+  queryMock.mockReset()
 })
 
 // ── startPractice (and reactivatePractice alias) ─────────────────────────────
@@ -142,7 +153,10 @@ describe('POST /api/practice — startPractice', () => {
   })
 
   it('FREE user at cap is blocked with 409 CAP_REACHED', async () => {
-    mockStore({ activePracticeIds: ['financial-label-decision'], subscriptionStatus: 'FREE' })
+    mockStore(
+      { activePracticeIds: ['financial-label-decision'], subscriptionStatus: 'FREE' },
+      { 'UPRACTICE#financial-label-decision': { status: 'active' } },
+    )
     const res = await POST(makeReq({ mode: 'startPractice', practiceId: 'sleep-consistent-bedtime' }))
     expect(res.status).toBe(409)
     expect((await res.json()).error).toBe('CAP_REACHED')
@@ -152,7 +166,9 @@ describe('POST /api/practice — startPractice', () => {
 
   it('PAID user blocked at 10 (no soft warnings)', async () => {
     const ten = Array.from({ length: 10 }, (_, i) => `practice-${i}`)
-    mockStore({ activePracticeIds: ten, subscriptionStatus: 'PAID' })
+    const uprBySK: Record<string, Record<string, unknown>> = {}
+    for (const id of ten) uprBySK[`UPRACTICE#${id}`] = { status: 'active' }
+    mockStore({ activePracticeIds: ten, subscriptionStatus: 'PAID' }, uprBySK)
     const res = await POST(makeReq({ mode: 'startPractice', practiceId: 'sleep-consistent-bedtime' }))
     expect(res.status).toBe(409)
     expect((await res.json()).error).toBe('CAP_REACHED')
@@ -160,11 +176,33 @@ describe('POST /api/practice — startPractice', () => {
 
   it('PAID user at 5 active gets no warning (warnings dropped in v2)', async () => {
     const five = Array.from({ length: 5 }, (_, i) => `practice-${i}`)
-    mockStore({ activePracticeIds: five, subscriptionStatus: 'PAID' })
+    const uprBySK: Record<string, Record<string, unknown>> = {}
+    for (const id of five) uprBySK[`UPRACTICE#${id}`] = { status: 'active' }
+    mockStore({ activePracticeIds: five, subscriptionStatus: 'PAID' }, uprBySK)
     const res = await POST(makeReq({ mode: 'startPractice', practiceId: 'sleep-consistent-bedtime' }))
     expect(res.status).toBe(201)
     const json = await res.json()
     expect(json.warning).toBeUndefined()
+  })
+
+  // Regression: PROFILE.activePracticeIds can drift from UPRACTICE.status if a prior
+  // parallel write failed. The cap check must use UPRACTICE as the source of truth so
+  // a stale PROFILE doesn't lock the user out when the UI correctly shows "no active practice."
+  it('allows starting when PROFILE.activePracticeIds is stale (no UPRACTICE is active)', async () => {
+    mockStore(
+      // PROFILE wrongly claims a practice is active, but the UPRACTICE for it is inactive.
+      { activePracticeIds: ['financial-label-decision'], subscriptionStatus: 'FREE' },
+      { 'UPRACTICE#financial-label-decision': { status: 'inactive' } },
+    )
+    const res = await POST(makeReq({ mode: 'startPractice', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(201)
+    // PROFILE.activePracticeIds is reconciled from UPRACTICE truth on the write.
+    const profileUpdate = updateItemMock.mock.calls.find(
+      (c) => c[0].Key.SK === 'PROFILE',
+    )
+    expect(profileUpdate[0].ExpressionAttributeValues[':ids']).toEqual([
+      'sleep-consistent-bedtime',
+    ])
   })
 
   it('returns 404 for unknown practiceId', async () => {


### PR DESCRIPTION
## Summary
- Reproduces a real prod bug: today page showed "Choose one practice to start" while picking a practice failed with `CAP_REACHED`.
- Root cause: `PROFILE.activePracticeIds` was the cap enforcement source but is a denormalized cache, updated alongside `UPRACTICE.status` via `Promise.all`. If either write failed (or a legacy path only touched one side), PROFILE and UPRACTICE diverged. `/api/practices/active` reads UPRACTICE (correct), but `/api/practice` was reading PROFILE (stale), so the UI and the limit check could contradict each other.
- Fix: all three handlers (`startPractice`/`reactivatePractice`, `makePracticeInactive`, `switchToPractice`) now query `UPRACTICE#*` once, derive the active count from `status === 'active'` (lenient — missing status counts as active, matching the UI), and rewrite `PROFILE.activePracticeIds` from that same snapshot. PROFILE becomes a cache, not a source of truth, and self-heals on every successful write.

## Why this self-unblocks the affected user
The next time a stuck user clicks "Start practice", the cap check sees 0 active UPRACTICEs (which is reality) and lets the write through; the same write reconciles `PROFILE.activePracticeIds` back to the truth. No manual DB fix required.

## Test plan
- [x] `npm run test` — 295 passing, including new unit regression: PROFILE stale → start still allowed, PROFILE reconciled.
- [x] `npm run test:integration` — 60 passing, including new integration regression that seeds the divergent state from the prod bug.
- [x] `npx tsc --noEmit` — clean.
- [ ] Deploy to staging, log into a test account, force the divergent state (or test the happy paths) at the staging URL.
- [ ] Layer 3 E2E against staging before merging to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)