### PR TITLE
fix(practice): cap check skips UPRACTICE rows with retired practiceIds

### DIFF
--- a/_docs/canon/hard-bugs.md
+++ b/_docs/canon/hard-bugs.md
@@ -117,8 +117,19 @@ If drift recurs, the cheapest fix is wrapping the two writes in
 `PROFILE.activePracticeIds` and having all three readers query
 UPRACTICE.
 
+**Follow-up (same day, second PR):** The #390 fix alone was insufficient
+for users with `UPRACTICE#<id>` rows left over from the 2026-05-16
+practice-ID rename ([`094fa55`](https://github.com/qianhaopower/fiappV1/commit/094fa55)).
+Those rows still carried `status='active'` but their `practiceId` was no
+longer in the library. The UI's `enrich()` filtered them out — the new
+cap check did not, so the user still hit `CAP_REACHED`. Fixed by tightening
+`isActiveUPractice` to require `practicesById.has(up.practiceId)`, matching
+the UI's behavior exactly. Lesson reinforced: "match the UI's source of
+truth" means matching its *filter rules* too, not just its source item.
+
 **References:**
-- PR [#390](https://github.com/qianhaopower/fiappV1/pull/390)
+- PR [#390](https://github.com/qianhaopower/fiappV1/pull/390) — initial fix (PROFILE → UPRACTICE)
+- PR [#393](https://github.com/qianhaopower/fiappV1/pull/393) — follow-up (skip ghost renamed IDs)
 - Diverging readers (still cache-trusting):
   [`app/api/return/route.ts`](../../app/api/return/route.ts),
   [`app/api/progress/route.ts`](../../app/api/progress/route.ts),

--- a/app/api/practice/route.ts
+++ b/app/api/practice/route.ts
@@ -35,10 +35,13 @@ type Body = {
 
 type Client = ReturnType<typeof createDynamoClient>
 
-// Single source of truth for "what counts as active." Matches the lenient read in
-// /api/practices/active: missing status defaults to active; paused/replaced/inactive do not.
+// Single source of truth for "what counts as active." Must match /api/practices/active:
+// missing status defaults to active; paused/replaced/inactive do not; rows whose
+// practiceId is no longer in the library (e.g. left over from the 2026-05-16 ID
+// rename) are treated as inactive — the UI's enrich() drops them, so the cap must too.
 function isActiveUPractice(up: UPracticeItem): boolean {
-  return !up.status || up.status === 'active'
+  if (up.status && up.status !== 'active') return false
+  return practicesById.has(up.practiceId)
 }
 
 async function queryUPractices(client: Client, pk: string): Promise<UPracticeItem[]> {

--- a/tests/unit/api/practice.post.test.ts
+++ b/tests/unit/api/practice.post.test.ts
@@ -165,7 +165,12 @@ describe('POST /api/practice — startPractice', () => {
   })
 
   it('PAID user blocked at 10 (no soft warnings)', async () => {
-    const ten = Array.from({ length: 10 }, (_, i) => `practice-${i}`)
+    const ten = [
+      'financial-label-decision', 'financial-repeated-cost', 'financial-auto-payment-review',
+      'financial-purchase-pause', 'financial-discuss-purchase',
+      'relationship-listen-to-understand', 'relationship-caring-question',
+      'relationship-notice-detail', 'relationship-phone-away', 'information-check-source',
+    ]
     const uprBySK: Record<string, Record<string, unknown>> = {}
     for (const id of ten) uprBySK[`UPRACTICE#${id}`] = { status: 'active' }
     mockStore({ activePracticeIds: ten, subscriptionStatus: 'PAID' }, uprBySK)
@@ -175,7 +180,10 @@ describe('POST /api/practice — startPractice', () => {
   })
 
   it('PAID user at 5 active gets no warning (warnings dropped in v2)', async () => {
-    const five = Array.from({ length: 5 }, (_, i) => `practice-${i}`)
+    const five = [
+      'financial-label-decision', 'financial-repeated-cost', 'financial-auto-payment-review',
+      'financial-purchase-pause', 'financial-discuss-purchase',
+    ]
     const uprBySK: Record<string, Record<string, unknown>> = {}
     for (const id of five) uprBySK[`UPRACTICE#${id}`] = { status: 'active' }
     mockStore({ activePracticeIds: five, subscriptionStatus: 'PAID' }, uprBySK)
@@ -183,6 +191,32 @@ describe('POST /api/practice — startPractice', () => {
     expect(res.status).toBe(201)
     const json = await res.json()
     expect(json.warning).toBeUndefined()
+  })
+
+  // Regression: the 2026-05-16 practice-ID rename left orphan UPRACTICE rows on existing
+  // users with status='active' but a practiceId that's no longer in the library. The UI
+  // hides those rows (enrich() returns null) — the cap check must skip them too, or the
+  // user is locked out by a ghost they can't see.
+  it('ignores UPRACTICE rows whose practiceId is no longer in the library (ghost rows)', async () => {
+    mockStore(
+      { activePracticeIds: ['retired-practice-id'], subscriptionStatus: 'FREE' },
+      {
+        // status='active' but the id is not in practicesById (a renamed/removed practice).
+        'UPRACTICE#retired-practice-id': {
+          status: 'active',
+          practiceId: 'retired-practice-id',
+        },
+      },
+    )
+    const res = await POST(makeReq({ mode: 'startPractice', practiceId: 'sleep-consistent-bedtime' }))
+    expect(res.status).toBe(201)
+    // Reconciled list contains only the new (valid) practice; ghost row excluded.
+    const profileUpdate = updateItemMock.mock.calls.find(
+      (c) => c[0].Key.SK === 'PROFILE',
+    )
+    expect(profileUpdate[0].ExpressionAttributeValues[':ids']).toEqual([
+      'sleep-consistent-bedtime',
+    ])
   })
 
   // Regression: PROFILE.activePracticeIds can drift from UPRACTICE.status if a prior


### PR DESCRIPTION
After #390 moved the cap check off the PROFILE cache and onto UPRACTICE truth, users with rows left over from the 2026-05-16 practice-ID rename (094fa55) still hit CAP_REACHED. Those rows carry status='active' but a practiceId no longer in the library. The UI hides them via enrich() returning null; the cap check counted them.

Tighten isActiveUPractice to require practicesById.has(up.practiceId) so the cap matches the UI's filter exactly. Adds a unit regression and fixes two existing PAID-cap tests that were using fake practice IDs.

Updates the hard-bugs entry with a follow-up note.