### PR TITLE
docs: reflect Stripe live mode (shipped 2026-05-17)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -31,7 +31,7 @@ Follow-up PRs after the main merge: #376 (manual checklist rewrites against v2) 
 
 ## Business / Payments
 
-- [ ] **Stripe live mode** — Currently on test keys. Update `FIAPP_STRIPE_SECRET_KEY`, `FIAPP_STRIPE_WEBHOOK_SECRET`, and `FIAPP_STRIPE_PRICE_ID` in Amplify to live values when ready to accept real payments.
+- [x] ~~**Stripe live mode**~~ → shipped 2026-05-17. Live `rk_live_…` key + live webhook + live price are on the `main`-branch Amplify override. Staging still runs on the Sandbox via "All branches" defaults. End-to-end verified with a real A$19 charge + refund. Webhook idempotent via `STRIPE_EVENT#` rows; refund + dispute handlers flip users back to FREE. See [docs/operations/stripe-go-live.md](docs/operations/stripe-go-live.md) for the cutover playbook and [docs/operations/runbook.md#stripe-configuration-reference](docs/operations/runbook.md) for ops reference.
 
 ---
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -54,10 +54,15 @@ If `ok: false` or HTTP 503 — DynamoDB is unreachable. Check AWS Console → Dy
 3. Check CloudWatch logs for `[withAuth]` errors
 
 ### Payments not working
-1. Check Stripe Dashboard → Webhooks → recent events — look for failed deliveries
-2. Verify `FIAPP_STRIPE_WEBHOOK_SECRET` env var in Amplify matches Stripe webhook secret
-3. Verify `FIAPP_STRIPE_PRICE_ID` matches the active price in Stripe
-4. CloudWatch logs for `/api/payment/webhook` errors
+1. Identify which environment: `friendsintelligence.net` (live) vs `staging.d3nyg9qvz1tj5n.amplifyapp.com` (Sandbox/test).
+2. Stripe Dashboard → switch to **Live mode** for prod issues, **Sandbox** for staging issues.
+3. Workbench → Webhooks → click the relevant endpoint → "Event deliveries" tab. Look for failed deliveries (non-2xx).
+4. Common failure modes:
+   - **400 "Invalid signature"** → `FIAPP_STRIPE_WEBHOOK_SECRET` mismatch. Verify the value in Amplify Console (live secret on `main` override, test secret on All branches) matches the secret in the Stripe Dashboard webhook detail page. Redeploy after editing.
+   - **400 "Missing userId"** → Checkout Session was created without `metadata.userId`. Inspect the event payload; should not happen with current code.
+   - **500 "DB update failed"** → DynamoDB issue. Check IAM permissions + CloudWatch logs.
+5. Manual replay: in the webhook event detail in Stripe Dashboard, click "Resend." If the event ID was already claimed by an earlier delivery, you may need to first delete the `STRIPE_EVENT#<event.id>` row from DynamoDB so the claim can be re-acquired.
+6. To manually flip a user: AWS Console → DynamoDB → FIAPP_MAIN → query `PK=USER#<userId>, SK=PROFILE` → set `subscriptionStatus` to `PAID` or `FREE`.
 
 ### DynamoDB errors in logs
 1. Check IAM role attached to Amplify Lambda has `dynamodb:GetItem`, `PutItem`, `UpdateItem`, `Query` on both tables
@@ -83,9 +88,9 @@ If `ok: false` or HTTP 503 — DynamoDB is unreachable. Check AWS Console → Dy
 | `FIAPP_AWS_ACCESS_KEY_ID` | AWS credentials for DynamoDB |
 | `FIAPP_AWS_SECRET_ACCESS_KEY` | AWS credentials for DynamoDB |
 | `FIAPP_AWS_REGION` | AWS region |
-| `FIAPP_STRIPE_SECRET_KEY` | Stripe secret key |
-| `FIAPP_STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret |
-| `FIAPP_STRIPE_PRICE_ID` | Stripe price ID for Plus plan |
+| `FIAPP_STRIPE_SECRET_KEY` | Stripe secret/restricted key. **All branches** = test (`sk_test_…`); **`main` override** = live (`rk_live_…`). |
+| `FIAPP_STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret. **All branches** = Sandbox webhook secret; **`main` override** = live webhook secret. |
+| `FIAPP_STRIPE_PRICE_ID` | Stripe price ID for Plus plan. **All branches** = test price; **`main` override** = live price (A$19 AUD one-time). |
 | `FIAPP_ADMIN_USER_ID` | Cognito userId of the operator (for /admin access) |
 | `NEXT_PUBLIC_FIAPP_APP_URL` | Public app URL |
 
@@ -107,3 +112,27 @@ If `ok: false` or HTTP 503 — DynamoDB is unreachable. Check AWS Console → Dy
 
 Users can email `hello@friendsintelligence.net` for support or feedback.  
 Monitor inbox after launch. First 48 hours are highest signal — respond to every email.
+
+---
+
+## Stripe configuration reference
+
+Live mode went online 2026-05-17. Two environments are wired up:
+
+| Env | URL | Stripe environment | Webhook subscribes to |
+|---|---|---|---|
+| Production | `https://friendsintelligence.net` | **Live mode** | `checkout.session.completed`, `charge.refunded`, `charge.dispute.created` |
+| Staging | `https://staging.d3nyg9qvz1tj5n.amplifyapp.com` | **Sandbox** (legacy test mode) | Same three events |
+
+Both webhooks deliver to `/api/payment/webhook` on their respective host.
+
+**Restricted key permissions** (live `rk_live_…` key, named `fiapp-server`):
+- Checkout Sessions: Write
+- PaymentIntents: Read
+- All other resources: None
+
+**Refund/dispute downgrade**: refunds (full only — partial refunds keep access) and disputes flip `subscriptionStatus` back to `FREE`. Webhook is idempotent via `STRIPE_EVENT#<event.id>` rows in DynamoDB.
+
+**Re-purchase guard**: `POST /api/payment/checkout` returns 409 `ALREADY_PAID` for users already on Plus.
+
+Full go-live playbook (with rollback): [stripe-go-live.md](./stripe-go-live.md).

--- a/docs/operations/stripe-go-live.md
+++ b/docs/operations/stripe-go-live.md
@@ -1,11 +1,22 @@
 # Stripe — Test → Live Cutover Playbook
 
+**Status: shipped 2026-05-17.** Production accepts real payments. This doc is preserved as the record of what was done and the rollback path.
+
 Goal: take payments from real users on production while keeping staging on Stripe test mode.
 
 After this is done:
 - `friendsintelligence.net` → Stripe **live** mode → real cards → real money
-- `staging.d3nyg9qvz1tj5n.amplifyapp.com` → Stripe **test** mode → test cards only
-- `localhost:3000` → Stripe test mode (unchanged)
+- `staging.d3nyg9qvz1tj5n.amplifyapp.com` → Stripe **Sandbox** (legacy test mode) → test cards only
+- `localhost:3000` → Stripe Sandbox (unchanged)
+
+### Important note on Stripe environments
+
+When this playbook was executed, Stripe's UI presented two separate test environments:
+
+- **Sandbox** (legacy "Test mode") — where the original `sk_test_51TU2Nj…` API keys live. This is where staging continues to run.
+- **Test mode** (newer feature, paired with the live account post-activation) — initially empty for us. We briefly created a webhook here (`fiapp-staging`) before realising our API keys point at Sandbox, not this one. The Test-mode webhook was deleted.
+
+The cleanest model going forward: **staging = Sandbox, production = Live mode.** The post-activation "Test mode" environment is unused.
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation-only PR. Updates three files to reflect that Stripe live mode shipped on 2026-05-17.

- **TODO.md** — checks off the Stripe live mode item with a one-line summary of what shipped (live key + webhook + price on main override; staging still on Sandbox; refund + dispute handlers verified; idempotency live).
- **docs/operations/runbook.md** — expands the "Payments not working" section to cover diagnosis across both environments (Live for prod, Sandbox for staging), documents how to replay events through the `STRIPE_EVENT#` idempotency rows, and how to manually flip a user's status in DynamoDB. Adds a "Stripe configuration reference" section at the bottom summarising the two-environment setup, restricted-key scopes, and refund/re-purchase behavior.
- **docs/operations/stripe-go-live.md** — status header marking the playbook as shipped. Adds a paragraph clarifying the Stripe environment confusion we hit (the post-activation "Test mode" environment is distinct from the legacy "Sandbox" where our API keys live).

## Test plan

- [x] Reads cleanly
- No runtime changes; no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)