### PR TITLE
test(e2e): align E2E selectors with batch-2 UI changes

### DIFF
--- a/tests/e2e/assessment.spec.ts
+++ b/tests/e2e/assessment.spec.ts
@@ -83,14 +83,30 @@ test.describe("/assessment", () => {
     expect(parseFloat(w2)).toBeGreaterThan(parseFloat(w1));
   });
 
-  test("Restart button resets to question 1", async ({ page }) => {
+  test("Restart button confirms and resets to question 1", async ({ page }) => {
+    // #415 — Restart now opens a confirmation dialog. Cancel preserves state,
+    // Start again wipes answers and returns to question 1.
     await page.goto("/assessment");
     await page.getByRole("button", { name: /start assessment/i }).click();
     await page.getByRole("button", { name: /^yes$/i }).click(); // → Q2
     await page.getByRole("button", { name: /^yes$/i }).click(); // → Q3
     await expect(page.getByText(/Question 3/i)).toBeVisible();
 
-    await page.getByRole("button", { name: /restart/i }).click();
+    // First Restart: opens dialog, doesn't reset yet.
+    await page.getByRole("button", { name: /^restart$/i }).click();
+    await expect(
+      page.getByRole("heading", { name: /Start the assessment again\?/i })
+    ).toBeVisible();
+    // Still on question 3 — dialog hasn't acted yet.
+    await expect(page.getByText(/Question 3/i)).toBeVisible();
+
+    // Cancel preserves state.
+    await page.getByRole("button", { name: /^cancel$/i }).click();
+    await expect(page.getByText(/Question 3/i)).toBeVisible();
+
+    // Restart again, this time confirm via Start again.
+    await page.getByRole("button", { name: /^restart$/i }).click();
+    await page.getByRole("button", { name: /^start again$/i }).click();
     await expect(page.getByText(/Question 1/i)).toBeVisible();
   });
 

--- a/tests/e2e/authenticated.spec.ts
+++ b/tests/e2e/authenticated.spec.ts
@@ -179,8 +179,12 @@ test.describe("/practices", () => {
   });
 
   test("top action links back to Today", async ({ page }) => {
+    // The brand link in AppShell also includes "go to Today" in its aria-label
+    // (added in #411), so target the explicit "Go to Today →" CTA by exact text.
     await page.goto("/practices");
-    await expect(page.getByRole("link", { name: /go to today/i })).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByRole("link", { name: "Go to Today →" })
+    ).toBeVisible({ timeout: 10_000 });
   });
 });
 
@@ -264,11 +268,13 @@ test.describe("/results", () => {
   });
 
   test("Go to Today button is present when assessment exists", async ({ page }) => {
+    // Brand link's aria-label also contains "go to Today" (#411). Target the
+    // explicit CTA by exact text to disambiguate.
     await page.goto("/results");
     await page.waitForTimeout(2000);
     const hasFocus = await page.getByText(/Focus Pillar/i).isVisible().catch(() => false);
     if (!hasFocus) { test.skip(); return; }
-    await expect(page.getByRole("link", { name: /go to today/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Go to Today →" })).toBeVisible();
   });
 
   test("Retake assessment button is present when assessment exists", async ({ page }) => {


### PR DESCRIPTION
## Summary

Follow-up to PR #420. Two E2E selectors need to be updated because the UI changes that shipped in #420 made the original selectors invalid:

1. **`/assessment Restart button resets to question 1`** — #415 made Restart open a confirmation dialog. Updated to click Restart, assert the dialog opens, exercise Cancel (preserves state), then Restart + Start again to confirm reset.
2. **`/practices top action links back to Today`** and **`/results Go to Today button is present when assessment exists`** — #411 added `aria-label=\"Friends Intelligence home — go to Today\"` to the AppShell brand link. The old selector `getByRole(\"link\", { name: /go to today/i })` now matches both the brand and the explicit \"Go to Today →\" button → strict-mode collision. Updated both tests to use the exact text `\"Go to Today →\"`.

This commit was pushed to the batch-2 feature branch just *after* #420 merged, so it didn't make it onto staging or main. Cherry-picked onto a fresh branch.

## Test plan

- [x] Local verification:
  ```sh
  BASE_URL=https://staging.d3nyg9qvz1tj5n.amplifyapp.com npm run test:e2e
  ```
  → 55 passed, 7 skipped, 0 failed (already verified during #420 review)
- [ ] Re-run against staging after this lands
- [ ] Promote staging → main once green

## No code/runtime impact

Only `tests/e2e/*.spec.ts` are changed. Production code already shipped via #420/#421 and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)