### PR TITLE
fix(practice): cap check reads UPRACTICE truth, reconciles PROFILE

### DIFF
--- a/_docs/canon/hard-bugs.md
+++ b/_docs/canon/hard-bugs.md
@@ -38,6 +38,94 @@ evidence matter more than narrative.
 
 ## Bugs
 
+### 2026-05-17 — "Choose a practice" + `CAP_REACHED`: UPRACTICE vs PROFILE divergence
+
+**Symptom (what users / monitoring saw):**
+On the today page, the UI showed "Choose one practice to start." (meaning
+no practice was active). Clicking to pick one returned `409 CAP_REACHED`
+on the FREE plan (cap = 1). UI and backend disagreed about whether the
+user already had an active practice.
+
+**Why it was hard to diagnose:**
+- Both endpoints individually looked correct. `/api/practices/active`
+  read UPRACTICE rows and reported "none active" — correct given the
+  data it saw. `/api/practice` read PROFILE and reported "cap reached" —
+  correct given the data *it* saw. The bug was in the *disagreement*,
+  not in either path alone.
+- The denormalization was historical and easy to overlook: PROFILE
+  carried `activePracticeIds` as a precomputed array, while UPRACTICE#
+  rows carried the authoritative `status` field. Nothing in the schema
+  flagged one as canonical.
+- The user's data had been in this state for some indeterminate amount
+  of time, so there was no recent code change to suspect.
+
+**Root cause:** Two sources of truth maintained by parallel writes.
+Every start / inactive / switch operation updated both the
+`UPRACTICE#<id>.status` field and the `PROFILE.activePracticeIds` array
+via `Promise.all` of two separate DynamoDB writes — no transaction, no
+rollback. If either write failed (throttle, Lambda mid-flight kill,
+network blip) the two items drifted. The cap check read PROFILE (the
+stale cache); the UI read UPRACTICE (truth). They contradicted each
+other and the user was locked out: PROFILE said "full," UPRACTICE said
+"empty," and there was no way for the user to break the deadlock
+because every "start practice" attempt got rejected by the cap check
+before it could rewrite PROFILE.
+
+**Fix:** PR [#390](https://github.com/qianhaopower/fiappV1/pull/390).
+All three handlers in `app/api/practice/route.ts`
+(`startPractice`/`reactivatePractice`, `makePracticeInactive`,
+`switchToPractice`) now query `UPRACTICE#*` once and derive *both* the
+active count (for the cap) and the new `activePracticeIds` value from
+that snapshot. PROFILE is rewritten from UPRACTICE truth on every
+successful write — so it's now a cache that self-heals on the next
+practice action, not an enforcement source that can lock the user out.
+
+No data backfill was required: the affected user's next "Start
+practice" click counts 0 active UPRACTICEs (reality), allows the
+write, and reconciles PROFILE in the same transaction-of-writes.
+
+**Lessons / what to check next time:**
+- **Never enforce a business rule against a denormalized cache.** If
+  the cap check had read UPRACTICE (the same source the UI used), the
+  divergence would have been invisible to the user — at worst PROFILE
+  stays slightly wrong for the admin count. The dangerous thing wasn't
+  the drift itself; it was *gating user actions on the side that could
+  drift*.
+- **`Promise.all` of two writes is not atomic.** It's two independent
+  DynamoDB calls. Either can fail. If both writes must agree, use
+  `TransactWriteItems` — or design so one side is derived from the
+  other and never written independently.
+- **Two readers of "the same thing" reading from two different items
+  is a smell.** Grep for every reader before adding a denormalized
+  cache. If readers disagree on the source, they will eventually
+  disagree on the answer.
+- **Self-healing beats backfill.** When you discover a class of drift,
+  prefer a fix that reconciles on the next write over a one-off cleanup
+  script. The script is one-time; the fix protects every future
+  incident of the same shape.
+
+**Residual risk (acknowledged, not yet fixed):** `PROFILE.activePracticeIds`
+is still updated via non-atomic `Promise.all` and is still read as a
+cache by `app/api/return/route.ts`, `app/api/progress/route.ts`, and
+`app/api/admin/users/route.ts`. A future partial-write failure can
+still cause those three to briefly see stale data (e.g. return
+submission blocked for a practice that's actually active) until the
+user's next practice mutation reconciles things. The cap check — the
+loud, lock-the-user-out path — is now safe. Smaller seams remain.
+If drift recurs, the cheapest fix is wrapping the two writes in
+`TransactWriteItems`; the structurally correct fix is dropping
+`PROFILE.activePracticeIds` and having all three readers query
+UPRACTICE.
+
+**References:**
+- PR [#390](https://github.com/qianhaopower/fiappV1/pull/390)
+- Diverging readers (still cache-trusting):
+  [`app/api/return/route.ts`](../../app/api/return/route.ts),
+  [`app/api/progress/route.ts`](../../app/api/progress/route.ts),
+  [`app/api/admin/users/route.ts`](../../app/api/admin/users/route.ts)
+
+---
+
 ### 2026-05-16 — Cognito verification emails silently lost to Gmail spam, plus the `amplify-backend#3134` deploy trap
 
 **Symptom (what users / monitoring saw):**

--- a/app/api/practice/route.ts
+++ b/app/api/practice/route.ts
@@ -35,6 +35,19 @@ type Body = {
 
 type Client = ReturnType<typeof createDynamoClient>
 
+// Single source of truth for "what counts as active." Matches the lenient read in
+// /api/practices/active: missing status defaults to active; paused/replaced/inactive do not.
+function isActiveUPractice(up: UPracticeItem): boolean {
+  return !up.status || up.status === 'active'
+}
+
+async function queryUPractices(client: Client, pk: string): Promise<UPracticeItem[]> {
+  return client.query<UPracticeItem>({
+    KeyConditionExpression: 'PK = :pk AND begins_with(SK, :prefix)',
+    ExpressionAttributeValues: { ':pk': pk, ':prefix': 'UPRACTICE#' },
+  })
+}
+
 export async function POST(req: Request) {
   return withAuth(req, async (user) => {
     if (!checkRateLimit(`practice:${user.userId}`, 20)) return rateLimitedResponse()
@@ -86,11 +99,16 @@ async function handleStartOrReactivate(args: {
     return NextResponse.json({ error: 'PRACTICE_NOT_FOUND' }, { status: 404 })
   }
 
+  // PROFILE provides subscriptionStatus for the cap; UPRACTICE# items are the source
+  // of truth for which practices are active. PROFILE.activePracticeIds is a
+  // denormalized cache that can drift, so we don't read it for cap enforcement.
   const sk = makeUPracticeSK(practiceId)
-  const [profile, existing] = await Promise.all([
+  const [profile, upractices] = await Promise.all([
     client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
-    client.getItem<UPracticeItem>({ PK: pk, SK: sk }),
+    queryUPractices(client, pk),
   ])
+
+  const existing = upractices.find((up) => up.practiceId === practiceId)
 
   // Already active — idempotent no-op (200 instead of 409)
   if (existing?.status === 'active') {
@@ -100,15 +118,18 @@ async function handleStartOrReactivate(args: {
     )
   }
 
-  const activePracticeIds = profile?.activePracticeIds ?? []
+  const otherActiveIds = upractices
+    .filter((up) => up.practiceId !== practiceId && isActiveUPractice(up))
+    .map((up) => up.practiceId)
 
-  const capCheck = checkActiveCap(profile?.subscriptionStatus, activePracticeIds.length)
+  const capCheck = checkActiveCap(profile?.subscriptionStatus, otherActiveIds.length)
   if (!capCheck.allowed) {
     return NextResponse.json({ error: capCheck.reason, cap: capCheck.cap }, { status: 409 })
   }
 
   const now = new Date().toISOString()
-  const newIds = [...activePracticeIds, practiceId]
+  // Reconcile PROFILE.activePracticeIds from the UPRACTICE source of truth on every write.
+  const newIds = [...otherActiveIds, practiceId]
 
   if (!existing) {
     await Promise.all([
@@ -157,16 +178,17 @@ async function handleMakeInactive(args: {
   const { pk, client, practiceId } = args
 
   const sk = makeUPracticeSK(practiceId)
-  const [profile, existing] = await Promise.all([
-    client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
-    client.getItem<UPracticeItem>({ PK: pk, SK: sk }),
-  ])
+  const upractices = await queryUPractices(client, pk)
+  const existing = upractices.find((up) => up.practiceId === practiceId)
 
   if (!existing || existing.status !== 'active') {
     return NextResponse.json({ error: 'PRACTICE_NOT_ACTIVE' }, { status: 409 })
   }
 
-  const activePracticeIds = (profile?.activePracticeIds ?? []).filter((id) => id !== practiceId)
+  // Reconcile from UPRACTICE truth, excluding the one being deactivated.
+  const remainingActiveIds = upractices
+    .filter((up) => up.practiceId !== practiceId && isActiveUPractice(up))
+    .map((up) => up.practiceId)
 
   const now = new Date().toISOString()
   await Promise.all([
@@ -179,7 +201,7 @@ async function handleMakeInactive(args: {
     client.updateItem({
       Key: { PK: pk, SK: 'PROFILE' },
       UpdateExpression: 'SET activePracticeIds = :ids',
-      ExpressionAttributeValues: { ':ids': activePracticeIds },
+      ExpressionAttributeValues: { ':ids': remainingActiveIds },
     }),
   ])
 
@@ -205,11 +227,10 @@ async function handleSwitch(args: {
 
   const oldSk = makeUPracticeSK(deactivatePracticeId)
   const newSk = makeUPracticeSK(practiceId)
-  const [profile, oldExisting, newExisting] = await Promise.all([
-    client.getItem<ProfileData>({ PK: pk, SK: 'PROFILE' }),
-    client.getItem<UPracticeItem>({ PK: pk, SK: oldSk }),
-    client.getItem<UPracticeItem>({ PK: pk, SK: newSk }),
-  ])
+
+  const upractices = await queryUPractices(client, pk)
+  const oldExisting = upractices.find((up) => up.practiceId === deactivatePracticeId)
+  const newExisting = upractices.find((up) => up.practiceId === practiceId)
 
   if (!oldExisting || oldExisting.status !== 'active') {
     return NextResponse.json({ error: 'DEACTIVATE_PRACTICE_NOT_ACTIVE' }, { status: 409 })
@@ -218,8 +239,15 @@ async function handleSwitch(args: {
     return NextResponse.json({ error: 'PRACTICE_ALREADY_ACTIVE' }, { status: 409 })
   }
 
-  const activePracticeIds = (profile?.activePracticeIds ?? [])
-    .filter((id) => id !== deactivatePracticeId)
+  // Reconcile from UPRACTICE truth: drop the deactivated id, add the new one.
+  const activePracticeIds = upractices
+    .filter(
+      (up) =>
+        up.practiceId !== deactivatePracticeId &&
+        up.practiceId !== practiceId &&
+        isActiveUPractice(up),
+    )
+    .map((up) => up.practiceId)
     .concat(practiceId)
 
   const now = new Date().toISOString()

--- a/tests/integration/api/practice.test.ts
+++ b/tests/integration/api/practice.test.ts
@@ -90,6 +90,29 @@ describe("mode=startPractice", () => {
     expect(profile?.activePracticeIds).toHaveLength(1);
   });
 
+  // Regression: PROFILE.activePracticeIds and UPRACTICE.status are two writes that can
+  // diverge if a Promise.all step fails. The cap check must trust UPRACTICE (the source
+  // of truth used by /api/practices/active), not the cached PROFILE array.
+  it("recovers when PROFILE.activePracticeIds is stale but no UPRACTICE is active", async () => {
+    const userId = randomUUID();
+    // PROFILE wrongly says the cap is full, but there's no active UPRACTICE.
+    await seedProfile(userId, {
+      activePracticeIds: ["financial-label-decision"],
+      subscriptionStatus: "FREE",
+    });
+
+    asUser(userId);
+    const res = await post({ mode: "startPractice", practiceId: "sleep-consistent-bedtime" });
+    expect(res.status).toBe(201);
+
+    const client = createDynamoClient();
+    const profile = await client.getItem<{ activePracticeIds: string[] }>({
+      PK: `USER#${userId}`, SK: "PROFILE",
+    });
+    // PROFILE is reconciled from UPRACTICE truth on the write.
+    expect(profile?.activePracticeIds).toEqual(["sleep-consistent-bedtime"]);
+  });
+
   it("PAID user can add up to 10 practices with no warnings", async () => {
     const userId = randomUUID();
     const practiceIds = [
@@ -122,7 +145,8 @@ describe("mode=startPractice", () => {
       "information-phone-away-think", "information-learn-in-chunks", "information-check-source",
       "emotional-name-before-reacting",
     ];
-    await seedProfile(userId, { subscriptionStatus: "PAID", activePracticeIds: practiceIds });
+    await seedProfile(userId, { subscriptionStatus: "PAID" });
+    for (const pid of practiceIds) await seedActivePractice(userId, pid);
 
     asUser(userId);
     const res = await post({ mode: "startPractice", practiceId: "emotional-now-or-echo" });

--- a/tests/unit/api/practice.post.test.ts
+++ b/tests/unit/api/practice.post.test.ts
@@ -4,12 +4,14 @@ import { POST } from '@/app/api/practice/route'
 const getItemMock = vi.fn()
 const putItemMock = vi.fn()
 const updateItemMock = vi.fn()
+const queryMock = vi.fn()
 
 vi.mock('@/utils/dynamoClient', () => ({
   createDynamoClient: () => ({
     getItem: getItemMock,
     putItem: putItemMock,
     updateItem: updateItemMock,
+    query: queryMock,
   }),
 }))
 
@@ -44,8 +46,16 @@ function mockStore(
 ) {
   getItemMock.mockImplementation(async ({ SK }: { SK: string }) => {
     if (SK === 'PROFILE') return profile
-    if (SK.startsWith('UPRACTICE#')) return uprBySK[SK] ?? null
     return null
+  })
+  queryMock.mockImplementation(async () => {
+    return Object.entries(uprBySK)
+      .filter(([, v]) => v !== null)
+      .map(([sk, v]) => ({
+        SK: sk,
+        practiceId: (v as Record<string, unknown>)?.practiceId ?? sk.replace('UPRACTICE#', ''),
+        ...(v as Record<string, unknown>),
+      }))
   })
 }
 
@@ -54,6 +64,7 @@ beforeEach(() => {
   getItemMock.mockReset()
   putItemMock.mockReset()
   updateItemMock.mockReset()
+  queryMock.mockReset()
 })
 
 // ── startPractice (and reactivatePractice alias) ─────────────────────────────
@@ -142,7 +153,10 @@ describe('POST /api/practice — startPractice', () => {
   })
 
   it('FREE user at cap is blocked with 409 CAP_REACHED', async () => {
-    mockStore({ activePracticeIds: ['financial-label-decision'], subscriptionStatus: 'FREE' })
+    mockStore(
+      { activePracticeIds: ['financial-label-decision'], subscriptionStatus: 'FREE' },
+      { 'UPRACTICE#financial-label-decision': { status: 'active' } },
+    )
     const res = await POST(makeReq({ mode: 'startPractice', practiceId: 'sleep-consistent-bedtime' }))
     expect(res.status).toBe(409)
     expect((await res.json()).error).toBe('CAP_REACHED')
@@ -152,7 +166,9 @@ describe('POST /api/practice — startPractice', () => {
 
   it('PAID user blocked at 10 (no soft warnings)', async () => {
     const ten = Array.from({ length: 10 }, (_, i) => `practice-${i}`)
-    mockStore({ activePracticeIds: ten, subscriptionStatus: 'PAID' })
+    const uprBySK: Record<string, Record<string, unknown>> = {}
+    for (const id of ten) uprBySK[`UPRACTICE#${id}`] = { status: 'active' }
+    mockStore({ activePracticeIds: ten, subscriptionStatus: 'PAID' }, uprBySK)
     const res = await POST(makeReq({ mode: 'startPractice', practiceId: 'sleep-consistent-bedtime' }))
     expect(res.status).toBe(409)
     expect((await res.json()).error).toBe('CAP_REACHED')
@@ -160,11 +176,33 @@ describe('POST /api/practice — startPractice', () => {
 
   it('PAID user at 5 active gets no warning (warnings dropped in v2)', async () => {
     const five = Array.from({ length: 5 }, (_, i) => `practice-${i}`)
-    mockStore({ activePracticeIds: five, subscriptionStatus: 'PAID' })
+    const uprBySK: Record<string, Record<string, unknown>> = {}
+    for (const id of five) uprBySK[`UPRACTICE#${id}`] = { status: 'active' }
+    mockStore({ activePracticeIds: five, subscriptionStatus: 'PAID' }, uprBySK)
     const res = await POST(makeReq({ mode: 'startPractice', practiceId: 'sleep-consistent-bedtime' }))
     expect(res.status).toBe(201)
     const json = await res.json()
     expect(json.warning).toBeUndefined()
+  })
+
+  // Regression: PROFILE.activePracticeIds can drift from UPRACTICE.status if a prior
+  // parallel write failed. The cap check must use UPRACTICE as the source of truth so
+  // a stale PROFILE doesn't lock the user out when the UI correctly shows "no active practice."
+  it('allows starting when PROFILE.activePracticeIds is stale (no UPRACTICE is active)', async () => {
+    mockStore(
+      // PROFILE wrongly claims a practice is active, but the UPRACTICE for it is inactive.
+      { activePracticeIds: ['financial-label-decision'], subscriptionStatus: 'FREE' },
+      { 'UPRACTICE#financial-label-decision': { status: 'inactive' } },
+    )
+    const res = await POST(makeReq({ mode: 'startPractice', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(201)
+    // PROFILE.activePracticeIds is reconciled from UPRACTICE truth on the write.
+    const profileUpdate = updateItemMock.mock.calls.find(
+      (c) => c[0].Key.SK === 'PROFILE',
+    )
+    expect(profileUpdate[0].ExpressionAttributeValues[':ids']).toEqual([
+      'sleep-consistent-bedtime',
+    ])
   })
 
   it('returns 404 for unknown practiceId', async () => {


### PR DESCRIPTION
PROFILE.activePracticeIds was the cap enforcement source, but it's a denormalized cache updated via Promise.all alongside UPRACTICE.status. If either write failed, PROFILE drifted from UPRACTICE — and since /api/practices/active reads UPRACTICE while /api/practice's cap check read PROFILE, the UI could show "no active practice" while the backend rejected new practices with CAP_REACHED.

Switch all three handlers (start/reactivate, makeInactive, switch) to query UPRACTICE# items once and derive both the active count and the new activePracticeIds value from that snapshot. PROFILE is now reconciled from UPRACTICE truth on every successful write, so the next start/switch self-heals stale state.