### PR TITLE
fix(ui): bug-tracker batch — 10 fixes (epic #328)

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -5,7 +5,7 @@ import { useAuthenticator } from '@aws-amplify/ui-react';
 import { NarrowFormPage } from '@/components/layout';
 import { Card, Button } from '@/components/ui';
 import { useProfile } from '@/contexts/ProfileContext';
-import { getPlanLabel } from '@/lib/plans';
+import { getPlanLabel, isPlusPlan, PLUS_PLAN_DESCRIPTION } from '@/lib/plans';
 import { UpgradeButton } from '@/components/UpgradeButton';
 import { useUserEmail } from '@/lib/useUserEmail';
 
@@ -42,6 +42,11 @@ export default function AccountPage() {
               <div>
                 <p className="text-xs text-muted-foreground mb-0.5">Plan</p>
                 <p className="text-sm font-medium text-foreground">{plan}</p>
+                {!isPlusPlan(profile?.subscriptionStatus) && (
+                  <p className="mt-2 text-xs text-muted-foreground leading-relaxed">
+                    {PLUS_PLAN_DESCRIPTION}
+                  </p>
+                )}
                 <div className="mt-2"><UpgradeButton /></div>
               </div>
             </div>

--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -223,7 +223,7 @@ export default function AssessmentPage() {
               {pillarLabel}
             </span>
 
-            <div className="mt-4 min-h-[3.5rem] text-xl font-semibold leading-7 text-foreground">
+            <div className="mt-4 min-h-[10rem] sm:min-h-[7rem] text-xl font-semibold leading-7 text-foreground">
               {current.text}
             </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -230,7 +230,7 @@ export default function LandingPage() {
             <div className="grid grid-cols-1 gap-5 md:grid-cols-3">
               {[
                 { n: "01", icon: <IconAssess />, title: "Assess", body: "35 questions across the seven Friends pillars. Honest answers, no right or wrong." },
-                { n: "02", icon: <IconInsight />, title: "Insight", body: "A personalised report with your scores and one focus pillar to start with — not a long to-do list." },
+                { n: "02", icon: <IconInsight />, title: "Insight", body: "A personalised report with your results and one focus pillar to start with — not a long to-do list." },
                 { n: "03", icon: <IconPractice />, title: "Practice", body: "Build one small daily practice at a time. We'll flag if you drift. We won't nag." },
               ].map((s) => (
                 <div

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -204,8 +204,8 @@ export default function PracticesPage() {
                 const busy = !!actionLoading[p.id]
                 return (
                   <Card key={p.id} variant="interactive">
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="space-y-2 min-w-0 flex-1">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="space-y-2 min-w-0 sm:flex-1">
                         <div className="flex items-center gap-2 flex-wrap">
                           <span
                             className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold text-white"
@@ -240,7 +240,7 @@ export default function PracticesPage() {
                         ) : null}
                       </div>
 
-                      <div className="flex flex-col gap-2 shrink-0">
+                      <div className="flex flex-row gap-2 sm:flex-col sm:shrink-0">
                         {status === 'none' && (
                           <Button size="sm" variant="outline" disabled={busy} onClick={() => handleStart(p)}>
                             {busy ? '…' : 'Start this practice'}

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -178,7 +178,7 @@ export default function ResultsPage() {
         {!loading && !error && !assessment && (
           <EmptyState
             title="No insights yet"
-            text="Take the assessment to see your pillar scores and get personalized practice suggestions."
+            text="Take the assessment to see your pillar results and get personalized practice suggestions."
             action={<Button asChild><Link href="/assessment">Start assessment →</Link></Button>}
           />
         )}
@@ -213,7 +213,7 @@ export default function ResultsPage() {
 
             <div>
               <div className="flex items-center gap-2 mb-4">
-                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">All Pillars</p>
+                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Your Results by Pillar</p>
                 <HelpTooltip content="Each pillar has 5 questions. Your score reflects how many you answered Yes to in the last 7–14 days. A 3/5 isn't a failure — it's a starting point." />
               </div>
               <div className="space-y-3">
@@ -340,8 +340,8 @@ export default function ResultsPage() {
                   <Link href="/assessment">Retake assessment</Link>
                 </Button>
                 <p className="mt-1.5 text-xs text-muted-foreground">
-                  Scores update when you retake — useful after a few weeks of practice.{" "}
-                  <Link href="/faq" className="underline underline-offset-2 hover:text-foreground">Questions about your scores?</Link>
+                  Your results update when you retake — useful after a few weeks of practice.{" "}
+                  <Link href="/faq" className="underline underline-offset-2 hover:text-foreground">Questions about your results?</Link>
                 </p>
               </div>
             </div>

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -150,7 +150,10 @@ export default function TodayPage() {
   }
 
   return (
-    <NarrowFormPage title="Today">
+    <NarrowFormPage
+      title="Today"
+      description="Did you practice today? Tap once for each active practice — you can change your answer any time today."
+    >
       <div className="space-y-8">
 
         {newMilestones.length > 0 && (
@@ -217,7 +220,7 @@ export default function TodayPage() {
                     >
                       {pillarLabels[p.pillar]}
                     </span>
-                    <HelpTooltip content="'Did it' logs that you completed your practice today. 'Not today' logs that you skipped — no judgment, it still counts as showing up. You can change your answer any time today." />
+                    <HelpTooltip content="'Did it today' logs that you completed your practice. 'Not today' logs that you skipped — no judgment, both count as showing up. You can change your answer any time today." />
                   </div>
                   <p className="mt-3 text-xl font-semibold text-foreground">{p.title}</p>
                   <p className="mt-1 text-sm text-muted-foreground">{p.description}</p>
@@ -231,7 +234,7 @@ export default function TodayPage() {
                     onClick={(e) => handleLog(p.id, true, { x: e.clientX, y: e.clientY })}
                     className={`w-full font-semibold ${s.didIt === null ? 'border-primary/40 text-primary hover:bg-primary/5' : ''} ${s.justLogged ? 'animate-button-confirm' : ''}`}
                   >
-                    {s.logging && s.loggingValue === true ? '…' : '✓ Did it'}
+                    {s.logging && s.loggingValue === true ? '…' : '✓ Did it today'}
                   </Button>
                   <Button
                     size="sm"

--- a/components/HelpTooltip.tsx
+++ b/components/HelpTooltip.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
 
 interface HelpTooltipProps {
   content: string;
 }
 
-const TOOLTIP_WIDTH = 256; // w-64
+const TOOLTIP_WIDTH = 256; // matches w-64
 const VIEWPORT_MARGIN = 12;
 
 export function HelpTooltip({ content }: HelpTooltipProps) {
   const [open, setOpen] = useState(false);
-  const [alignRight, setAlignRight] = useState(false);
+  const [position, setPosition] = useState<CSSProperties>({ left: 0 });
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -27,7 +28,17 @@ export function HelpTooltip({ content }: HelpTooltipProps) {
   function handleOpen() {
     if (ref.current) {
       const rect = ref.current.getBoundingClientRect();
-      setAlignRight(rect.left + TOOLTIP_WIDTH > window.innerWidth - VIEWPORT_MARGIN);
+      const vw = window.innerWidth;
+      const usable = vw - 2 * VIEWPORT_MARGIN;
+      const width = Math.min(TOOLTIP_WIDTH, usable);
+
+      if (rect.left + width <= vw - VIEWPORT_MARGIN) {
+        setPosition({ left: 0 });
+      } else if (rect.right - width >= VIEWPORT_MARGIN) {
+        setPosition({ right: 0 });
+      } else {
+        setPosition({ left: VIEWPORT_MARGIN - rect.left });
+      }
     }
     setOpen((v) => !v);
   }
@@ -44,7 +55,8 @@ export function HelpTooltip({ content }: HelpTooltipProps) {
       </button>
       {open && (
         <div
-          className={`absolute top-6 z-50 w-64 rounded-lg border border-border bg-card p-3 text-xs leading-relaxed text-muted-foreground shadow-lg ${alignRight ? "right-0" : "left-0"}`}
+          style={position}
+          className="absolute top-6 z-50 w-64 max-w-[calc(100vw-24px)] rounded-lg border border-border bg-card p-3 text-xs leading-relaxed text-muted-foreground shadow-lg"
         >
           {content}
         </div>

--- a/components/PlanBadge.tsx
+++ b/components/PlanBadge.tsx
@@ -1,27 +1,59 @@
 "use client";
 
+import { useState } from "react";
+import { toast } from "sonner";
 import { useProfile } from "@/contexts/ProfileContext";
 import { getPlanLabel, isPlusPlan } from "@/lib/plans";
 
 export function PlanBadge() {
   const { profile, loading } = useProfile();
+  const [busy, setBusy] = useState(false);
 
   if (loading || !profile?.subscriptionStatus) return null;
 
   const plan = profile.subscriptionStatus;
   const label = getPlanLabel(plan);
-  const variant = isPlusPlan(plan) ? "primary" : "muted";
+  const isPlus = isPlusPlan(plan);
+
+  const baseClass =
+    "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium";
+  const colorClass = isPlus
+    ? "bg-primary/15 text-primary"
+    : "bg-muted text-muted-foreground";
+
+  if (isPlus) {
+    return (
+      <span className={`${baseClass} ${colorClass}`} aria-label={`Plan: ${label}`}>
+        {label}
+      </span>
+    );
+  }
+
+  async function handleClick() {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/payment/checkout", { method: "POST" });
+      const data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+        return;
+      }
+      toast.error("Could not start checkout. Please try again.");
+    } catch {
+      toast.error("Could not start checkout. Please try again.");
+    }
+    setBusy(false);
+  }
 
   return (
-    <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-        variant === "primary"
-          ? "bg-primary/15 text-primary"
-          : "bg-muted text-muted-foreground"
-      }`}
-      aria-label={`Plan: ${label}`}
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={busy}
+      aria-label={`Plan: ${label}. Upgrade to Plus.`}
+      className={`${baseClass} ${colorClass} cursor-pointer transition-colors hover:bg-primary/15 hover:text-primary disabled:opacity-60`}
     >
-      {label}
-    </span>
+      {busy ? "Loading…" : label}
+    </button>
   );
 }

--- a/components/UpgradeButton.tsx
+++ b/components/UpgradeButton.tsx
@@ -18,14 +18,13 @@ export function UpgradeButton() {
       const data = await res.json();
       if (data.url) {
         window.location.href = data.url;
-      } else {
-        toast.error("Could not start checkout. Please try again.");
+        return;
       }
+      toast.error("Could not start checkout. Please try again.");
     } catch {
       toast.error("Could not start checkout. Please try again.");
-    } finally {
-      setBusy(false);
     }
+    setBusy(false);
   }
 
   return (

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui'
 import { PlanBadge } from '@/components/PlanBadge'
 import { DevSubscriptionToggle } from '@/components/DevSubscriptionToggle'
 import { useProfile } from '@/contexts/ProfileContext'
-import { getPlanLabel, isPlusPlan } from '@/lib/plans'
+import { getPlanLabel, isPlusPlan, PLUS_PLAN_TAGLINE } from '@/lib/plans'
 import { useUserEmail } from '@/lib/useUserEmail'
 
 interface AppShellProps {
@@ -39,13 +39,15 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
     try {
       const res = await fetch('/api/payment/checkout', { method: 'POST' })
       const data = await res.json()
-      if (data.url) window.location.href = data.url
-      else toast.error('Could not start checkout. Please try again.')
+      if (data.url) {
+        window.location.href = data.url
+        return
+      }
+      toast.error('Could not start checkout. Please try again.')
     } catch {
       toast.error('Could not start checkout. Please try again.')
-    } finally {
-      setCheckoutBusy(false)
     }
+    setCheckoutBusy(false)
   }
   const accountRef = useRef<HTMLDivElement>(null)
   const { profile } = useProfile()
@@ -110,13 +112,18 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
                     <p className="text-xs text-muted-foreground truncate">{email}</p>
                     <p className="text-xs font-medium text-foreground mt-0.5">{planLabel}</p>
                     {!isPlusPlan(profile?.subscriptionStatus) && (
-                      <button
-                        onClick={handleUpgrade}
-                        disabled={checkoutBusy}
-                        className="mt-2 w-full rounded-md bg-primary/10 border border-primary/25 px-2 py-1 text-xs font-semibold text-primary hover:bg-primary/20 transition-colors text-center disabled:opacity-50"
-                      >
-                        {checkoutBusy ? 'Loading…' : 'Upgrade to Plus'}
-                      </button>
+                      <>
+                        <p className="mt-2 text-[10px] leading-snug text-muted-foreground">
+                          {PLUS_PLAN_TAGLINE}
+                        </p>
+                        <button
+                          onClick={handleUpgrade}
+                          disabled={checkoutBusy}
+                          className="mt-1.5 w-full rounded-md bg-primary/10 border border-primary/25 px-2 py-1 text-xs font-semibold text-primary hover:bg-primary/20 transition-colors text-center disabled:opacity-50"
+                        >
+                          {checkoutBusy ? 'Loading…' : 'Upgrade to Plus'}
+                        </button>
+                      </>
                     )}
                   </div>
                   <Link
@@ -192,13 +199,18 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
                 Account
               </Link>
               {!isPlusPlan(profile?.subscriptionStatus) && (
-                <button
-                  onClick={() => { setMobileOpen(false); handleUpgrade(); }}
-                  disabled={checkoutBusy}
-                  className="block w-full text-left px-3 py-2 rounded-md text-sm font-medium text-primary hover:bg-primary/10 transition-colors disabled:opacity-50"
-                >
-                  {checkoutBusy ? 'Loading…' : 'Upgrade to Plus'}
-                </button>
+                <div>
+                  <button
+                    onClick={() => { setMobileOpen(false); handleUpgrade(); }}
+                    disabled={checkoutBusy}
+                    className="block w-full text-left px-3 py-2 rounded-md text-sm font-medium text-primary hover:bg-primary/10 transition-colors disabled:opacity-50"
+                  >
+                    {checkoutBusy ? 'Loading…' : 'Upgrade to Plus'}
+                  </button>
+                  <p className="px-3 mt-0.5 text-[11px] leading-snug text-muted-foreground">
+                    {PLUS_PLAN_TAGLINE}
+                  </p>
+                </div>
               )}
               {onSignOut && (
                 <button

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -11,3 +11,8 @@ export function getPlanLabel(status?: string | null): string {
 export function getPlanShortLabel(status?: string | null): string {
   return isPlusPlan(status) ? "Plus" : "Free";
 }
+
+export const PLUS_PLAN_TAGLINE = "Track up to 10 active practices instead of 1.";
+
+export const PLUS_PLAN_DESCRIPTION =
+  "Plus unlocks up to 10 active practices at once (Free is limited to 1), so you can build habits across multiple pillars in parallel.";

--- a/lib/useUserEmail.ts
+++ b/lib/useUserEmail.ts
@@ -39,7 +39,5 @@ export function useUserEmail(): string {
   }, [user]);
 
   const loginId = user?.signInDetails?.loginId ?? "";
-  const username = user?.username ?? "";
-  const isFederatedUsername = /^[a-z]+_[a-zA-Z0-9-]+$/.test(username);
-  return email || loginId || (isFederatedUsername ? "" : username);
+  return email || loginId || "";
 }

--- a/tests/unit/components/PlanBadge.test.tsx
+++ b/tests/unit/components/PlanBadge.test.tsx
@@ -49,7 +49,7 @@ describe("PlanBadge", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders Free plan when subscriptionStatus is FREE", () => {
+  it("renders Free plan as an upgrade-triggering button when subscriptionStatus is FREE", () => {
     useProfileMock.mockReturnValue({
       profile: { subscriptionStatus: "FREE" },
       loading: false,
@@ -58,8 +58,9 @@ describe("PlanBadge", () => {
     });
 
     render(<PlanBadge />);
-    expect(screen.getByText("Free plan")).toBeInTheDocument();
-    expect(screen.getByLabelText("Plan: Free plan")).toBeInTheDocument();
+    const badge = screen.getByRole("button", { name: /Plan: Free plan\. Upgrade to Plus\./ });
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("Free plan");
   });
 
   it("renders Plus plan when subscriptionStatus is PAID", () => {


### PR DESCRIPTION
## Summary

Batch of small UI/copy fixes from EPIC #328 (Bug Tracker). Cut from `staging`, intended to merge back to `staging` for QA before promoting to `main`.

## Bugs fixed (code change)

- **#387** — Reserve question-area height (`min-h-[10rem] sm:min-h-[7rem]`) on /assessment so the Yes/No buttons don't shift between questions
- **#396** — "Did it today" label + new-user orientation copy on /today, tooltip rewritten to pair with "Not today"
- **#397** — Practice Library cards stack vertically on mobile so the Start button no longer squeezes the text column
- **#398** — Renamed "All Pillars" → "Your Results by Pillar"
- **#399** — `HelpTooltip` clamps width to `calc(100vw - 24px)` and picks position (left / right / viewport-pinned) so the popup stays inside the screen
- **#400** — Soft-pass "score" → "results" on results page CTAs + landing (kept "score" where it literally explains the number, e.g. FAQ Q3)
- **#401** — Free `PlanBadge` is now a button that triggers Stripe checkout (Plus stays as a span)
- **#402** — Removed Cognito-sub fallback in `useUserEmail` so the Account view no longer flashes a GUID before email loads
- **#405** — Skip `setBusy(false)` on the success path of all 3 checkout call sites; button stays in "Loading…" until the browser navigates to Stripe (no flash)
- **#360** — Single source for Plus copy in `lib/plans.ts`; full description on /account, tagline on the desktop dropdown + mobile menu

## Bugs closed without code change (verified obsolete)

- **#354** — "Promote or discard" copy gone after v2 simplification (E2E test asserts absence)
- **#358** — Cap-limit copy already friendly in `CapLimitNotice.tsx`
- **#359** — "days left to decide" copy gone after v2 trial removal (E2E test asserts absence)

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 298 pass (PlanBadge test updated for new button role)
- [x] `npm run test:integration` — 60 pass
- [ ] **Manual: staging URL** — walk through /assessment, /today, /practices on mobile + desktop; click Free badge to confirm Stripe redirect with no flash; tap a help "?" near the right edge on mobile to confirm tooltip doesn't clip
- [ ] **Manual: /account** — confirm email no longer flashes a GUID, Plus description renders
- [ ] **Layer 3 E2E** against staging before merging staging→main: `BASE_URL=https://staging.d3nyg9qvz1tj5n.amplifyapp.com npm run test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)