### PR TITLE
fix(security+ui): bug-tracker batch 2 — cross-user data isolation + 7…

### DIFF
--- a/_docs/canon/hard-bugs.md
+++ b/_docs/canon/hard-bugs.md
@@ -38,6 +38,146 @@ evidence matter more than narrative.
 
 ## Bugs
 
+### 2026-05-18 — CloudFront caching cross-user `/api/*` responses (data isolation incident)
+
+**Symptom (what users / monitoring saw):**
+A friend who had signed up the previous day (Google login, brand-new Cognito
+user, no prior history) opened the app and saw a fully-populated UI that
+belonged to someone else. /today showed 2 active practices labelled "Label
+one spending decision" and "Notice one repeated cost" with "you've done this
+2 times" / "1 time" captions; /practices showed those same two with `Active`
+/ `Paused` status; /progress showed 6 total check-ins, "Practices started:
+4", and a `First check-in` milestone dated 5/9/2026 — 8 days before their
+Cognito account was even created. A direct DynamoDB query on the user's
+partition key (`USER#698e8478-...`) returned only 37 rows: 1 PROFILE
+(empty `activePracticeIds`, empty `returnCounters`), 1 ASSESS#, and 35 ANS#.
+Zero UPRACTICE rows. Zero MILESTONE rows. The UI was rendering data that
+did not exist on the server for that user.
+
+**Why it was hard to diagnose:**
+- The UI and the database told contradictory stories. The natural debug
+  path ("what data does this user have?") said empty. The UI clearly
+  rendered consistent non-empty state — practice cards with the right
+  pillar colours, a milestone with a specific date, counters that matched
+  the dot history. It looked like real data, just not theirs.
+- Initial hypothesis was the boring one: "user just forgot they used the
+  app earlier." Took two rounds of evidence (Cognito timestamps + DDB
+  query) before we accepted that the contradiction was real.
+- Pre-sign-up trigger account linking (Google ↔ existing native account
+  with same email) was the obvious next theory and would have explained
+  inherited data. The Cognito user's `Created time` equalling
+  `Last updated time` ruled it out — no subsequent linking write had
+  happened on that record.
+- No recent code change to suspect. The cache headers had been wrong
+  since the routes were written; only some users hit the wrong cache
+  entry at the right time.
+- The smoking gun was a date that *could not exist*: "First check-in
+  5/9/2026" pre-dates the account creation (`2026-05-17 20:04`) by 8
+  days. Once we noticed it, the cross-user theory was inescapable.
+
+**Root cause:** Authenticated API routes returning per-user JSON didn't
+set `Cache-Control: no-store`. Affected routes:
+`/api/progress`, `/api/practices/active`, `/api/returns`, `/api/practice`,
+`/api/return`, `/api/assessment`. Only `/api/me` had the header
+(via a local `jsonWithNoStore` helper that wasn't reused elsewhere).
+
+Behind Amplify Hosting's CloudFront, a response with no `Cache-Control`
+falls back to the distribution's default TTL and is cached under the
+URL alone — **CloudFront's default cache key does not include cookies**.
+So `GET /api/practices/active` cached the first authenticated user's
+response at the edge, and every subsequent user requesting the same URL
+got that same JSON until the cached entry expired or was evicted. The
+authenticated request even arrived at the origin Lambda only on the
+first call; after that, the edge served the cached payload without ever
+re-running `withAuth` or rechecking the cookie.
+
+`#416` ("you've done this X times" wrong after clearing today) was the
+same root cause from a different angle — the counter the user saw came
+from another user's cached `/api/practices/active` / `/api/returns`
+response.
+
+**Fix:** Defense in depth, 5 layers:
+
+1. **`utils/authServer.ts` `withAuth`** — always rewrites
+   `Cache-Control: no-store, private` and `Vary: Cookie` on every
+   response it passes through, including the 401 / 429 / 500 error
+   paths. Overrides any permissive header a handler tried to set, so a
+   future new route can't accidentally reintroduce caching. This is the
+   chokepoint fix and would have prevented the original bug on its own.
+2. **`next.config.ts`** — global header rule for `source: "/api/:path*"`
+   applying the same `Cache-Control` + `Vary`. Belt; catches public
+   API routes that don't go through `withAuth`.
+3. **`customHttp.yml`** (new file) — Amplify Hosting CDN-level header
+   override for `/api/**/*`. Suspenders; enforced at the edge even if
+   the app layer regresses.
+4. **Unit tests** in `tests/unit/authServer.test.ts` — assert the
+   headers on success responses, that `withAuth` overrides a permissive
+   header set by a handler, that the 500 error path also carries them,
+   and that `unauthorizedResponse()` includes them.
+5. **Post-deploy curl verification** — `curl -sSI .../api/me` against
+   staging then prod after deploy to confirm headers are on the wire,
+   not just in code.
+
+`Vary: Cookie` is the load-bearing header for the
+defense-in-depth story: even if a future change weakens `Cache-Control`,
+any cache that respects `Vary` keys responses by the auth cookie — so
+two different users can never share a cache entry. `private` does the
+same job for shared caches that ignore `Vary`. `no-store` is the
+strictest blanket "don't cache anywhere" directive. All three together
+cover the realistic failure modes.
+
+**Lessons / what to check next time:**
+- **Authed routes need explicit cache control. `no-store` is not the
+  CDN default.** CloudFront, every other CDN, every reverse proxy —
+  they all default to "may cache." If you do nothing, your private API
+  responses are cacheable. The vulnerability is the absence of a
+  header, not the presence of a wrong one.
+- **CloudFront's default cache key is URL-only. Cookies are not in
+  it unless you configure the cache policy to forward and key on
+  them.** "Cookies vary, so the response varies" is a *server*
+  assumption. The CDN does not share it.
+- **Add the header at a chokepoint, not per-route.** This bug
+  happened because cache control was per-route and four out of ~ten
+  authed routes were missing it. `withAuth` is the natural chokepoint
+  for all authed responses. Per-route headers are exactly how this
+  bug was created.
+- **Believe the database.** When the UI shows data and the DB has
+  none, do not assume "user is mistaken" or "stale frontend cache."
+  A 37-row DDB query with zero UPRACTICE is the truth; the UI
+  rendering practices is the question to answer.
+- **Look for values whose existence is logically impossible for the
+  user.** Timestamps predating signup, IDs from a previous schema,
+  references to users who don't share that account — these are
+  higher-signal than any "looks suspicious" pattern.
+- **`Vary` is cheap insurance.** Even if you trust your `Cache-Control`
+  today, adding `Vary: Cookie` makes the next class of weakening
+  failure (someone tweaks `Cache-Control` to allow short caching for
+  perf) safe by construction.
+- **Test by curl after deploy, not by code review.** App-layer
+  headers can be silently stripped by hosting platforms, edge
+  workers, or middlebox proxies. `curl -I` against the deployed URL
+  is the ground truth.
+
+**Residual risk (acknowledged):** `customHttp.yml` patterns are an
+Amplify Hosting feature whose exact glob syntax has shifted across
+Amplify versions. The pattern in this PR is `/api/**/*` which matches
+Amplify Hosting's current behaviour, but a future Amplify version could
+change pattern interpretation. The `withAuth` (layer 1) and
+`next.config.ts` (layer 2) defenses are independent of `customHttp.yml`
+and would still hold if layer 3 ever silently stopped matching.
+
+**References:**
+- Issue [#417](https://github.com/qianhaopower/fiappV1/issues/417) — original report (data pollution)
+- Issue [#416](https://github.com/qianhaopower/fiappV1/issues/416) — same root cause (counter tooltip)
+- Epic [#328](https://github.com/qianhaopower/fiappV1/issues/328) — bug tracker
+- PR fix/bug-tracker-batch-2
+- Layer 1: [`utils/authServer.ts`](../../utils/authServer.ts)
+- Layer 2: [`next.config.ts`](../../next.config.ts)
+- Layer 3: [`customHttp.yml`](../../customHttp.yml)
+- Layer 4: [`tests/unit/authServer.test.ts`](../../tests/unit/authServer.test.ts)
+
+---
+
 ### 2026-05-17 — "Choose a practice" + `CAP_REACHED`: UPRACTICE vs PROFILE divergence
 
 **Symptom (what users / monitoring saw):**

--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -7,6 +7,14 @@ import { assessmentQuestions } from "@/lib/assessment/questions";
 import { pillarColors } from "@/lib/design/pillarColors";
 import { NarrowFormPage } from "@/components/layout";
 import { Button, Card } from "@/components/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 export default function AssessmentPage() {
   const router = useRouter();
@@ -16,6 +24,7 @@ export default function AssessmentPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [introAccepted, setIntroAccepted] = useState(false);
+  const [confirmRestart, setConfirmRestart] = useState(false);
 
   function getContrastingTextColor(hex: string) {
     const match = /^#?([0-9a-fA-F]{6})$/.exec(hex);
@@ -103,6 +112,11 @@ export default function AssessmentPage() {
     setSubmitting(false);
   }
 
+  function confirmAndReset() {
+    handleReset();
+    setConfirmRestart(false);
+  }
+
   if (!introAccepted) {
     return (
       <NarrowFormPage title="">
@@ -168,7 +182,7 @@ export default function AssessmentPage() {
               <Button
                 type="button"
                 variant="outline"
-                onClick={handleReset}
+                onClick={() => setConfirmRestart(true)}
                 disabled={submitting || answeredCount === 0}
               >
                 Restart
@@ -285,6 +299,30 @@ export default function AssessmentPage() {
         This assessment is for personal reflection only —{' '}
         <Link href="/disclaimer" className="underline underline-offset-2 hover:text-foreground">not professional advice</Link>.
       </p>
+
+      <Dialog open={confirmRestart} onOpenChange={setConfirmRestart}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Start the assessment again?</DialogTitle>
+            <DialogDescription>
+              This goes back to the first question and clears your{' '}
+              {answeredCount} {answeredCount === 1 ? 'answer' : 'answers'} so far.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setConfirmRestart(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={confirmAndReset}>
+              Start again
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </NarrowFormPage>
   );
 }

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -16,11 +16,33 @@ const SAMPLE_SCORES: Record<Pillar, number> = {
   sleep: 3,
 };
 
+// #419 escape hatch — some users got stuck on /onboarding when router.replace
+// silently failed to change the URL (browser/router state we couldn't repro).
+// If we're still on /onboarding NAV_FALLBACK_MS after the click, force a full
+// page navigation so the user is never trapped. The console.warn leaves a
+// breadcrumb the next time someone reports being stuck.
+const NAV_FALLBACK_MS = 600;
+
 export default function OnboardingPage() {
   const router = useRouter();
 
   function start() {
+    if (typeof window !== "undefined") {
+      console.info("[onboarding] start: navigating to /assessment");
+    }
     router.replace("/assessment");
+    if (typeof window !== "undefined") {
+      window.setTimeout(() => {
+        if (window.location.pathname.startsWith("/onboarding")) {
+          console.warn(
+            "[onboarding] router.replace did not change URL after",
+            NAV_FALLBACK_MS,
+            "ms — falling back to window.location"
+          );
+          window.location.href = "/assessment";
+        }
+      }, NAV_FALLBACK_MS);
+    }
   }
 
   return (

--- a/app/practices/page.tsx
+++ b/app/practices/page.tsx
@@ -186,8 +186,34 @@ export default function PracticesPage() {
         {loading && <Loading text="Loading practices…" />}
         {!loading && error && <ErrorState message="Couldn't load practices." onRetry={load} />}
 
+        {!loading && !error && (
+          <nav
+            aria-label="Jump to pillar"
+            className="-mb-4 flex flex-wrap gap-1.5 sm:gap-2 pb-4 border-b border-border/40"
+          >
+            {pillarOrder.map((pillar) => (
+              <a
+                key={pillar}
+                href={`#pillar-${pillar}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-background px-2.5 py-1 text-xs text-foreground no-underline hover:bg-muted/40 transition-colors"
+              >
+                <span
+                  className="h-2 w-2 rounded-full shrink-0"
+                  style={{ backgroundColor: pillarColors[pillar] }}
+                  aria-hidden="true"
+                />
+                {pillarLabels[pillar]}
+              </a>
+            ))}
+          </nav>
+        )}
+
         {!loading && !error && pillarOrder.map((pillar) => (
-          <section key={pillar} className="space-y-3">
+          <section
+            key={pillar}
+            id={`pillar-${pillar}`}
+            className="space-y-3 scroll-mt-20"
+          >
             <div className="flex items-center gap-2">
               <span
                 className="h-3 w-3 rounded-full shrink-0"

--- a/app/today/page.tsx
+++ b/app/today/page.tsx
@@ -264,11 +264,14 @@ export default function TodayPage() {
                 {s.dots.some((d) => d.didIt !== null) && (
                   <div>
                     <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground mb-3">Last 14 days</p>
-                    <div className="flex flex-wrap gap-2">
+                    <div className="grid grid-cols-7 gap-2 justify-items-center">
                       {s.dots.map((dot) => {
                         const d = new Date(dot.date + 'T00:00:00Z')
                         const label = d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' })
-                        const tooltip = dot.didIt === true ? `${label} · Did it` : dot.didIt === false ? `${label} · Skipped` : label
+                        const isToday = dot.date === s.currentReturnDate
+                        const tooltip = isToday
+                          ? `${label} · Today${dot.didIt === true ? ' · Did it' : dot.didIt === false ? ' · Skipped' : ''}`
+                          : dot.didIt === true ? `${label} · Did it` : dot.didIt === false ? `${label} · Skipped` : label
                         return (
                           <span
                             key={dot.date}
@@ -279,7 +282,7 @@ export default function TodayPage() {
                                 : dot.didIt === false
                                 ? 'bg-foreground/20 border-foreground/35'
                                 : 'bg-muted/70 border-border/50'
-                            } ${s.justLogged && dot.date === s.currentReturnDate ? 'animate-dot-pop' : ''}`}
+                            } ${isToday ? 'ring-2 ring-primary/40 ring-offset-2 ring-offset-card' : ''} ${s.justLogged && isToday ? 'animate-dot-pop' : ''}`}
                           />
                         )
                       })}

--- a/components/AuthenticatorWrapper.tsx
+++ b/components/AuthenticatorWrapper.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react";
 import { Hub } from "aws-amplify/utils";
 import { getCurrentUser } from "aws-amplify/auth";
 import { ensureAmplifyConfigured } from "@/lib/amplifyClient";
+import { detectInAppBrowser, type InAppBrowser } from "@/lib/inAppBrowser";
 
 const passwordSettings = {
   minLength: 8,
@@ -64,9 +65,44 @@ function AuthRedirect() {
   );
 }
 
+// Google OAuth rejects embedded webviews with `disallowed_useragent` (Error
+// 403). Surface a notice so users in WeChat / Facebook / Instagram / etc.
+// know to open the link in their device's real browser before tapping Google.
+function InAppBrowserNotice({ browser }: { browser: InAppBrowser }) {
+  const openInstructions: Record<InAppBrowser, string> = {
+    WeChat: "Tap the ⋯ menu in the top-right and choose ‘Open in Browser’.",
+    Facebook: "Tap the ⋯ menu and choose ‘Open in External Browser’.",
+    Instagram: "Tap the ⋯ menu and choose ‘Open in External Browser’.",
+    TikTok: "Tap the ⋯ menu and choose ‘Open in External Browser’.",
+    Line: "Tap the ⋯ menu and choose ‘Open in Default Browser’.",
+  };
+
+  return (
+    <div
+      role="status"
+      className="mb-4 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs leading-relaxed text-amber-900 dark:text-amber-200"
+    >
+      <p className="font-semibold">
+        Open this page in your phone&apos;s browser to sign in with Google.
+      </p>
+      <p className="mt-1">
+        Google blocks sign-in inside {browser}. {openInstructions[browser]} You can still sign in with email and password here.
+      </p>
+    </div>
+  );
+}
+
 export default function AuthenticatorWrapper() {
   ensureAmplifyConfigured();
   const router = useRouter();
+  const [inAppBrowser, setInAppBrowser] = useState<InAppBrowser | null>(null);
+
+  // Runs only on the client to avoid SSR/CSR markup mismatch — we can't
+  // read navigator on the server. One-shot setState after mount is fine.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setInAppBrowser(detectInAppBrowser(navigator.userAgent));
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -105,6 +141,8 @@ export default function AuthenticatorWrapper() {
             An account saves your assessment results and practice progress so you can pick up where you left off. We only store your email and your responses — nothing is shared or sold.
           </p>
         </div>
+
+        {inAppBrowser && <InAppBrowserNotice browser={inAppBrowser} />}
 
         <div className="fiapp-auth-shell">
           <Authenticator

--- a/components/DecideRouteClient.tsx
+++ b/components/DecideRouteClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthenticator } from "@aws-amplify/ui-react";
 import { decideRoute, type ProfileForRouting } from "@/lib/decideRoute";
@@ -8,10 +8,26 @@ import { useProfile } from "@/contexts/ProfileContext";
 import FullPageSpinner from "@/components/FullPageSpinner";
 import { Button } from "@/components/ui";
 
+// After a quiet period the Lambda may need to cold-start. fetchMe retries
+// transient failures already (see lib/apiClient.ts); this just lets the
+// user know we're still working, instead of staring at a silent spinner.
+const SLOW_LOAD_MESSAGE_MS = 6000;
+
 export default function DecideRouteClient() {
   const router = useRouter();
   const { authStatus } = useAuthenticator((context) => [context.authStatus]);
   const { profile, loading, error, refetch } = useProfile();
+  const [slow, setSlow] = useState(false);
+
+  useEffect(() => {
+    if (!loading) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSlow(false);
+      return;
+    }
+    const t = setTimeout(() => setSlow(true), SLOW_LOAD_MESSAGE_MS);
+    return () => clearTimeout(t);
+  }, [loading]);
 
   useEffect(() => {
     if (authStatus === "unauthenticated") {
@@ -37,7 +53,11 @@ export default function DecideRouteClient() {
   }
 
   if (loading) {
-    return <FullPageSpinner label="Loading your profile…" />;
+    return (
+      <FullPageSpinner
+        label={slow ? "Waking the server up — almost there…" : "Loading your profile…"}
+      />
+    );
   }
 
   if (error && error.status !== 401 && error.status !== 403) {

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -72,11 +72,19 @@ export function AppShell({ children, onSignOut }: AppShellProps) {
         </div>
         <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-14 flex items-center justify-between">
           <div className="flex items-center gap-6">
-            <Link href="/today" className="flex items-center gap-2 group">
+            <Link
+              href="/today"
+              aria-label="Friends Intelligence home — go to Today"
+              title="Go to Today"
+              className="flex items-center gap-2 group"
+            >
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/logo-mark.svg" alt="Friends Intelligence" className="h-7 w-7 shrink-0" />
+              <img src="/logo-mark.svg" alt="" aria-hidden="true" className="h-7 w-7 shrink-0" />
               <span className="whitespace-nowrap font-semibold tracking-tight text-foreground group-hover:text-primary transition-colors text-sm">
                 Friends Intelligence
+              </span>
+              <span className="hidden sm:inline text-xs text-muted-foreground font-normal" aria-hidden="true">
+                · Today
               </span>
             </Link>
             <nav className="hidden md:flex items-center gap-4 text-sm">

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,0 +1,12 @@
+customHeaders:
+  # API responses are per-user. Force the CDN (CloudFront in front of Amplify
+  # Hosting) and every intermediate cache to never store them, and to never
+  # share an entry across sessions. Defense in depth alongside withAuth and
+  # next.config.ts — even if a future code change weakens the app-layer
+  # headers, the hosting layer still rewrites Cache-Control here.
+  - pattern: '/api/**/*'
+    headers:
+      - key: 'Cache-Control'
+        value: 'no-store, private'
+      - key: 'Vary'
+        value: 'Cookie'

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -4,22 +4,59 @@ export type ApiMeResponse<TProfile = unknown> = {
   profile?: TProfile; // normalized for backwards compat when ok/data envelope
 };
 
-export async function fetchMe<TProfile>(): Promise<{
-  status: number;
-  data: ApiMeResponse<TProfile> | null;
-}> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 10_000);
+// Lambda cold start after a long idle window can easily blow 5–10s on the
+// first invocation, and that's exactly when a user signs in after a quiet
+// period. We give each attempt a generous per-call budget and retry the
+// classes of failure that warming up will resolve. See #419.
+const PER_ATTEMPT_TIMEOUT_MS = 15_000;
+const MAX_ATTEMPTS = 3;
+const RETRY_BACKOFF_MS = [400, 1200];
 
-  let res: Response;
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchMeOnce(): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PER_ATTEMPT_TIMEOUT_MS);
   try {
-    res = await fetch("/api/me", {
+    return await fetch("/api/me", {
       cache: "no-store",
       credentials: "include",
       signal: controller.signal,
     });
   } finally {
     clearTimeout(timeout);
+  }
+}
+
+export async function fetchMe<TProfile>(): Promise<{
+  status: number;
+  data: ApiMeResponse<TProfile> | null;
+}> {
+  let lastError: unknown = null;
+  let res: Response | null = null;
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    try {
+      res = await fetchMeOnce();
+      // 5xx is also worth retrying — same warmup story as a hung request.
+      if (res.status >= 500 && attempt < MAX_ATTEMPTS - 1) {
+        await sleep(RETRY_BACKOFF_MS[attempt] ?? RETRY_BACKOFF_MS[RETRY_BACKOFF_MS.length - 1]);
+        continue;
+      }
+      break;
+    } catch (err) {
+      lastError = err;
+      if (attempt < MAX_ATTEMPTS - 1) {
+        await sleep(RETRY_BACKOFF_MS[attempt] ?? RETRY_BACKOFF_MS[RETRY_BACKOFF_MS.length - 1]);
+        continue;
+      }
+    }
+  }
+
+  if (!res) {
+    throw lastError ?? new Error("fetchMe failed without response");
   }
 
   let body: { ok?: boolean; data?: TProfile } | null = null;

--- a/lib/assessment/questions.ts
+++ b/lib/assessment/questions.ts
@@ -201,11 +201,11 @@ export const QUESTIONS: Question[] = [
     pillar: "emotional",
     order: 1,
     mappedPracticeId: "emotional-name-before-reacting",
-    text: "Have you named an emotion before reacting to it?",
+    text: "Have you stopped and asked yourself what you were feeling — like anger, hurt, fear, or worry — before saying or doing something?",
     suggestions: [
-      "When a strong reaction rises, pause and say the feeling silently — \"anger\", \"hurt\", \"fear\".",
-      "Add one word about the cause: \"frustrated about the delay\".",
-      "Notice that naming it often shrinks it.",
+      "When something gets to you, take a breath and say the feeling to yourself — anger, hurt, fear, worry.",
+      "Add one word about why: \"frustrated about the delay\".",
+      "Just saying what you feel often makes it feel smaller.",
     ],
   },
   {

--- a/lib/inAppBrowser.ts
+++ b/lib/inAppBrowser.ts
@@ -1,0 +1,22 @@
+// Detects known in-app webviews where Google OAuth fails with
+// `disallowed_useragent` (Error 403). Returning the name lets the UI
+// tailor instructions per app (e.g. "Tap ⋯ → Open in Browser" for WeChat).
+// Reference: Google blocks any User-Agent it classifies as an embedded
+// webview from completing the OAuth flow.
+
+export type InAppBrowser =
+  | "WeChat"
+  | "Facebook"
+  | "Instagram"
+  | "TikTok"
+  | "Line";
+
+export function detectInAppBrowser(userAgent: string): InAppBrowser | null {
+  if (!userAgent) return null;
+  if (/MicroMessenger/i.test(userAgent)) return "WeChat";
+  if (/FBAN|FBAV/i.test(userAgent)) return "Facebook";
+  if (/Instagram/i.test(userAgent)) return "Instagram";
+  if (/Bytedance|TTWebView|musical_ly|TikTok/i.test(userAgent)) return "TikTok";
+  if (/\bLine\//i.test(userAgent)) return "Line";
+  return null;
+}

--- a/lib/practices/library.ts
+++ b/lib/practices/library.ts
@@ -159,9 +159,9 @@ export const practices: Practice[] = [
     pillar: 'emotional',
     order: 1,
     mappedQuestionId: 'emotional-1',
-    title: 'Name before reacting',
-    description: 'Name one emotion today before reacting, such as anxiety, anger, sadness, excitement, shame, calm, or frustration.',
-    rationale: 'Naming a feeling activates the thinking part of the brain and quiets the reactive part. The half-second between feeling and labelling is where calmer choices live.',
+    title: 'Catch a feeling before it acts',
+    description: 'When something gets to you today, pause and say what you\'re feeling — like anger, hurt, fear, worry, or excitement — before you say or do anything back.',
+    rationale: 'Putting a feeling into a word — even a quick "I\'m hurt" or "I\'m worried" — gives your brain a beat to slow down. That tiny pause is where calmer choices live.',
   },
   {
     id: 'emotional-now-or-echo',

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,15 @@ const securityHeaders = [
   { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
 ];
 
+// API responses carry per-user data. Forbid any cache (browser, CDN, proxy)
+// from storing them, and vary by Cookie so even if a downstream cache ignores
+// no-store it never shares an entry across sessions. Belt-and-suspenders with
+// withAuth (which also sets these headers) and customHttp.yml (Amplify CDN).
+const apiNoStoreHeaders = [
+  { key: "Cache-Control", value: "no-store, private" },
+  { key: "Vary", value: "Cookie" },
+];
+
 const nextConfig: NextConfig = {
   typescript: { ignoreBuildErrors: false },
   async headers() {
@@ -14,6 +23,10 @@ const nextConfig: NextConfig = {
       {
         source: "/(.*)",
         headers: securityHeaders,
+      },
+      {
+        source: "/api/:path*",
+        headers: apiNoStoreHeaders,
       },
     ];
   },

--- a/tests/unit/authServer.test.ts
+++ b/tests/unit/authServer.test.ts
@@ -61,10 +61,11 @@ describe("authServer", () => {
       expect(json.error.message).toBe("Authentication required");
     });
 
-    it("sets Cache-Control no-store", () => {
+    it("sets Cache-Control no-store, private and Vary: Cookie", () => {
       const res = unauthorizedResponse();
 
-      expect(res.headers.get("Cache-Control")).toBe("no-store");
+      expect(res.headers.get("Cache-Control")).toBe("no-store, private");
+      expect(res.headers.get("Vary")).toBe("Cookie");
     });
   });
 
@@ -109,6 +110,53 @@ describe("authServer", () => {
       await withAuth(undefined, handler);
 
       expect(handler).toHaveBeenCalledWith({ userId: "usr-99", username: "test" });
+    });
+
+    // Cross-user data isolation guard. Every authenticated response must
+    // forbid shared caches (CDN, proxies) from storing it. See #417 for the
+    // incident this defends against.
+    it("forces Cache-Control: no-store, private and Vary: Cookie on the handler's response", async () => {
+      runWithAmplifyMock.mockResolvedValue({
+        user: { userId: "usr-77", username: "test" },
+      });
+
+      const { withAuth } = await import("@/utils/authServer");
+      const res = await withAuth(undefined, async () =>
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+
+      expect(res.headers.get("Cache-Control")).toBe("no-store, private");
+      expect(res.headers.get("Vary")).toBe("Cookie");
+    });
+
+    it("overrides a handler that tries to set a permissive Cache-Control", async () => {
+      runWithAmplifyMock.mockResolvedValue({
+        user: { userId: "usr-77", username: "test" },
+      });
+
+      const { withAuth } = await import("@/utils/authServer");
+      const res = await withAuth(undefined, async () => {
+        const r = new Response(JSON.stringify({ ok: true }), { status: 200 });
+        r.headers.set("Cache-Control", "public, max-age=3600");
+        return r;
+      });
+
+      expect(res.headers.get("Cache-Control")).toBe("no-store, private");
+    });
+
+    it("sets cache headers on 500 responses from handler errors", async () => {
+      runWithAmplifyMock.mockResolvedValue({
+        user: { userId: "usr-77", username: "test" },
+      });
+
+      const { withAuth } = await import("@/utils/authServer");
+      const res = await withAuth(undefined, async () => {
+        throw new Error("boom");
+      });
+
+      expect(res.status).toBe(500);
+      expect(res.headers.get("Cache-Control")).toBe("no-store, private");
+      expect(res.headers.get("Vary")).toBe("Cookie");
     });
   });
 });

--- a/tests/unit/inAppBrowser.test.ts
+++ b/tests/unit/inAppBrowser.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { detectInAppBrowser } from "@/lib/inAppBrowser";
+
+describe("detectInAppBrowser", () => {
+  it("returns WeChat for MicroMessenger UA", () => {
+    expect(
+      detectInAppBrowser(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) MicroMessenger/8.0.42"
+      )
+    ).toBe("WeChat");
+  });
+
+  it("returns Facebook for FBAN/FBAV UA", () => {
+    expect(detectInAppBrowser("Mozilla/5.0 FBAN/FBIOS;FBAV/450.0")).toBe("Facebook");
+  });
+
+  it("returns Instagram for Instagram UA", () => {
+    expect(detectInAppBrowser("Mozilla/5.0 Instagram 301.0.0.33.110")).toBe("Instagram");
+  });
+
+  it("returns TikTok for ByteDance / TTWebView UA", () => {
+    expect(
+      detectInAppBrowser("Mozilla/5.0 musical_ly_31.4.0 JsSdk/2.0 NetType/WIFI TTWebView/123")
+    ).toBe("TikTok");
+  });
+
+  it("returns Line for Line/ UA", () => {
+    expect(
+      detectInAppBrowser("Mozilla/5.0 (iPhone) AppleWebKit/605.1.15 Line/13.0.0")
+    ).toBe("Line");
+  });
+
+  it("returns null for Safari", () => {
+    expect(
+      detectInAppBrowser(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1"
+      )
+    ).toBeNull();
+  });
+
+  it("returns null for Chrome", () => {
+    expect(
+      detectInAppBrowser(
+        "Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36"
+      )
+    ).toBeNull();
+  });
+
+  it("returns null for empty UA", () => {
+    expect(detectInAppBrowser("")).toBeNull();
+  });
+});

--- a/tests/unit/pages/assessment.page.test.tsx
+++ b/tests/unit/pages/assessment.page.test.tsx
@@ -99,6 +99,78 @@ describe("Assessment page", () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
+  // #415 — Restart action must require explicit confirmation so users can't
+  // accidentally wipe in-progress answers near the end of a 35-question flow.
+  describe("Restart confirmation (#415)", () => {
+    it("opens a confirmation dialog and does NOT reset answers immediately", () => {
+      render(<AssessmentPage />);
+      fireEvent.click(screen.getByRole("button", { name: /Start assessment/ }));
+
+      // Answer 2 questions so Restart is enabled (it's disabled at 0 answers).
+      fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+      fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+
+      // We're now on question 3.
+      expect(screen.getByText(/Question\s*3\s*\/\s*35/)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Restart" }));
+
+      // Dialog is visible. Answers untouched — still on question 3.
+      expect(
+        screen.getByRole("heading", { name: /Start the assessment again\?/ })
+      ).toBeInTheDocument();
+      expect(screen.getByText(/clears your 2 answers/)).toBeInTheDocument();
+      expect(screen.getByText(/Question\s*3\s*\/\s*35/)).toBeInTheDocument();
+    });
+
+    it("Cancel closes the dialog and preserves answers + current question", () => {
+      render(<AssessmentPage />);
+      fireEvent.click(screen.getByRole("button", { name: /Start assessment/ }));
+
+      fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+      fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+      fireEvent.click(screen.getByRole("button", { name: "Restart" }));
+
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      // Dialog dismissed; user still on question 3 with both answers intact.
+      expect(
+        screen.queryByRole("heading", { name: /Start the assessment again\?/ })
+      ).not.toBeInTheDocument();
+      expect(screen.getByText(/Question\s*3\s*\/\s*35/)).toBeInTheDocument();
+
+      // Walking back confirms answers weren't dropped.
+      fireEvent.click(screen.getByRole("button", { name: "Back" }));
+      expect(screen.getByRole("button", { name: "Next" })).not.toBeDisabled();
+    });
+
+    it("Start again wipes answers and returns to question 1", () => {
+      render(<AssessmentPage />);
+      fireEvent.click(screen.getByRole("button", { name: /Start assessment/ }));
+
+      fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+      fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+      fireEvent.click(screen.getByRole("button", { name: "Restart" }));
+
+      fireEvent.click(screen.getByRole("button", { name: "Start again" }));
+
+      // Back at question 1 with no preserved answer (Next disabled).
+      expect(screen.getByText(/Question\s*1\s*\/\s*35/)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+      expect(
+        screen.queryByRole("heading", { name: /Start the assessment again\?/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it("Restart button is disabled when no answers have been given yet", () => {
+      render(<AssessmentPage />);
+      fireEvent.click(screen.getByRole("button", { name: /Start assessment/ }));
+
+      expect(screen.getByRole("button", { name: "Restart" })).toBeDisabled();
+    });
+  });
+
   it("redirects to /auth on unauthorized", async () => {
     (global.fetch as unknown as Mock).mockResolvedValue({
       ok: false,

--- a/utils/authServer.ts
+++ b/utils/authServer.ts
@@ -44,6 +44,22 @@ export async function getUserId(_req?: Request): Promise<AuthUser> {
   }
 }
 
+/**
+ * Cross-user data isolation defense.
+ *
+ * Every authenticated response carries per-user data. Without these headers
+ * the CDN (CloudFront in front of Amplify Hosting) and any intermediate proxy
+ * can cache one user's response under the URL alone and serve it back to
+ * other users. `no-store` forbids storage; `private` forbids shared caches
+ * even if a future change weakens `no-store`; `Vary: Cookie` keys responses
+ * by the auth cookie so no cache entry is ever shared across sessions.
+ */
+function applyNoStoreHeaders(res: Response): Response {
+  res.headers.set("Cache-Control", "no-store, private");
+  res.headers.set("Vary", "Cookie");
+  return res;
+}
+
 export function unauthorizedResponse() {
   const res = NextResponse.json(
     {
@@ -55,8 +71,7 @@ export function unauthorizedResponse() {
     },
     { status: 401 },
   );
-  res.headers.set("Cache-Control", "no-store");
-  return res;
+  return applyNoStoreHeaders(res);
 }
 
 export function rateLimitedResponse() {
@@ -70,8 +85,7 @@ export function rateLimitedResponse() {
     },
     { status: 429 },
   );
-  res.headers.set("Cache-Control", "no-store");
-  return res;
+  return applyNoStoreHeaders(res);
 }
 
 export function isUnauthorizedError(error: unknown): error is UnauthorizedError {
@@ -107,7 +121,7 @@ export async function withAuth(
     const status = response.status
     const outcome = status === 429 ? 'rate_limited' : status < 400 ? 'ok' : 'error'
     log({ requestId, route, method, outcome, status, latencyMs: Date.now() - startedAt, userId: user.userId })
-    return response
+    return applyNoStoreHeaders(response)
   } catch (error) {
     log({ requestId, route, method, outcome: 'error', status: 500, latencyMs: Date.now() - startedAt, userId: user.userId }, 'error')
     // Amplify Data client throws NoSignedUser when server context isn't
@@ -115,16 +129,16 @@ export async function withAuth(
     // redirect authenticated users back to /auth
     if (error instanceof Error && error.name === 'NoSignedUser') {
       console.warn('[withAuth] NoSignedUser in handler — Amplify Data client missing server context')
-      return NextResponse.json(
+      return applyNoStoreHeaders(NextResponse.json(
         { ok: false, error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
         { status: 500 }
-      )
+      ))
     }
     console.error('[withAuth] handler error:', error);
-    return NextResponse.json(
+    return applyNoStoreHeaders(NextResponse.json(
       { ok: false, error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
       { status: 500 }
-    );
+    ));
   }
 }
 


### PR DESCRIPTION
… UX fixes (epic #328)

P1 — Cross-user data isolation via CDN edge caching
  #417 friend signed up cleanly; saw a different user's practices,
  check-in counters, and a milestone dated 8 days before their account
  existed. DDB query under their PK returned only PROFILE + 1 assessment
  + 35 answers — zero UPRACTICE, empty counters. UI was rendering data that did not exist on the server.

  Root cause: only /api/me set Cache-Control: no-store. Every other
  authenticated route (/api/progress, /api/practices/active, /api/returns,
  /api/practice, /api/return, /api/assessment) returned JSON with no
  cache header. CloudFront's default cache key is URL-only — cookies
  are not in it — so one user's response was cached at the edge and
  served back to any other user requesting the same URL.

  Defense in depth, 5 layers:
    1. withAuth rewrites Cache-Control: no-store, private + Vary: Cookie on every authed response (including 401/429/500 paths), overriding any permissive header a handler tried to set
    2. next.config.ts /api/:path* global rule
    3. customHttp.yml /api/**/* Amplify Hosting CDN override
    4. 4 new unit tests cover 200, override, 500, unauthorized paths
    5. curl -I post-deploy verification documented in PR

  #416 was the same root cause from a different angle (counter tooltip).
  Closed as duplicate.

  Hard-bugs registry entry added in _docs/canon/hard-bugs.md.

UX bugs / features
  #410 Assessment question wording — abstract "named an emotion before
       reacting" replaced with concrete "stopped and asked yourself what you were feeling — like anger, hurt, fear, or worry — before saying or doing something". Matching pass on the suggestions block and the mapped practice (title "Catch a feeling before it acts", new accessible description + rationale). #411 Brand/logo affordance — aria-label, hover title, and a visible "· Today" subscript on sm+ screens so users see where the logo link goes. #412 Google sign-in in WeChat — Google enforces disallowed_useragent; we can't bypass it. Added lib/inAppBrowser.ts UA detector for WeChat/Facebook/Instagram/TikTok/Line and a banner above the Authenticator with per-browser "Open in Browser" instructions. Email/password still works inline. 8 UA detection tests. #414 14-day return dots — switched from flex-wrap to a 7×2 grid so today is always rightmost; added a subtle ring on today's dot; removed all explanatory text. Matches GitHub / habit-tracker conventions. #415 Restart confirmation — tapping Restart mid-assessment now opens a confirmation dialog showing the answer count. Cancel preserves state; Start again wipes. localStorage draft persistence intentionally deferred (out of scope, not a big enough problem to justify the complexity). 4 new regression tests. #418 Practice Bank pillar nav — anchor jump-pills row at top of /practices, scrolling to id={`pillar-${pillar}`} sections with scroll-margin-top reserved for the sticky header. Native anchor behavior, no JS. #419 New users stuck on onboarding — escape-hatch in OnboardingPage.start(): if router.replace soft-nav stalls for any reason, force a hard window.location.href = "/assessment" after 600ms. console.info on click, console.warn on fallback for next-time diagnostics. Also bumped fetchMe to retry 3× with 400ms/1200ms backoff and 15s per-attempt timeout (was: 1 attempt, 10s), and DecideRoute now shows "Waking the server up — almost there…" after 6s.

Closed without code change
  #413 Suggestion cap — already implemented in getSuggestedPractices
       (hard caps at 3, prioritizes lowest pillar's weak answers). Closed with code pointer. #409 "I don't know" option — declined for v1 with reasoning trail: low product friction in current questions, scoring decision adds subtle bias, third button forces UI complexity on a stabilized card. Cheap fallback (helper-text tweak) documented for future copy pass.

Tests: 313 unit pass (16 new: 8 UA detection + 4 cache-header + 4 restart
       confirmation), 60 integration pass. Lint + typecheck clean.