### PR TITLE
chore(practices): registry + CI guard against reusing retired practice IDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,20 @@ After merging a feature to `main`, sync staging back up:
 git checkout staging && git merge main && git push origin staging
 ```
 
+## Practice IDs — HARD RULES
+
+**NEVER reuse a retired practice ID.** Practice IDs in `lib/practices/library.ts`
+are write keys in DynamoDB (`UPRACTICE#<id>`, `RETURN#<id>`, milestone SKs). When a
+practice is renamed or removed, dormant rows survive in existing users' data. If a
+new practice ever takes a retired ID, those rows silently come back to life with all
+the wrong history attached — data-correctness incident, no UI warning.
+
+**When renaming or removing a practice:**
+1. Add the OLD id to `RETIRED_PRACTICE_IDS` in [`lib/practices/retired-ids.ts`](lib/practices/retired-ids.ts).
+2. The test in `tests/unit/practices/retired-ids.test.ts` will fail any PR that
+   reuses a retired id. Do not bypass it.
+3. Never delete entries from `RETIRED_PRACTICE_IDS`. It is append-only.
+
 ## E2E tests (Layer 3) — SAFETY RULES
 
 **NEVER run `npm run test:e2e` or `npx playwright test` unless one of these is true:**

--- a/lib/practices/retired-ids.ts
+++ b/lib/practices/retired-ids.ts
@@ -1,0 +1,57 @@
+// Registry of practice IDs that were once live but have since been retired or renamed.
+//
+// Why this exists: UPRACTICE# rows in DynamoDB are keyed by the practice ID at the
+// time of writing. When we rename a practice, old rows survive in users' data with
+// the *old* ID and (usually) status='active'. We tolerate them by filtering on
+// `practicesById.has(up.practiceId)` everywhere we read UPRACTICE — they become
+// inert ghosts.
+//
+// The hazard: if a *new* practice ID later collides with a retired one, those
+// dormant ghost rows silently spring back to life. The new practice would
+// inherit the old rows' status, firstStartedAt, returns history, milestone
+// progress — every consumer would treat it as if the user had been doing
+// the new practice for years. That is a data-correctness incident, not a
+// minor UI bug.
+//
+// Procedure when renaming or removing a practice:
+//   1. Add the OLD id to RETIRED_PRACTICE_IDS below.
+//   2. The unit test in tests/unit/practices/retired-ids.test.ts will refuse
+//      any current practice ID that overlaps this set.
+//   3. Never delete entries from this list. It is append-only.
+
+export const RETIRED_PRACTICE_IDS: ReadonlySet<string> = new Set([
+  // 2026-05-16 — v2 content rewrite, commit 094fa55
+  'dynamic-10-min-walk',
+  'dynamic-active-choice',
+  'dynamic-daylight-block',
+  'dynamic-one-challenge',
+  'dynamic-stretch-break',
+  'emotional-3-breath-reset',
+  'emotional-calm-routine',
+  'emotional-journal-3-lines',
+  'emotional-name-feeling',
+  'emotional-trigger-note',
+  'financial-24hr-rule',
+  'financial-bill-list',
+  'financial-expense-buffer',
+  'financial-save-small',
+  'financial-weekly-review',
+  'information-decision-pause',
+  'information-evening-review',
+  'information-news-free-morning',
+  'information-single-tab',
+  'information-thinking-block',
+  'nutrition-eat-without-screens',
+  'nutrition-half-plate-check',
+  'nutrition-no-processed-snack',
+  'nutrition-vegetables-first',
+  'nutrition-water-first',
+  'relationship-daily-checkin',
+  'relationship-device-free-meal',
+  'relationship-express-gratitude',
+  'relationship-one-deeper-question',
+  'relationship-pause-before-reply',
+  'sleep-bedroom-prep',
+  'sleep-screen-off',
+  'sleep-wind-down-ritual',
+])

--- a/tests/unit/practices/retired-ids.test.ts
+++ b/tests/unit/practices/retired-ids.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { practices } from '@/lib/practices/library'
+import { RETIRED_PRACTICE_IDS } from '@/lib/practices/retired-ids'
+
+describe('retired practice IDs', () => {
+  // The hazard this test guards against: reusing a retired practice ID would
+  // resurrect every UPRACTICE# row, RETURN# row, and milestone tied to it in
+  // existing users' DynamoDB data — silently, with no UI warning. See
+  // lib/practices/retired-ids.ts for the full rationale.
+  it('no current practice ID is in the retired registry', () => {
+    const collisions = practices
+      .map((p) => p.id)
+      .filter((id) => RETIRED_PRACTICE_IDS.has(id))
+    expect(
+      collisions,
+      `These practice IDs were previously retired and must not be reused: ${collisions.join(
+        ', ',
+      )}. Pick a different id, or — only if you are absolutely sure no production user ever had data under this id — remove it from RETIRED_PRACTICE_IDS in lib/practices/retired-ids.ts.`,
+    ).toEqual([])
+  })
+
+  it('retired registry contains no duplicates with current library (sanity)', () => {
+    const currentIds = new Set(practices.map((p) => p.id))
+    for (const retiredId of RETIRED_PRACTICE_IDS) {
+      expect(currentIds.has(retiredId)).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
Follow-up guardrail to #390 + #393. Practice IDs are write keys in DynamoDB (`UPRACTICE#<id>`, `RETURN#<id>`, milestone SKs) — when a practice is renamed, the rows survive in users' data. If a new practice ever takes a retired ID, those dormant rows silently resurrect with the wrong history attached.

This PR adds:
- **[lib/practices/retired-ids.ts](lib/practices/retired-ids.ts)** — append-only registry of retired practice IDs, seeded with the 33 IDs retired in the 2026-05-16 v2 content rewrite (commit [`094fa55`](https://github.com/qianhaopower/fiappV1/commit/094fa55)).
- **[tests/unit/practices/retired-ids.test.ts](tests/unit/practices/retired-ids.test.ts)** — fails any PR whose `library.ts` overlaps the registry, with an error message pointing the developer at the file.
- **[CLAUDE.md](CLAUDE.md)** "Practice IDs — HARD RULES" section: on rename, add the OLD id to the registry; never delete entries.

## Test plan
- [x] `npm run test` — 298 passing (296 before + 2 new for the guard).
- [x] Verified test fails when a current ID is added to the registry, then passes when removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)