### PR TITLE
feat(funnel): anonymous assessment funnel + launch analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,11 @@ NEXT_PUBLIC_FIAPP_DEV_SUBSCRIPTION=
 # Force subscription status in dev
 # Allowed values: FREE | PAID
 FIAPP_FORCE_SUBSCRIPTION_STATUS=FREE
+
+# ================================
+# Analytics (GA4)
+# ================================
+# Set to your GA4 Measurement ID (G-XXXXXXX) to enable client-side analytics.
+# Empty/missing = GA4 silently off (cookie banner won't appear either).
+# Loaded only after cookie consent — see docs/operations/analytics-privacy-boundaries.md.
+NEXT_PUBLIC_GA4_MEASUREMENT_ID=

--- a/_docs/canon/business-logic-v2.md
+++ b/_docs/canon/business-logic-v2.md
@@ -101,16 +101,18 @@ Same CTA rules everywhere: results screen, practice bank, recommendation cards.
 
 Note: with assessment but 0 active practices, the default destination is **still `/today`** (it renders the empty state). It is no longer `/results`.
 
+Note: `decideRoute` itself stays pure. `DecideRouteClient` may one-shot override the destination to `/results` immediately after a successful anonymous-result hydration on signup — the hydration logic does not modify the pure function. See [anonymous-assessment-funnel](../plans/anonymous-assessment-funnel.md).
+
 ### Per-route guards
 
 | Route | Required state | 0-active behaviour |
 |---|---|---|
 | `/auth` | unauthenticated | N/A. Authed users who land here are redirected to the default route. |
 | `/onboarding` | authed, no assessment | N/A (pre-assessment). Intro screen that leads into `/assessment`. |
-| `/assessment` | authed | N/A. Always accessible (user can retake anytime). |
+| `/assessment` | **public** | N/A. Anonymous visitors complete the questions and submit. Authed visitors see the same questions; submission persists an `ASSESS#` row. See [anonymous-assessment-funnel](../plans/anonymous-assessment-funnel.md). |
 | `/today` | authed + assessment | Empty state with "Browse practices" / "Take assessment" CTAs. **Never redirect.** |
 | `/practices` | authed + assessment | Always accessible. Practice bank: all 35 practices grouped by 7 pillars. |
-| `/results` | authed + assessment | Always accessible. Shows latest assessment summary + suggested practices. |
+| `/results` | **public** | Anonymous visitors render from localStorage (set by `/assessment` submit); empty localStorage → redirect to `/assessment`. Authed visitors render from server-side latest assessment. |
 | `/progress` | authed + assessment | Always accessible. Robust to 0 counters / 0 milestones. |
 
 ### Forbidden / server-enforced
@@ -194,6 +196,8 @@ Removed modes: `startTrial`, `promoteTrial`, `discardTrial`, `add`, `replace`, `
 
 All endpoints require an authenticated user; `userId` is resolved server-side from the session. Error responses follow `{ error: "CODE", ...optional fields }` with an appropriate HTTP status.
 
+**Exception:** `POST /api/assessment` accepts anonymous submissions and returns a compute-only response (no DynamoDB writes). Persistence still requires auth. See dual response shape below and [anonymous-assessment-funnel](../plans/anonymous-assessment-funnel.md).
+
 ### `GET /api/me`
 
 **Purpose:** return PROFILE (create if missing).
@@ -235,7 +239,7 @@ Notes:
 5. Write `ASSESS#<assessmentId>` item with all of the above.
 6. Update `PROFILE.latestAssessmentId` and `PROFILE.lowestPillarId`.
 
-**Returns:**
+**Returns (authed):**
 ```json
 {
   "assessmentId": "...",
@@ -244,6 +248,18 @@ Notes:
   "suggestedPracticeIds": ["...", "...", "..."]
 }
 ```
+
+**Returns (anonymous):** identical shape, minus `assessmentId` (no row was written). Clients must tolerate both shapes — the presence of `assessmentId` is the signal that persistence happened.
+
+```json
+{
+  "pillarScores": { "<pillarId>": number },
+  "lowestPillarId": "...",
+  "suggestedPracticeIds": ["...", "...", "..."]
+}
+```
+
+Anonymous submissions still increment the aggregate `totalAnonymousAssessments` counter (see [analytics-privacy-boundaries.md](../../docs/operations/analytics-privacy-boundaries.md)).
 
 ---
 

--- a/_docs/canon/db-schema.md
+++ b/_docs/canon/db-schema.md
@@ -16,7 +16,7 @@
 
 **Status:** Partially canonical (see supersede note above)
 **Tables:** 2 (FIAPP_MAIN + FIAPP_RETURNS)  
-**Rule:** DynamoDB is the source of truth (no local-storage persistence logic).
+**Rule:** DynamoDB is the source of truth for all authenticated state. `localStorage` may hold transient pre-account state — specifically `assessment.draft` (in-progress quiz answers) and `assessment.result` (anonymous-computed result for `/results` rendering). Both are cleared on signup hydration. No other client-side persistence is permitted. See [anonymous-assessment-funnel](../plans/anonymous-assessment-funnel.md).
 
 ---
 

--- a/_docs/canon/launch-checklist.md
+++ b/_docs/canon/launch-checklist.md
@@ -48,6 +48,13 @@ Last revised: 2026-05-16 (added SES email delivery + password policy checks).
 - [ ] Submit on last question → spinner visible, then redirected to `/results`
 - [ ] **Mobile**: question text readable, buttons not overlapping, progress bar visible
 
+### Anonymous funnel (new, 2026-05-21)
+
+- [ ] **Logged out**: visiting `/assessment` directly loads the intro screen (no auth redirect)
+- [ ] **Logged out**: answer 3-5 questions, refresh the tab — previous answers and current question are restored from localStorage
+- [ ] **Logged out**: submit on last question → spinner → redirected to `/results` (no auth wall)
+- [ ] **Logged out**: clicking Restart clears the in-progress draft from localStorage
+
 ---
 
 ## 3. Results / Insights
@@ -68,6 +75,18 @@ Last revised: 2026-05-16 (added SES email delivery + password policy checks).
 - [ ] Empty state (no assessment yet): CTA to start assessment shown — radar/scores absent
 - [ ] **Mobile**: radar chart not clipped, pillar labels readable
 - [ ] **No v1 vocabulary** anywhere: "Try this practice", "Your focus", "Go to My Practices", "Inactive", "Bring this back" must not appear
+
+### Anonymous funnel (new, 2026-05-21)
+
+- [ ] **Logged out at `/results` with localStorage result**: full pillar scores, focus pillar, radar chart, and 3 suggested practices with full titles + descriptions + rationale
+- [ ] Per-practice CTA reads `Sign up to start →` (not `Start this practice`)
+- [ ] Footer CTA is pillar-aware: `Sign up free to start your <Pillar> practice` (Pillar uses the focusPillar label)
+- [ ] `Retake (clears your result)` link clears localStorage and lands on `/assessment`
+- [ ] **Logged out at `/results` with no localStorage**: redirected to `/assessment`
+- [ ] **Logged out with localStorage `takenAt` > 30 days**: amber "Your result is N days old" banner visible above focus pillar card
+- [ ] **After signup via email**: localStorage hydrated to DynamoDB (`ASSESS#` row), lands on `/results` with working `Start this practice` CTAs
+- [ ] **After signup via Google OAuth**: same outcome — verifies localStorage survived the OAuth redirect (highest-risk unknown per the plan)
+- [ ] **Existing user login with localStorage on the browser**: localStorage silently dropped, server data preserved, lands per `decideRoute` (`/today` if they had a prior assessment)
 
 ---
 
@@ -196,6 +215,25 @@ Last revised: 2026-05-16 (added SES email delivery + password policy checks).
 - [ ] /practices renders 35 cards smoothly (no jank when scrolling)
 - [ ] No visible layout shift (CLS) after initial load
 - [ ] Radar chart renders without flicker
+
+---
+
+## 13. Anonymous funnel + analytics end-to-end (new, 2026-05-21)
+
+Full happy path on the deployed staging URL, then again on prod after deploy.
+
+- [ ] Open incognito → `/` → "Free · no account needed to start" micro-copy visible under primary CTA; "8 minutes" pill visible on mobile too
+- [ ] Click `Start free assessment` → lands on `/assessment` with intro screen (no auth wall)
+- [ ] Answer all 35 questions → click Submit → lands on `/results`
+- [ ] `/results` shows: focus pillar, radar, per-pillar bars, 3 suggested practices with full content, pillar-aware "Sign up free" CTA
+- [ ] Click the per-practice `Sign up to start` → lands on `/auth`
+- [ ] Sign up with a fresh email → confirm code → redirected → eventually lands back on `/results` with working `Start this practice` CTAs
+- [ ] DynamoDB now has the user with a populated `ASSESS#` row matching what was just submitted (manual spot check in console)
+- [ ] Repeat the entire path via **Google OAuth signup** instead of email — same outcome
+- [ ] **Cookie banner**: on first incognito visit, banner appears at bottom; DevTools Network filtered for `google` shows zero requests until `Accept` clicked
+- [ ] After `Accept`: GA4 Realtime (analytics.google.com → Realtime) shows the current visit within ~30s; `assessment_started`, `assessment_submitted`, `results_viewed`, `signup_clicked`, `signup_completed`, `hydration_success` events appear in order
+- [ ] After `Decline`: no further GA requests, no flicker, banner stays dismissed
+- [ ] CloudWatch Logs Insights query for `funnel_event` returns all expected server-side events for the test run
 
 ---
 

--- a/_docs/plans/anonymous-assessment-funnel.md
+++ b/_docs/plans/anonymous-assessment-funnel.md
@@ -1,0 +1,659 @@
+# Anonymous Assessment Funnel — Implementation Plan
+
+**Status:** Drafted, awaiting implementation.
+**Drafted:** 2026-05-20
+**Owner:** @qianhaopower
+**Target:** ship to `staging` first, then `main` before LinkedIn launch.
+
+---
+
+## Why this PR exists
+
+### The data
+- Shared `friendsintelligence.net` to ~50-person social group on 2026-05-19.
+- Amplify metrics: ~3,900 requests in the share window (≈50–130 visits at typical Next.js request fan-out).
+- DynamoDB: 30 users before share → 30 users after. **Zero new signups.**
+- Cognito User Pool: zero `UNCONFIRMED` accounts → no one attempted email signup.
+- `/api/assessment` server log hits: 2 in 24h (the user themselves testing).
+- SES out of sandbox, custom domain, DKIM healthy — email delivery is not the bug.
+
+### The diagnosis
+- The middleware-enforced auth gate on `/assessment` ([`middleware.ts:5-15`](../../middleware.ts)) means *"Start free assessment"* on the landing page is a misleading CTA. Clicking it 302-redirects an unauthenticated visitor to `/auth` before any assessment question renders.
+- The friends' funnel: **Land → click "Start free assessment" → see signup wall → bounce.** Their Cognito doesn't record an attempt because they never submitted the form.
+- The product itself works — 4 friends (within the existing 30) signed up earlier and completed assessments successfully. The bug is in *how the front door opens*, not in what's behind it.
+
+### Industry comparison
+Researched 13 commercial assessment/quiz/wellbeing apps. Every conversion-optimized product (16Personalities, Truity, Open Psychometrics, Noom, BetterHelp, BuzzFeed) lets the quiz run **without an account first**. The only products that gate behind signup are non-commercial academic (VIA, Penn Authentic Happiness). The current FIApp flow matches the academic pattern, not the commercial one.
+
+---
+
+## Goals
+- Let a first-time visitor complete the 35-question assessment and see their full results (focus pillar + per-pillar scores + 3 suggested practices with descriptions and rationale) without signing up.
+- Move the signup ask to immediately *after* results — gated by the "save your results / start a daily practice" payoff.
+- After signup, restore the user's anonymous answers as their canonical `ASSESS#` record in DynamoDB, no retake.
+- Instrument the new funnel so the LinkedIn launch produces real attribution + drop-off data.
+- Update the canonical specs in the same PR so doctrine doesn't drift.
+
+## Non-goals
+- Changing the Plus-plan checkout flow (still routes through `/auth`).
+- Improving landing-page copy/social proof/screenshots beyond two trivial fixes (no-account microcopy + mobile 8-min badge visibility).
+- Server-side anonymous claim model (cookie UUID + `ANON#` rows). Deferred as a v2 enhancement.
+- Adding share/viral mechanics ("share your focus pillar"). Deferred.
+- Email-capture for "not now" visitors. Deferred.
+- Fixing the Google OAuth `email_verified=NO` Cognito quirk. Out of scope; tracked separately.
+
+---
+
+## Design decisions (locked)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | What does an anonymous user see on `/results`? | **Full disclosure** — pillar scores, focus pillar, AND the 3 suggested practices with titles, descriptions, rationale. Only the action CTA differs (`Sign up to start` instead of `Start this practice`). |
+| 2 | Where does the user land after signup hydration? | **Back to `/results` with unlocked CTAs.** Same page they were just on, now with working `Start this practice` buttons. |
+| 3 | Stale localStorage result on return visit | **Keep forever**, show "Your result is N days old — retake?" banner if `takenAt` > 30 days. User decides. |
+| 4 | Existing authed user logs in with new localStorage from an anonymous take | **Ignore the localStorage**, preserve their server-side assessment. Drop localStorage silently. |
+| 5 | Signup CTA personalization | **Pillar-aware** — "Sign up to start your Sleep practice" using `focusPillar` label. |
+| 6 | Launch telemetry | **Both** — server-side structured `console.log` events at funnel boundaries AND GA4 with a cookie consent banner. |
+| 7 | Cross-browser scenario (take on phone, sign up on laptop) | **Accept v1 loss.** localStorage is per-browser. Document as known limitation. |
+| 8 | Anonymous user clicks a specific practice's "Sign up to start" | **Nothing carried.** After signup → `/results` unlocked → user clicks the same card again. Simpler state. |
+| 9 | Cookie consent banner | **Minimal banner in this PR** before GA4 fires. Required by GDPR/UK PECR strict reading; we have a global LinkedIn audience. |
+| 10 | Landing page micro-copy tweaks | **Bundle in.** Two one-line edits in the same PR. |
+| 11 | localStorage invariant in canon | **Update canon** to allow transient pre-account state. |
+| 12 | GA4 vs strict privacy doctrine | **Loosen doctrine** with strict scope: anonymized IPs, no PII custom params, no user-ID merging, behavioral funnel only. Update privacy doc. |
+
+---
+
+## Current flow vs. target flow
+
+### Current
+
+```
+[/] -- click "Start free assessment" -->
+[middleware.ts: /assessment in PROTECTED_PREFIXES, no Cognito tokens]
+[302] --> [/auth] -- sign up + email confirm --> [/decideRoute]
+[DecideRouteClient] reads /api/me, no latestAssessmentId --> [/onboarding]
+[/onboarding] --> [/assessment]
+[/assessment] -- answer 35 Qs, click Submit --> [POST /api/assessment (authed)]
+[withAuth wraps everything] --> DynamoDB writes (ASSESS#, ANS#, PROFILE update)
+[router.replace('/results')]
+[/results] reads /api/assessment/latest + suggestions + active --> renders insights + practice cards
+```
+
+### Target
+
+```
+[/] -- click "Start free assessment" --> [/assessment]   ← PUBLIC
+  - On mount: rehydrate from localStorage.assessment.draft if present
+  - On answer change: persist assessment.draft
+  - On submit: POST /api/assessment (no auth header) --> server computes scores
+
+[POST /api/assessment, refactored to withOptionalAuth]
+  - If session present: existing path — write ASSESS#, ANS#, update PROFILE, return assessmentId + scores
+  - If no session: compute scores + focus pillar + suggested practice IDs, return result, NO DynamoDB writes
+
+[client receives response]
+  - persist localStorage.assessment.result = { answers, scoresByPillar, focusPillar, lowestPillarId, suggestedPracticeIds, takenAt, version: 1 }
+  - clear localStorage.assessment.draft
+  - router.replace('/results')
+
+[/results]   ← PUBLIC, dual-mode
+  - If authenticated: existing fetch path (assessment/latest, suggestions, active)
+  - If anonymous: read localStorage.assessment.result; redirect to /assessment if absent
+    - Render same UI; replace per-practice "Start this practice" CTAs with "Sign up to start"
+    - Replace bottom CTAs with pillar-aware "Sign up to start your <Pillar> practice"
+    - Show 30-day age banner if takenAt > 30 days ago
+
+[anonymous user clicks Sign up CTA]
+  → /auth (no query params; nothing carried)
+  → sign up + email confirm
+  → /decideRoute
+
+[DecideRouteClient]   ← new hydration step
+  - If localStorage.assessment.result is present:
+      - If profile.latestAssessmentId already exists: clear localStorage, run decideRoute(profile) as today
+      - Else: POST /api/assessment authed with { answers }; on 200, clear localStorage, refetch profile
+              then one-shot router.replace('/results') (overrides decideRoute's default)
+  - If localStorage.assessment.result is absent: existing decideRoute logic
+```
+
+`decideRoute` (the pure function in [`lib/decideRoute.ts`](../../lib/decideRoute.ts)) is **not modified**. The one-shot `/results` redirect is logic inside `DecideRouteClient` only, triggered by the presence of a localStorage entry.
+
+---
+
+## Architecture decisions (recap with rationale)
+
+### A. Anonymous result computation lives on the server
+- `lib/assessment/scoring.ts` (pure: `computeScores`, `pickFocusPillar`) and `getSuggestedPractices` stay server-side.
+- Reasons: single source of truth for scores; algorithm not in client bundle; cheap (35 booleans → small math); one byte-identical compute path for authed and anonymous.
+
+### B. Anonymous hydration via localStorage replay
+- localStorage keys: `assessment.draft` (in-progress answers + index) and `assessment.result` (computed result).
+- Schema versioned (`version: 1`) so future migrations can no-op stale data.
+- On signup, `DecideRouteClient` replays `POST /api/assessment` with the stored answers; the authed branch writes ASSESS# / ANS# / PROFILE.
+- Per Decision 11, this localStorage usage is added to the canon as the *one* permitted pre-account exception.
+
+### C. localStorage lifecycle (full table)
+
+| Event | Action |
+|---|---|
+| Mount `/assessment` | Read `assessment.draft`. If present, restore `answers` + `index` state. |
+| Answer change | Persist updated `assessment.draft`. |
+| Submit success | Save `assessment.result`. Clear `assessment.draft`. |
+| Anonymous visit `/results` | Read `assessment.result`. If absent → `router.replace('/assessment')`. |
+| Anonymous click "Sign up" | Keep both keys (auth flow may need to re-render). |
+| Post-auth in `DecideRouteClient` | Hydrate via POST. On success clear `assessment.result`. |
+| Existing user post-auth with `assessment.result` present | Clear silently, preserve server data (Decision 4). |
+| User clicks "Retake" (anonymous) | Clear both keys, `router.replace('/assessment')`. |
+| `takenAt` > 30 days when reading | Show banner, do not auto-clear. |
+
+### D. Schema and contract changes
+
+**`POST /api/assessment` becomes dual-mode.**
+
+Anonymous response shape:
+```json
+{
+  "scoresByPillar": { "<pillarId>": number },
+  "focusPillar": "<pillarId>",
+  "lowestPillarId": "<pillarId>",
+  "suggestedPracticeIds": ["...", "...", "..."]
+}
+```
+
+Authed response shape (unchanged from today):
+```json
+{
+  "assessmentId": "...",
+  "scoresByPillar": { "<pillarId>": number },
+  "focusPillar": "<pillarId>",
+  "lowestPillarId": "<pillarId>",
+  "suggestedPracticeIds": ["...", "...", "..."]
+}
+```
+
+The only delta: anonymous lacks `assessmentId`. Clients must tolerate both shapes.
+
+### E. Routing change minimal-surface
+
+`middleware.ts` removes `/assessment` and `/results` from `PROTECTED_PREFIXES`. All other protected routes (`/today`, `/practices`, `/onboarding`, `/progress`, `/account`, `/admin`, `/decideRoute`) keep their guards exactly as today.
+
+---
+
+## File-by-file changes
+
+### 1. [`middleware.ts`](../../middleware.ts)
+
+Remove `'/assessment'` and `'/results'` from `PROTECTED_PREFIXES` (lines 5–15). No other logic changes. The `hasCognitoSessionCookie` safety net and the redirect-loop protection (per `project_auth_hang_identity_pool` memory) remain intact.
+
+### 2. [`utils/authServer.ts`](../../utils/authServer.ts)
+
+Add a sibling helper `withOptionalAuth(req, handler)`:
+- Attempts to resolve the Cognito session the same way `withAuth` does.
+- Calls `handler({ user })` where `user` is the user object if authed, or `null` if not.
+- Never returns 401 for missing session; only for *malformed/expired* tokens.
+
+Keep `withAuth` unchanged. New helper is additive — same file, same module export.
+
+### 3. [`app/api/assessment/route.ts`](../../app/api/assessment/route.ts)
+
+Convert `POST` from `withAuth` to `withOptionalAuth`. Sketch:
+
+```ts
+export async function POST(req: Request) {
+  return withOptionalAuth(req, async ({ user }) => {
+    const body = (await req.json()) as { answers?: Record<string, boolean> };
+
+    // existing answer validation (unchanged)
+
+    const { scoresByPillar, totalScore } = computeScores(body.answers);
+    const focusPillar = pickFocusPillar(scoresByPillar);
+    const lowestPillarId = focusPillar;
+    const suggestedPracticeIds = getSuggestedPractices(body.answers, lowestPillarId).map(p => p.id);
+
+    // Server-side log line for funnel
+    console.log(JSON.stringify({
+      funnel_event: user ? 'assessment_submitted_authed' : 'assessment_submitted_anonymous',
+      ts: new Date().toISOString(),
+      focusPillar,
+    }));
+
+    if (!user) {
+      // anonymous: compute-only, no DynamoDB writes
+      return NextResponse.json(
+        { focusPillar, lowestPillarId, scoresByPillar, suggestedPracticeIds },
+        { status: 200 }
+      );
+    }
+
+    // authed: existing persistence path
+    const assessmentId = crypto.randomUUID();
+    // ... existing putItem(ASSESS#), per-question putItem(ANS#), PROFILE updateItem
+    trackEvent('totalAssessments', 'assessments');
+    trackPillarFocus(focusPillar);
+
+    return NextResponse.json(
+      { assessmentId, focusPillar, lowestPillarId, scoresByPillar, suggestedPracticeIds },
+      { status: 200 }
+    );
+  });
+}
+```
+
+Anonymous submissions also increment a new `totalAnonymousAssessments` counter (Decision 12; see canon update in §Canon updates).
+
+### 4. [`app/assessment/page.tsx`](../../app/assessment/page.tsx)
+
+Changes:
+- New `useEffect` on mount: read `localStorage.getItem('assessment.draft')`. If present and version matches, restore `answers` + `index` from it.
+- Wrap `setAnswers`/`setIndex` updates with a helper that also persists to `localStorage` as `assessment.draft`.
+- In `handleSubmit` (around lines 80–105):
+  - POST as today. The browser will not send Cognito tokens if logged out — server's `withOptionalAuth` handles both cases.
+  - On success: parse `{ scoresByPillar, focusPillar, lowestPillarId, suggestedPracticeIds }`.
+  - Write `localStorage.assessment.result = { answers, ...computedFields, takenAt: new Date().toISOString(), version: 1 }`.
+  - Clear `assessment.draft`.
+  - Fire GA4 event `assessment_submitted` with `{ is_anonymous: !authStatus === 'authenticated' }`.
+  - `router.replace('/results')`.
+- **Remove** the 401/403 → `/auth` redirect on submit (lines 90–93). The API no longer 401s anonymous callers.
+
+### 5. [`app/results/page.tsx`](../../app/results/page.tsx)
+
+Introduce a mode discriminator at the top of `ResultsPage`:
+```ts
+const { authStatus } = useAuthenticator(c => [c.authStatus]);
+const isAnonymous = authStatus !== 'authenticated';
+```
+
+Split the existing `load()` into two paths:
+- **Authed path**: unchanged. Fetch `/api/assessment/latest`, `/api/practices/suggestions`, `/api/practices/active`.
+- **Anonymous path**: read `localStorage.assessment.result` via the new helper module. If absent → `router.replace('/assessment')` and exit. If present, hydrate `assessment` and `suggestions` state directly from localStorage (the full practice objects can be looked up from `lib/practices/library.ts` using the stored `suggestedPracticeIds`). Skip the `/api/practices/active` fetch entirely.
+
+Render adjustments for anonymous mode:
+- Focus Pillar card: **unchanged.**
+- Radar chart: **unchanged.**
+- Per-pillar breakdown: **unchanged.**
+- Suggested Practices section: full titles, descriptions, rationale (Decision 1). The per-practice CTA changes from `Start this practice` / `Resume` / `View on Today` to **`Sign up to start →`** (single state, since no UPRACTICE exists for anonymous users). Clicking → `router.push('/auth')`.
+- Footer area: replace the existing `Go to Today` + `Retake assessment` buttons with a single pillar-aware primary CTA — `Sign up free to start your <PillarLabel> practice` — and a small `Retake (clears your result)` link that calls the localResult clear helper and navigates to `/assessment`.
+- If `takenAt > 30 days ago`: render a soft banner above the focus pillar card — *"Your result is N days old — things may have changed. Retake?"* with a retake link.
+
+GA4 event `results_viewed` fires on mount with `{ is_anonymous, focus_pillar }`.
+
+### 6. [`components/DecideRouteClient.tsx`](../../components/DecideRouteClient.tsx)
+
+Add a hydration step that runs after auth + profile resolve and before the existing `decideRoute(profile)` call. Sketch:
+
+```ts
+useEffect(() => {
+  if (authStatus === "unauthenticated") {
+    router.replace("/auth");
+    return;
+  }
+  if (error?.status === 401 || error?.status === 403) {
+    router.replace("/auth");
+    return;
+  }
+  if (loading || !profile) return;
+  if (error) return;
+
+  let cancelled = false;
+
+  async function go() {
+    const stored = readLocalResult();
+
+    // Existing authed user with new localStorage → silently drop, preserve server data (Decision 4).
+    if (stored && profile.latestAssessmentId) {
+      clearLocalResult();
+      const next = decideRoute(profile as ProfileForRouting);
+      if (!cancelled) router.replace(next);
+      return;
+    }
+
+    // Anonymous-result post-signup hydration
+    if (stored && !profile.latestAssessmentId) {
+      try {
+        const res = await fetch('/api/assessment', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ answers: stored.answers }),
+        });
+        if (res.ok) {
+          clearLocalResult();
+          await refetch();
+          console.log(JSON.stringify({ funnel_event: 'hydration_success', ts: new Date().toISOString() }));
+          if (!cancelled) router.replace('/results');   // one-shot override (Decision 2)
+          return;
+        }
+        // hydration failure — leave localStorage intact so user can retry
+        console.log(JSON.stringify({ funnel_event: 'hydration_failure', ts: new Date().toISOString(), status: res.status }));
+      } catch (e) {
+        console.log(JSON.stringify({ funnel_event: 'hydration_error', ts: new Date().toISOString() }));
+      }
+      // fall through to default routing on failure
+    }
+
+    const next = decideRoute(profile as ProfileForRouting);
+    if (!cancelled) router.replace(next);
+  }
+
+  go();
+  return () => { cancelled = true; };
+}, [authStatus, loading, profile, error, router, refetch]);
+```
+
+### 7. [`app/page.tsx`](../../app/page.tsx)
+
+Two one-line edits:
+- Below the primary `Start free assessment` button (around lines 206–211), add a small muted line: `Free · no account needed to start`.
+- The `35-question · 7 pillars · about 8 minutes` pill (line 193) currently has `hidden sm:inline-flex` — replace with a layout that shows it on all breakpoints. On mobile, render it above the headline as a small chip.
+
+### 8. New file: `lib/assessment/localResult.ts`
+
+Typed helpers for localStorage access, single source of truth for the schema and version. Sketch:
+
+```ts
+import type { Pillar } from '@/lib/assessment/pillars';
+
+const RESULT_KEY = 'assessment.result';
+const DRAFT_KEY = 'assessment.draft';
+const CURRENT_VERSION = 1;
+
+export type LocalAssessmentResult = {
+  version: 1;
+  answers: Record<string, boolean>;
+  scoresByPillar: Record<Pillar, number>;
+  focusPillar: Pillar;
+  lowestPillarId: Pillar;
+  suggestedPracticeIds: string[];
+  takenAt: string;  // ISO
+};
+
+export type LocalAssessmentDraft = {
+  version: 1;
+  answers: Record<string, boolean>;
+  index: number;
+  startedAt: string;
+};
+
+export function readLocalResult(): LocalAssessmentResult | null { /* JSON.parse, version check */ }
+export function writeLocalResult(r: LocalAssessmentResult): void { /* serialize */ }
+export function clearLocalResult(): void { /* removeItem */ }
+
+export function readLocalDraft(): LocalAssessmentDraft | null { /* ... */ }
+export function writeLocalDraft(d: LocalAssessmentDraft): void { /* ... */ }
+export function clearLocalDraft(): void { /* ... */ }
+
+export function ageInDays(takenAt: string): number { /* (Date.now() - parsed) / 86400000 */ }
+```
+
+All callers (`app/assessment/page.tsx`, `app/results/page.tsx`, `components/DecideRouteClient.tsx`) go through this module — no direct `localStorage.getItem('assessment.…')` anywhere else.
+
+### 9. New file: `components/CookieBanner.tsx`
+
+Minimal client component with three states: not-decided (banner shown), accepted (GA4 fires), declined (GA4 does not fire). State stored in `localStorage` under `cookie_consent: 'accepted' | 'declined'`.
+
+```ts
+"use client";
+import { useEffect, useState } from "react";
+
+const KEY = 'cookie_consent';
+
+export function useCookieConsent(): 'accepted' | 'declined' | null {
+  const [state, setState] = useState<'accepted' | 'declined' | null>(null);
+  useEffect(() => {
+    const v = localStorage.getItem(KEY);
+    if (v === 'accepted' || v === 'declined') setState(v);
+  }, []);
+  return state;
+}
+
+export default function CookieBanner() {
+  const consent = useCookieConsent();
+  if (consent !== null) return null;
+  return (
+    /* fixed-bottom banner with Accept / Decline buttons that write to localStorage */
+  );
+}
+```
+
+Copy is short and honest — no dark patterns; both buttons equally prominent.
+
+### 10. [`app/layout.tsx`](../../app/layout.tsx)
+
+- Mount `<CookieBanner />` once.
+- Conditionally include `<GoogleAnalytics gaId={GA_ID} />` from `@next/third-parties/google` when `cookie_consent === 'accepted'` (uses a thin client wrapper to read the consent state).
+- `GA_ID` is read from `process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID`. Empty/missing = GA4 silently off.
+
+### 11. GA4 event taxonomy
+
+Custom events fired client-side (after consent):
+
+| Event | Trigger | Custom params |
+|---|---|---|
+| `landing_viewed` | `/` mount | `utm_source`, `utm_medium`, `utm_campaign` (auto from URL) |
+| `assessment_started` | `/assessment` mount | `is_anonymous: true|false` |
+| `assessment_submitted` | submit success | `is_anonymous`, `focus_pillar` |
+| `results_viewed` | `/results` mount | `is_anonymous`, `focus_pillar` |
+| `signup_clicked` | click any "Sign up to start" CTA on /results | `focus_pillar` |
+| `signup_completed` | first `/decideRoute` mount with a Cognito session that wasn't there before | (none) |
+| `hydration_success` | DecideRouteClient successfully persists localStorage | `focus_pillar` |
+| `hydration_failure` | DecideRouteClient fails to persist | `error_status` |
+
+**Strict rules** (per the updated privacy doc, see Canon updates):
+- No `user_id`, `email`, or any field that could identify a user.
+- No raw assessment answers as custom params.
+- No specific `practice_id` as custom params (Decision 8 means we don't even need to).
+- Anonymized IPs (default in GA4).
+- No user-ID merging across sessions.
+
+### 12. Server-side structured log events
+
+`console.log(JSON.stringify({ funnel_event: '...', ts: '...', ...fields }))` lines at:
+- `assessment_submitted_anonymous` and `assessment_submitted_authed` (in `app/api/assessment/route.ts`)
+- `hydration_success`, `hydration_failure`, `hydration_error` (in `components/DecideRouteClient.tsx`)
+
+CloudWatch Logs Insights query (canned, for the launch retro):
+```
+fields @timestamp, funnel_event, focusPillar
+| filter ispresent(funnel_event)
+| stats count(*) as n by funnel_event
+| sort n desc
+```
+
+### 13. Test plan
+
+#### Layer 1 (unit, vitest)
+- `withOptionalAuth` returns `{ user: null }` for an unauth request, `{ user: {...} }` for authed.
+- `localResult` round-trip (write → read → clear).
+- `localResult.readLocalResult()` returns `null` for a stale `version` field.
+- `ageInDays` boundary: 29.9 days, 30.1 days.
+
+#### Layer 2 (integration, dynalite)
+- `POST /api/assessment` anonymous: 200 with `{ scoresByPillar, focusPillar, lowestPillarId, suggestedPracticeIds }`. **No** items written to FIAPP_MAIN.
+- `POST /api/assessment` anonymous: increments `METRICS#TOTALS.totalAnonymousAssessments`.
+- `POST /api/assessment` authed: writes ASSESS#, ANS# (×35), PROFILE update. Existing test must still pass.
+- `POST /api/assessment` authed via hydration replay (called from DecideRouteClient simulation): identical outcome to direct authed call.
+
+#### Layer 3 (E2E, Playwright, against staging before merge to main)
+- Anonymous happy path: open `/`, click `Start free assessment`, answer 35 questions, see `/results` with focus pillar + 3 practice cards each showing `Sign up to start`. Click signup CTA → `/auth`, sign up + confirm, land on `/results` with `Start this practice` CTAs.
+- Anonymous Google OAuth happy path: same as above but signup via Google. **Critical** — verifies localStorage survives the OAuth redirect.
+- Draft survival: refresh mid-quiz → answers + position restored.
+- Anonymous → existing-account-login: localStorage cleared, existing assessment served, lands on `/today`.
+- Anonymous result + clear localStorage manually → `/results` redirects to `/assessment`.
+- Existing authed user retake (regression): unchanged from today.
+
+---
+
+## Canon updates (in the same PR)
+
+### [`_docs/canon/business-logic-v2.md`](../canon/business-logic-v2.md)
+
+**§Routing rules — Per-route guards table:** update two rows.
+
+Before:
+```
+| /assessment | authed | N/A. Always accessible (user can retake anytime). |
+| /results    | authed + assessment | Always accessible. Shows latest assessment summary + suggested practices. |
+```
+
+After:
+```
+| /assessment | public | Public. Authed users see the same questions; submission persists for authed, returns compute-only for anonymous. |
+| /results    | public | Public. Authed users load from server; anonymous users load from localStorage (set by /assessment). |
+```
+
+**§API contract — Conventions:** add an exception clause.
+
+Before:
+> All endpoints require an authenticated user; `userId` is resolved server-side from the session.
+
+After:
+> All endpoints require an authenticated user; `userId` is resolved server-side from the session. **Exception:** `POST /api/assessment` accepts anonymous submissions and returns compute-only results (no DynamoDB writes). Persistence still requires auth.
+
+**§API contract — `POST /api/assessment`:** document the dual response.
+
+Add a "Response (anonymous)" subsection:
+```json
+{
+  "scoresByPillar": { "<pillarId>": number },
+  "focusPillar": "<pillarId>",
+  "lowestPillarId": "<pillarId>",
+  "suggestedPracticeIds": ["...", "...", "..."]
+}
+```
+And note that the authed response is the existing shape plus `assessmentId`.
+
+**§decideRoute:** add a clarifying note.
+
+> `decideRoute` (the pure function) is unchanged. `DecideRouteClient` may one-shot override the destination to `/results` immediately after successful anonymous-result hydration (see *Anonymous Assessment Funnel* plan). This override does not modify the pure function and only fires once per signup event.
+
+### [`_docs/canon/db-schema.md`](../canon/db-schema.md)
+
+**§Status / Rule:** reword the invariant.
+
+Before:
+> **Rule:** DynamoDB is the source of truth (no local-storage persistence logic).
+
+After:
+> **Rule:** DynamoDB is the source of truth for all authenticated state. `localStorage` may hold transient pre-account state — specifically `assessment.draft` (in-progress quiz answers) and `assessment.result` (anonymous-computed result). Both are cleared on signup. No other client-side persistence is allowed.
+
+### [`docs/operations/analytics-privacy-boundaries.md`](../../docs/operations/analytics-privacy-boundaries.md)
+
+Add a new section after §Forbidden:
+
+**§Third-party analytics (GA4)**
+
+> FIApp uses Google Analytics 4 for behavioral funnel analysis. GA4 sets first-party cookies and records session IDs and (anonymized) IP addresses. It is **only loaded after explicit cookie consent**.
+>
+> Strict scope:
+> - Anonymized IPs enabled (GA4 default).
+> - No PII in custom dimensions or event parameters — no email, no Cognito userId, no assessment answers, no specific practice IDs.
+> - No User-ID merging across sessions.
+> - Standard 14-month event data retention.
+> - Cookie consent is required and gated by [`components/CookieBanner.tsx`](../../components/CookieBanner.tsx); declining keeps GA4 off entirely.
+>
+> Events tracked (see [`_docs/plans/anonymous-assessment-funnel.md`](../../_docs/plans/anonymous-assessment-funnel.md) §GA4 event taxonomy for the canonical list).
+
+**§Event model — update `assessment_completed` row:**
+
+> | `assessment_completed` | `POST /api/assessment` success (authed OR anonymous) | `totalAssessments`, daily `assessments`, `pillarFocus_<pillar>`. **Authed only** also: `pillarFocus_<pillar>`. Anonymous additionally increments `totalAnonymousAssessments`. |
+
+Add `totalAnonymousAssessments` row to §Allowed:
+> | `totalAnonymousAssessments` | Total anonymous assessment submissions (pre-signup) | `METRICS#TOTALS` |
+
+### [`_docs/canon/launch-checklist.md`](../canon/launch-checklist.md)
+
+**§2. Assessment** — add bullets:
+- [ ] Logged-out: visit `/assessment` directly, all 35 questions load, no auth redirect
+- [ ] Logged-out: refresh mid-quiz — previous answers and position restored from localStorage
+- [ ] Logged-out: submit on last question → spinner visible, then redirected to `/results`
+
+**§3. Results / Insights** — add bullets:
+- [ ] Logged-out at `/results` with localStorage result: full pillar scores, focus pillar, radar chart, **3 suggested practices with full titles + descriptions + rationale**
+- [ ] Logged-out per-practice CTA reads `Sign up to start →` (not `Start this practice`)
+- [ ] Logged-out footer CTA is pillar-aware: `Sign up free to start your <Pillar> practice`
+- [ ] Logged-out `Retake (clears your result)` link clears localStorage and lands on `/assessment`
+- [ ] Logged-out at `/results` with no localStorage: redirected to `/assessment`
+- [ ] Logged-out with localStorage `takenAt` > 30 days: age banner visible above focus pillar card
+- [ ] After signup via email: localStorage hydrated to DynamoDB, lands on `/results` with working `Start this practice` CTAs
+- [ ] After signup via Google OAuth: same — verify localStorage survived the OAuth redirect
+
+**Add a new §13. Anonymous funnel happy path:**
+- [ ] End-to-end: open incognito → `/` → click `Start free assessment` → answer all 35 Qs → see `/results` → click `Sign up to start your <Pillar> practice` → sign up → confirm email → lands back at `/results` with unlocked CTAs → click `Start this practice` → lands on `/today` with that practice active
+- [ ] Same path but via Google OAuth signup — works identically
+- [ ] Cookie banner appears on first visit; Accept loads GA4 (verify via GA4 Realtime); Decline keeps GA4 off
+
+---
+
+## Rollout
+
+1. **Local Layer 1 + Layer 2** (`npm run test:all`) — must be green. Add the new tests in §Test plan.
+2. **Update `NEXT_PUBLIC_GA4_MEASUREMENT_ID`** in Amplify env vars (staging and production properties separate).
+3. **Open PR to `staging`** with the full file list + canon updates. Self-review.
+4. **Manual smoke on staging** per the new launch-checklist items above. Critical: verify Google OAuth + localStorage survival.
+5. **Layer 3 E2E against staging** (`BASE_URL=https://staging.d3nyg9qvz1tj5n.amplifyapp.com npm run test:e2e`).
+6. **Open PR `staging` → `main`** after staging soak (≥2 hours of passive monitoring).
+7. **Post-merge:** verify CloudWatch funnel events firing, GA4 Realtime showing landing/assessment events, no spike in error rate. Tag a release.
+8. **LinkedIn launch** with UTM-tagged URL: `https://friendsintelligence.net/?utm_source=linkedin&utm_medium=social&utm_campaign=launch_2026_05`.
+
+---
+
+## Risks & open watches
+
+1. **Google OAuth localStorage survival** (highest-risk unknown). The Cognito hosted UI redirects through `auth.<region>.amazoncognito.com` and back to the same origin. localStorage *should* survive because it's scoped to origin and the round-trip ends on the same origin. **Verify on staging before merging to main.** If broken, fall back to URL-encoded payload in the OAuth state parameter (rejected as gross in v1, but real if needed).
+2. **Public POST endpoint surface area.** `/api/assessment` becomes the first unauthenticated POST. No rate limit. Burn rate at 1000 RPS ≈ a few cents/hour in Lambda. Acceptable for launch; add IP-based limit if abuse appears.
+3. **Hydration retry idempotency.** If hydration partially fails (writes ASSESS# but not PROFILE update), a refresh + retry produces a *new* `assessmentId` for the same answers — second row is harmless because PROFILE.latestAssessmentId always wins, but it's a phantom. Log it; review in launch retro.
+4. **Shared computer privacy.** Anonymous results in localStorage on a shared browser = next person sees the previous person's pillar scores if they hit `/results` directly. Acceptable for v1 — wellbeing scores are not high-sensitivity. Could move to `sessionStorage` later if anyone complains.
+5. **Safari ITP / private browsing** caps localStorage at ~7 days or makes it ephemeral. Hydration falls through gracefully (no localStorage → no hydration → user re-takes after signup). Document in FAQ.
+6. **GDPR / UK PECR exposure.** With GA4 enabled, the cookie banner is now load-bearing. If we ever ship anything that fires before consent (current plan does not), we're exposed. Manual smoke must confirm GA4 is silent on first visit until Accept is clicked.
+7. **Bundle size.** `lib/practices/library.ts` is already a shared module; rendering practice cards anonymously doesn't add anything new to the client bundle. Confirm with `next build` output before/after.
+8. **Cross-browser story** (Decision 7). Documented as a v1 accepted limitation. Anyone who takes the quiz on phone and signs up on laptop will retake on laptop.
+
+---
+
+## Effort estimate
+
+| Item | Hours |
+|---|---|
+| Middleware change | 0.1 |
+| `withOptionalAuth` helper + tests | 0.5 |
+| `app/api/assessment/route.ts` refactor + tests | 1.0 |
+| `app/assessment/page.tsx` (draft + submit) | 1.0 |
+| `lib/assessment/localResult.ts` + tests | 0.5 |
+| `app/results/page.tsx` anonymous mode | 2.0 |
+| `DecideRouteClient.tsx` hydration | 1.0 |
+| Landing tweaks (`app/page.tsx`) | 0.2 |
+| `CookieBanner.tsx` + consent integration | 1.0 |
+| GA4 setup (`@next/third-parties/google`, layout wiring, event hooks) | 2.0 |
+| Server-side `console.log` funnel events | 0.3 |
+| Canon doc updates (4 files) | 1.0 |
+| Layer 3 E2E for anonymous flow | 1.5 |
+| Manual smoke + bug-fix buffer | 2.0 |
+| **Total** | **~14 hours** |
+
+Realistic: two focused half-days. Aim — staging by end of day 1, main by end of day 2, LinkedIn launch day 3.
+
+---
+
+## Decision log
+
+For traceability when the PR is reviewed or this plan is revisited:
+
+- Decisions 1–10: locked during plan-shaping Q&A on 2026-05-20 (session with @qianhaopower).
+- Decisions 11–12: locked after cross-checking the plan against `business-logic-v2.md`, `db-schema.md`, and `analytics-privacy-boundaries.md` — both involved updating canon doctrine, both authorized explicitly.
+- Open architectural decisions A–E in §Architecture decisions: all defaulted to the "v1 simple" path; server-side anonymous claim (alternative B) explicitly deferred.
+
+---
+
+## Done = ?
+
+This PR is "done" when:
+
+1. All file changes in §File-by-file changes are merged to `staging`.
+2. All four canon docs are updated and reflect the new flow.
+3. Layer 1 + Layer 2 tests pass locally (`npm run test:all`).
+4. Layer 3 E2E passes against staging (`BASE_URL=https://staging.d3nyg9qvz1tj5n.amplifyapp.com npm run test:e2e`).
+5. Staging manual smoke confirms (i) anonymous → email signup → `/results` unlocked, (ii) anonymous → Google OAuth signup → `/results` unlocked, (iii) existing user login is unchanged, (iv) cookie banner gates GA4.
+6. Merged to `main` per the branching strategy (`staging → main` only).
+7. CloudWatch shows the funnel events firing on the first real visit.
+8. GA4 Realtime shows the funnel events firing on the first real visit.
+
+Then we're ready for LinkedIn.

--- a/app/api/assessment/route.ts
+++ b/app/api/assessment/route.ts
@@ -8,14 +8,14 @@ import {
 } from "@/lib/assessment/questions";
 import { computeScores, pickFocusPillar } from "../../../lib/assessment/scoring";
 import { getSuggestedPractices } from "@/lib/practices/suggestions";
-import { withAuth } from "@/utils/authServer";
+import { withOptionalAuth } from "@/utils/authServer";
 import { trackEvent, trackPillarFocus } from "@/utils/metricsClient";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
-  return withAuth(req, async (user) => {
+  return withOptionalAuth(req, async ({ user }) => {
     const body = (await req.json()) as {
       answers?: Record<string, boolean>;
     };
@@ -44,14 +44,37 @@ export async function POST(req: Request) {
       }
     }
 
-    const assessmentId = crypto.randomUUID();
-    const createdAt = new Date().toISOString();
     const { scoresByPillar, totalScore } = computeScores(body.answers);
     const focusPillar = pickFocusPillar(scoresByPillar);
     const lowestPillarId = focusPillar;
     const suggestedPracticeIds = getSuggestedPractices(body.answers, lowestPillarId).map(
       (p) => p.id,
     );
+
+    // Structured funnel log line. Authed and anonymous both fire; queryable in
+    // CloudWatch Logs Insights as `funnel_event in [...]`. Intentionally
+    // anonymous — no userId, no answers (see analytics-privacy-boundaries.md).
+    console.log(JSON.stringify({
+      funnel_event: user ? 'assessment_submitted_authed' : 'assessment_submitted_anonymous',
+      ts: new Date().toISOString(),
+      focusPillar,
+    }));
+
+    if (!user) {
+      // Anonymous: compute-only response. No DynamoDB writes against any USER#
+      // PK (no userId to key against). One aggregate counter is incremented so
+      // the launch dashboard can count anonymous starts. See plan
+      // _docs/plans/anonymous-assessment-funnel.md and the updated
+      // analytics-privacy-boundaries.md.
+      trackEvent('totalAnonymousAssessments', 'anonymousAssessments');
+      return NextResponse.json(
+        { focusPillar, lowestPillarId, scoresByPillar, suggestedPracticeIds },
+        { status: 200 }
+      );
+    }
+
+    const assessmentId = crypto.randomUUID();
+    const createdAt = new Date().toISOString();
 
     const client = createDynamoClient();
     const pk = `USER#${user.userId}`;

--- a/app/assessment/page.tsx
+++ b/app/assessment/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import { useAuthenticator } from "@aws-amplify/ui-react";
 import { assessmentQuestions } from "@/lib/assessment/questions";
 import { pillarColors } from "@/lib/design/pillarColors";
 import { NarrowFormPage } from "@/components/layout";
@@ -15,9 +16,19 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  readLocalDraft,
+  writeLocalDraft,
+  clearLocalDraft,
+  writeLocalResult,
+} from "@/lib/assessment/localResult";
+import type { Pillar } from "@/lib/assessment/pillars";
+import { trackEvent } from "@/lib/analytics";
 
 export default function AssessmentPage() {
   const router = useRouter();
+  const { authStatus } = useAuthenticator((c) => [c.authStatus]);
+  const isAnonymous = authStatus !== "authenticated";
   const total = assessmentQuestions.length;
   const [index, setIndex] = useState(0);
   const [answers, setAnswers] = useState<Record<string, boolean>>({});
@@ -25,6 +36,43 @@ export default function AssessmentPage() {
   const [error, setError] = useState<string | null>(null);
   const [introAccepted, setIntroAccepted] = useState(false);
   const [confirmRestart, setConfirmRestart] = useState(false);
+  const [hydratedFromDraft, setHydratedFromDraft] = useState(false);
+
+  // Fire once per page mount, after auth status has resolved (no point firing
+  // before we know if the user is anonymous).
+  useEffect(() => {
+    if (authStatus === "configuring") return;
+    trackEvent("assessment_started", { is_anonymous: isAnonymous });
+  }, [authStatus, isAnonymous]);
+
+  // On mount, restore in-progress answers from localStorage so a refresh or
+  // tab-close doesn't lose the user's work. Anonymous users especially — they
+  // have no server-side row to recover from. See plan §localStorage lifecycle.
+  useEffect(() => {
+    const draft = readLocalDraft();
+    if (draft && Object.keys(draft.answers).length > 0) {
+      setAnswers(draft.answers);
+      setIndex(Math.min(draft.index, total - 1));
+      setIntroAccepted(true);
+    }
+    setHydratedFromDraft(true);
+  }, [total]);
+
+  // Persist in-progress answers as they change. Skip until the hydration
+  // pass has finished — otherwise the initial mount writes an empty draft
+  // before we can read the existing one.
+  useEffect(() => {
+    if (!hydratedFromDraft) return;
+    if (!introAccepted) return;
+    if (Object.keys(answers).length === 0 && index === 0) return;
+    const existing = readLocalDraft();
+    writeLocalDraft({
+      version: 1,
+      answers,
+      index,
+      startedAt: existing?.startedAt ?? new Date().toISOString(),
+    });
+  }, [answers, index, introAccepted, hydratedFromDraft]);
 
   function getContrastingTextColor(hex: string) {
     const match = /^#?([0-9a-fA-F]{6})$/.exec(hex);
@@ -87,15 +135,41 @@ export default function AssessmentPage() {
         body: JSON.stringify({ answers }),
       });
 
-      if (res.status === 401 || res.status === 403) {
-        router.replace("/auth");
-        return;
-      }
-
       if (!res.ok) {
         setError("Something went wrong. Please try again.");
         return;
       }
+
+      const data = (await res.json()) as {
+        assessmentId?: string;
+        focusPillar: Pillar;
+        lowestPillarId: Pillar;
+        scoresByPillar: Record<Pillar, number>;
+        suggestedPracticeIds: string[];
+      };
+
+      // Persist for anonymous submissions only. Authed submissions already
+      // wrote ASSESS# server-side — /results in authed mode reads from the
+      // server, not localStorage. Writing here for authed users would just
+      // leave stale data behind after logout for the next visitor on this
+      // browser to stumble into.
+      if (!data.assessmentId) {
+        writeLocalResult({
+          version: 1,
+          answers,
+          scoresByPillar: data.scoresByPillar,
+          focusPillar: data.focusPillar,
+          lowestPillarId: data.lowestPillarId,
+          suggestedPracticeIds: data.suggestedPracticeIds,
+          takenAt: new Date().toISOString(),
+        });
+      }
+      clearLocalDraft();
+
+      trackEvent("assessment_submitted", {
+        is_anonymous: !data.assessmentId,
+        focus_pillar: data.focusPillar,
+      });
 
       router.replace("/results");
     } catch {
@@ -110,6 +184,7 @@ export default function AssessmentPage() {
     setIndex(0);
     setError(null);
     setSubmitting(false);
+    clearLocalDraft();
   }
 
   function confirmAndReset() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,8 @@ import "./globals.css";
 import { Toaster } from "@/components/ui";
 import AmplifyProvider from "@/components/AmplifyProvider";
 import AppChrome from "@/components/AppChrome";
+import CookieBanner from "@/components/CookieBanner";
+import GA4Loader from "@/components/GA4Loader";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
 
@@ -26,6 +28,8 @@ export default function RootLayout({
         <AmplifyProvider>
           <AppChrome>{children}</AppChrome>
         </AmplifyProvider>
+        <CookieBanner />
+        <GA4Loader />
         <Toaster />
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -190,7 +190,7 @@ export default function LandingPage() {
         {/* Hero */}
         <section className="px-6 pt-24 pb-28 text-center sm:pt-28 sm:pb-32">
           <div className="mx-auto max-w-[47.5rem]">
-            <div className="mb-7 hidden items-center gap-2 rounded-full border border-line-2 bg-white px-3 py-1.5 text-[0.78rem] text-ink-2 sm:inline-flex">
+            <div className="mb-7 inline-flex items-center gap-2 rounded-full border border-line-2 bg-white px-3 py-1.5 text-[0.78rem] text-ink-2">
               <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
               <span>35-question assessment · 7 pillars · about 8 minutes</span>
             </div>
@@ -202,19 +202,24 @@ export default function LandingPage() {
             <p className="mx-auto mb-9 max-w-[36rem] text-[clamp(1.05rem,1.4vw,1.2rem)] text-ink-2 text-pretty">
               Find your focus pillar, then build one small daily practice at a time.
             </p>
-            <div className="inline-flex flex-wrap items-center justify-center gap-3">
-              <Link
-                href="/assessment"
-                className="group inline-flex h-12 items-center gap-2 rounded-[0.5rem] bg-primary px-5 text-[0.95rem] font-medium text-white no-underline transition-colors hover:bg-[oklch(0.5_0.22_260)]"
-              >
-                Start free assessment <Arrow />
-              </Link>
-              <Link
-                href="/auth"
-                className="inline-flex h-12 items-center gap-2 rounded-[0.5rem] border border-line bg-transparent px-5 text-[0.95rem] font-medium text-ink no-underline transition-colors hover:border-[oklch(0.85_0.012_260)] hover:bg-bg-2"
-              >
-                Log in
-              </Link>
+            <div>
+              <div className="inline-flex flex-wrap items-center justify-center gap-3">
+                <Link
+                  href="/assessment"
+                  className="group inline-flex h-12 items-center gap-2 rounded-[0.5rem] bg-primary px-5 text-[0.95rem] font-medium text-white no-underline transition-colors hover:bg-[oklch(0.5_0.22_260)]"
+                >
+                  Start free assessment <Arrow />
+                </Link>
+                <Link
+                  href="/auth"
+                  className="inline-flex h-12 items-center gap-2 rounded-[0.5rem] border border-line bg-transparent px-5 text-[0.95rem] font-medium text-ink no-underline transition-colors hover:border-[oklch(0.85_0.012_260)] hover:bg-bg-2"
+                >
+                  Log in
+                </Link>
+              </div>
+              <p className="mt-3 text-[0.8rem] text-ink-3">
+                Free · no account needed to start
+              </p>
             </div>
           </div>
         </section>

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
+import { useAuthenticator } from '@aws-amplify/ui-react';
 import { HelpTooltip } from '@/components/HelpTooltip';
 import { StandardPage } from '@/components/layout';
 import { Card, Button, Loading, ErrorState, EmptyState } from '@/components/ui';
@@ -12,6 +13,14 @@ import { pillarColors } from '@/lib/design/pillarColors';
 import { pillarOrder, pillarLabels } from '@/lib/assessment/pillars';
 import type { Pillar } from '@/lib/assessment/pillars';
 import type { Practice } from '@/lib/practices/library';
+import { practicesById } from '@/lib/practices/library';
+import {
+  readLocalResult,
+  clearLocalResult,
+  ageInDays,
+  STALE_AGE_DAYS,
+} from '@/lib/assessment/localResult';
+import { trackEvent } from '@/lib/analytics';
 
 const MAX_SCORE = 5;
 
@@ -52,17 +61,21 @@ type SwitchState = {
 
 export default function ResultsPage() {
   const router = useRouter()
+  const { authStatus } = useAuthenticator((c) => [c.authStatus])
+  const isAnonymous = authStatus !== 'authenticated'
+
   const [assessment, setAssessment] = useState<AssessmentData | null>(null)
   const [suggestions, setSuggestions] = useState<Practice[] | null>(null)
   const [active, setActive] = useState<ActiveData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
+  const [staleDays, setStaleDays] = useState<number | null>(null)
   const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({})
   const [inlineError, setInlineError] = useState<Record<string, string>>({})
   const [capNotice, setCapNotice] = useState<Record<string, number>>({})
   const [switchState, setSwitchState] = useState<SwitchState>(null)
 
-  const load = useCallback(async () => {
+  const loadAuthed = useCallback(async () => {
     setLoading(true)
     setError(false)
     try {
@@ -83,6 +96,7 @@ export default function ResultsPage() {
       if (activeRes.ok) {
         setActive(await activeRes.json() as ActiveData)
       }
+      setStaleDays(null)
     } catch {
       setError(true)
     } finally {
@@ -90,7 +104,49 @@ export default function ResultsPage() {
     }
   }, [])
 
-  useEffect(() => { load() }, [load])
+  const loadAnonymous = useCallback(() => {
+    setLoading(true)
+    setError(false)
+    const stored = readLocalResult()
+    if (!stored) {
+      router.replace('/assessment')
+      return
+    }
+    setAssessment({
+      scoresByPillar: stored.scoresByPillar,
+      focusPillar: stored.focusPillar,
+      lowestPillarId: stored.lowestPillarId,
+    })
+    const sugs = stored.suggestedPracticeIds
+      .map((id) => practicesById.get(id))
+      .filter((p): p is Practice => Boolean(p))
+    setSuggestions(sugs)
+    setActive(null)
+    const age = ageInDays(stored.takenAt)
+    setStaleDays(age >= STALE_AGE_DAYS ? Math.floor(age) : null)
+    setLoading(false)
+  }, [router])
+
+  useEffect(() => {
+    if (authStatus === 'configuring') return
+    if (isAnonymous) {
+      loadAnonymous()
+    } else {
+      loadAuthed()
+    }
+  }, [authStatus, isAnonymous, loadAuthed, loadAnonymous])
+
+  // Fire `results_viewed` once we have an assessment loaded and know the
+  // focus pillar. Effect deps include focusPillar so it fires exactly when
+  // the data lands, not before.
+  const focusPillarForTracking = assessment?.lowestPillarId ?? assessment?.focusPillar
+  useEffect(() => {
+    if (!focusPillarForTracking) return
+    trackEvent('results_viewed', {
+      is_anonymous: isAnonymous,
+      focus_pillar: focusPillarForTracking,
+    })
+  }, [focusPillarForTracking, isAnonymous])
 
   const statusById = useMemo(() => {
     const map = new Map<string, CardStatus>()
@@ -119,7 +175,7 @@ export default function ResultsPage() {
       const res = await callPractice({ mode: 'startPractice', practiceId: practice.id })
       const json = await res.json().catch(() => ({} as Record<string, unknown>))
       if (res.ok) {
-        await load()
+        await loadAuthed()
         router.push('/today')
         return
       }
@@ -155,15 +211,21 @@ export default function ResultsPage() {
         return
       }
       setSwitchState(null)
-      await load()
+      await loadAuthed()
       router.push('/today')
     } finally {
       setAction(newPractice.id, false)
     }
   }
 
+  function handleAnonymousRetake() {
+    clearLocalResult()
+    router.replace('/assessment')
+  }
+
   const scores = assessment?.scoresByPillar
   const focusPillar = assessment?.lowestPillarId ?? assessment?.focusPillar
+  const focusPillarLabel = focusPillar ? pillarLabels[focusPillar] : null
 
   return (
     <StandardPage
@@ -185,6 +247,19 @@ export default function ResultsPage() {
 
         {assessment && (
           <>
+            {staleDays !== null && (
+              <Card className="border-amber-300/60 bg-amber-50/60 dark:bg-amber-950/20">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-sm text-foreground">
+                    Your result is {staleDays} days old — things may have changed.
+                  </p>
+                  <Button variant="outline" size="sm" onClick={handleAnonymousRetake}>
+                    Retake assessment
+                  </Button>
+                </div>
+              </Card>
+            )}
+
             <Card className="border-primary/30 bg-primary/5">
               <div className="flex items-center gap-2 mb-2">
                 <p className="text-xs uppercase tracking-[0.2em] text-primary">Focus Pillar</p>
@@ -267,12 +342,12 @@ export default function ResultsPage() {
                               >
                                 {pillarLabels[practice.pillar]}
                               </span>
-                              {status === 'active' && (
+                              {!isAnonymous && status === 'active' && (
                                 <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-primary/10 text-primary border border-primary/30">
                                   Active
                                 </span>
                               )}
-                              {status === 'inactive' && (
+                              {!isAnonymous && status === 'inactive' && (
                                 <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-muted text-muted-foreground border border-border">
                                   Paused
                                 </span>
@@ -280,7 +355,7 @@ export default function ResultsPage() {
                             </div>
                             <p className="font-semibold text-foreground">{practice.title}</p>
                             <p className="text-sm text-muted-foreground">{practice.description}</p>
-                            {status === 'inactive' && (
+                            {!isAnonymous && status === 'inactive' && (
                               <p className="text-xs text-muted-foreground">
                                 You started this before — currently paused. Resume anytime.
                               </p>
@@ -292,28 +367,44 @@ export default function ResultsPage() {
                             )}
                           </div>
                           <div>
-                            {status === 'none' && (
-                              <Button variant="outline" disabled={busy} onClick={() => handleStart(practice)}>
-                                {busy ? '…' : 'Start this practice'}
+                            {isAnonymous ? (
+                              <Button asChild variant="outline">
+                                <Link
+                                  href="/auth"
+                                  onClick={() => trackEvent('signup_clicked', {
+                                    focus_pillar: focusPillarForTracking,
+                                    source: 'practice_card',
+                                  })}
+                                >
+                                  Sign up to start →
+                                </Link>
                               </Button>
+                            ) : (
+                              <>
+                                {status === 'none' && (
+                                  <Button variant="outline" disabled={busy} onClick={() => handleStart(practice)}>
+                                    {busy ? '…' : 'Start this practice'}
+                                  </Button>
+                                )}
+                                {status === 'inactive' && (
+                                  <Button variant="outline" disabled={busy} onClick={() => handleStart(practice)}>
+                                    {busy ? '…' : 'Resume'}
+                                  </Button>
+                                )}
+                                {status === 'active' && (
+                                  <Button asChild>
+                                    <Link href="/today">View on Today</Link>
+                                  </Button>
+                                )}
+                                {capNotice[practice.id] ? (
+                                  <CapLimitNotice cap={capNotice[practice.id]} />
+                                ) : inlineError[practice.id] ? (
+                                  <p className="text-xs text-destructive mt-1">
+                                    {inlineError[practice.id]}
+                                  </p>
+                                ) : null}
+                              </>
                             )}
-                            {status === 'inactive' && (
-                              <Button variant="outline" disabled={busy} onClick={() => handleStart(practice)}>
-                                {busy ? '…' : 'Resume'}
-                              </Button>
-                            )}
-                            {status === 'active' && (
-                              <Button asChild>
-                                <Link href="/today">View on Today</Link>
-                              </Button>
-                            )}
-                            {capNotice[practice.id] ? (
-                              <CapLimitNotice cap={capNotice[practice.id]} />
-                            ) : inlineError[practice.id] ? (
-                              <p className="text-xs text-destructive mt-1">
-                                {inlineError[practice.id]}
-                              </p>
-                            ) : null}
                           </div>
                         </div>
                       </Card>
@@ -331,20 +422,54 @@ export default function ResultsPage() {
               </div>
             </div>
 
-            <div className="pt-2 space-y-3">
-              <Button asChild size="lg" className="w-full sm:w-auto">
-                <Link href="/today">Go to Today →</Link>
-              </Button>
-              <div>
-                <Button asChild variant="outline" size="lg" className="w-full sm:w-auto">
-                  <Link href="/assessment">Retake assessment</Link>
-                </Button>
-                <p className="mt-1.5 text-xs text-muted-foreground">
-                  Your results update when you retake — useful after a few weeks of practice.{" "}
-                  <Link href="/faq" className="underline underline-offset-2 hover:text-foreground">Questions about your results?</Link>
-                </p>
+            {isAnonymous ? (
+              <div className="pt-2 space-y-4">
+                <Card className="border-primary/40 bg-primary/5">
+                  <div className="space-y-3">
+                    <p className="text-xs uppercase tracking-[0.2em] text-primary">Save your results</p>
+                    <p className="text-base text-foreground">
+                      Sign up free to start your {focusPillarLabel} practice — we&apos;ll save your
+                      results and set up a single daily check-in.
+                    </p>
+                    <Button asChild size="lg">
+                      <Link
+                        href="/auth"
+                        onClick={() => trackEvent('signup_clicked', {
+                          focus_pillar: focusPillarForTracking,
+                          source: 'results_bottom',
+                        })}
+                      >
+                        Sign up free →
+                      </Link>
+                    </Button>
+                  </div>
+                </Card>
+                <div>
+                  <button
+                    type="button"
+                    onClick={handleAnonymousRetake}
+                    className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-2"
+                  >
+                    Retake (clears your result)
+                  </button>
+                </div>
               </div>
-            </div>
+            ) : (
+              <div className="pt-2 space-y-3">
+                <Button asChild size="lg" className="w-full sm:w-auto">
+                  <Link href="/today">Go to Today →</Link>
+                </Button>
+                <div>
+                  <Button asChild variant="outline" size="lg" className="w-full sm:w-auto">
+                    <Link href="/assessment">Retake assessment</Link>
+                  </Button>
+                  <p className="mt-1.5 text-xs text-muted-foreground">
+                    Your results update when you retake — useful after a few weeks of practice.{" "}
+                    <Link href="/faq" className="underline underline-offset-2 hover:text-foreground">Questions about your results?</Link>
+                  </p>
+                </div>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/components/AppChrome.tsx
+++ b/components/AppChrome.tsx
@@ -6,7 +6,7 @@ import { useAuthenticator } from "@aws-amplify/ui-react";
 import { AppShell } from "@/components/layout";
 import { ProfileProvider } from "@/contexts/ProfileContext";
 
-function shouldUseAppShell(pathname: string | null) {
+function shouldUseAppShell(pathname: string | null, isAuthed: boolean) {
   if (!pathname) return true;
   if (pathname === "/") return false;
   if (pathname.startsWith("/auth")) return false;
@@ -18,12 +18,22 @@ function shouldUseAppShell(pathname: string | null) {
   if (pathname.startsWith("/admin")) return false;
   if (pathname.startsWith("/onboarding")) return false;
   if (pathname.startsWith("/payment")) return false;
+  // Anonymous funnel: /assessment and /results are public. When a visitor is
+  // unauthenticated, skip the AppShell — its nav links (Today/Practices/etc)
+  // would all 302 to /auth. Authed visitors still get the shell here.
+  if (!isAuthed && (pathname.startsWith("/assessment") || pathname.startsWith("/results"))) {
+    return false;
+  }
   return true;
 }
 
 export default function AppChrome({ children }: { children: ReactNode }) {
   const pathname = usePathname();
-  const { signOut } = useAuthenticator((context) => [context.signOut]);
+  const { authStatus, signOut } = useAuthenticator((context) => [
+    context.authStatus,
+    context.signOut,
+  ]);
+  const isAuthed = authStatus === "authenticated";
 
   async function handleSignOut() {
     try {
@@ -41,7 +51,7 @@ export default function AppChrome({ children }: { children: ReactNode }) {
 
   return (
     <ProfileProvider>
-      {!shouldUseAppShell(pathname) ? (
+      {!shouldUseAppShell(pathname, isAuthed) ? (
         <>{children}</>
       ) : (
         <AppShell onSignOut={handleSignOut}>{children}</AppShell>

--- a/components/CookieBanner.tsx
+++ b/components/CookieBanner.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Button } from "@/components/ui";
+
+const KEY = "cookie_consent";
+const EVENT = "fiapp:cookie-consent";
+
+export type ConsentState = "accepted" | "declined" | null;
+
+function read(): ConsentState {
+  if (typeof window === "undefined") return null;
+  try {
+    const v = window.localStorage.getItem(KEY);
+    return v === "accepted" || v === "declined" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function write(v: "accepted" | "declined") {
+  try {
+    window.localStorage.setItem(KEY, v);
+    window.dispatchEvent(new Event(EVENT));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Read-only hook returning current consent state. Re-renders when a banner
+ * decision is made anywhere in the app (via the fiapp:cookie-consent event).
+ */
+export function useCookieConsent(): ConsentState {
+  // Default to `null` on the server so SSR doesn't ship an accepted/declined
+  // assumption that mismatches the client's first paint.
+  const [state, setState] = useState<ConsentState>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState(read());
+    setHydrated(true);
+    function onChange() {
+      setState(read());
+    }
+    window.addEventListener(EVENT, onChange);
+    // Cross-tab updates: storage events fire for other tabs.
+    window.addEventListener("storage", onChange);
+    return () => {
+      window.removeEventListener(EVENT, onChange);
+      window.removeEventListener("storage", onChange);
+    };
+  }, []);
+
+  return hydrated ? state : null;
+}
+
+export default function CookieBanner() {
+  const consent = useCookieConsent();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  const accept = useCallback(() => write("accepted"), []);
+  const decline = useCallback(() => write("declined"), []);
+
+  // Don't render anything until we've hydrated localStorage on the client —
+  // avoids a flash on every page load.
+  if (!mounted) return null;
+  if (consent !== null) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-live="polite"
+      aria-label="Cookie preferences"
+      className="fixed inset-x-0 bottom-0 z-[100] border-t border-border bg-card/95 backdrop-blur px-4 py-3 shadow-lg sm:px-6"
+    >
+      <div className="mx-auto flex max-w-3xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-foreground">
+          We use a single analytics cookie to understand how the assessment is
+          used. No personal data is shared.{" "}
+          <a
+            href="/privacy"
+            className="underline underline-offset-2 hover:text-primary"
+          >
+            Learn more
+          </a>
+          .
+        </p>
+        <div className="flex shrink-0 gap-2">
+          <Button variant="outline" size="sm" onClick={decline}>
+            Decline
+          </Button>
+          <Button size="sm" onClick={accept}>
+            Accept
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/DecideRouteClient.tsx
+++ b/components/DecideRouteClient.tsx
@@ -7,6 +7,8 @@ import { decideRoute, type ProfileForRouting } from "@/lib/decideRoute";
 import { useProfile } from "@/contexts/ProfileContext";
 import FullPageSpinner from "@/components/FullPageSpinner";
 import { Button } from "@/components/ui";
+import { readLocalResult, clearLocalResult } from "@/lib/assessment/localResult";
+import { trackEvent } from "@/lib/analytics";
 
 // After a quiet period the Lambda may need to cold-start. fetchMe retries
 // transient failures already (see lib/apiClient.ts); this just lets the
@@ -44,9 +46,63 @@ export default function DecideRouteClient() {
 
     if (error) return;
 
-    const next = decideRoute(profile as ProfileForRouting);
-    router.replace(next);
-  }, [authStatus, loading, profile, error, router]);
+    let cancelled = false;
+    const profileSnapshot = profile;
+
+    async function go() {
+      const stored = readLocalResult();
+
+      // Existing user with stale localStorage from a curious anonymous take.
+      // Decision 4 in the plan: preserve server data, silently drop local.
+      if (stored && profileSnapshot.latestAssessmentId) {
+        clearLocalResult();
+      } else if (stored && !profileSnapshot.latestAssessmentId) {
+        // Anonymous → signup hydration. Persist their answers as the canonical
+        // ASSESS# record via the existing authed POST path. On success, route
+        // straight to /results so they see unlocked CTAs (Decision 2).
+        try {
+          const res = await fetch("/api/assessment", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ answers: stored.answers }),
+          });
+          if (res.ok) {
+            clearLocalResult();
+            console.log(JSON.stringify({
+              funnel_event: "hydration_success",
+              ts: new Date().toISOString(),
+              focusPillar: stored.focusPillar,
+            }));
+            trackEvent("hydration_success", { focus_pillar: stored.focusPillar });
+            trackEvent("signup_completed");
+            await refetch();
+            if (!cancelled) router.replace("/results");
+            return;
+          }
+          console.log(JSON.stringify({
+            funnel_event: "hydration_failure",
+            ts: new Date().toISOString(),
+            status: res.status,
+          }));
+          trackEvent("hydration_failure", { error_status: res.status });
+        } catch {
+          console.log(JSON.stringify({
+            funnel_event: "hydration_error",
+            ts: new Date().toISOString(),
+          }));
+          trackEvent("hydration_failure", { error_status: -1 });
+        }
+        // On failure, fall through to default routing. localStorage stays so
+        // the user can retry by visiting /results manually.
+      }
+
+      const next = decideRoute(profileSnapshot as ProfileForRouting);
+      if (!cancelled) router.replace(next);
+    }
+
+    go();
+    return () => { cancelled = true; };
+  }, [authStatus, loading, profile, error, router, refetch]);
 
   if (authStatus === "unauthenticated") {
     return <FullPageSpinner label="Redirecting..." />;

--- a/components/GA4Loader.tsx
+++ b/components/GA4Loader.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { GoogleAnalytics } from "@next/third-parties/google";
+import { useCookieConsent } from "@/components/CookieBanner";
+
+/**
+ * Loads GA4 only when (a) `NEXT_PUBLIC_GA4_MEASUREMENT_ID` is set and
+ * (b) the user has accepted the cookie banner. Decline keeps GA4 entirely off.
+ * See docs/operations/analytics-privacy-boundaries.md §Third-party analytics.
+ */
+export default function GA4Loader() {
+  const consent = useCookieConsent();
+  const id = process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
+  if (!id) return null;
+  if (consent !== "accepted") return null;
+  return <GoogleAnalytics gaId={id} />;
+}

--- a/docs/operations/analytics-privacy-boundaries.md
+++ b/docs/operations/analytics-privacy-boundaries.md
@@ -13,6 +13,7 @@ FIApp v1 collects only aggregate, non-personal metrics. This document defines ex
 | `totalTrials` | Total trial practices started | `METRICS#TOTALS` |
 | `totalPromotions` | Total trials promoted to active | `METRICS#TOTALS` |
 | `totalReturns` | Total `didIt=true` returns logged | `METRICS#TOTALS` |
+| `totalAnonymousAssessments` | Total anonymous (pre-signup) assessment submissions | `METRICS#TOTALS` |
 | `pillarFocus_<pillar>` | Count of times each pillar was selected as focus | `METRICS#TOTALS` |
 | `DAILY#<date>.*` | Per-day counts of the above events | `METRICS#DAILY#<date>` |
 
@@ -22,11 +23,13 @@ All fields are counters. No user IDs, emails, or identifiers are stored alongsid
 
 ## Forbidden — never tracked
 
-- Individual user identifiers linked to any metric
-- Assessment answers (individual yes/no responses)
-- Which specific practice a user chose
-- Which user belongs to which pillar focus
-- Session data, device fingerprints, IP addresses
+The rules below apply to the FIAPP-owned metrics system. GA4 has its own scoped allowances; see §Third-party analytics (GA4) below.
+
+- Individual user identifiers linked to any FIAPP metric
+- Assessment answers (individual yes/no responses) — anywhere, including GA4
+- Which specific practice a user chose — anywhere, including GA4
+- A specific user's pillar focus tied to an identifier — anywhere, including GA4
+- Session data, device fingerprints, or IPs in our own metrics (GA4 receives a GA-generated client ID + anonymized IP under the §Third-party analytics scope)
 - Any field that could re-identify a user
 
 ---
@@ -38,7 +41,8 @@ Events are fired fire-and-forget via `utils/metricsClient.ts`. They never block 
 | Event | Trigger | Fields incremented |
 |---|---|---|
 | `signup` | New profile created in `GET /api/me` | `totalUsers`, daily `newUsers` |
-| `assessment_completed` | `POST /api/assessment` success | `totalAssessments`, daily `assessments`, `pillarFocus_<pillar>` |
+| `assessment_completed` | `POST /api/assessment` success (authed) | `totalAssessments`, daily `assessments`, `pillarFocus_<pillar>` |
+| `assessment_completed_anonymous` | `POST /api/assessment` success (anonymous, pre-signup) | `totalAnonymousAssessments`, daily `anonymousAssessments` |
 | `trial_started` | `POST /api/practice` mode=startTrial success | `totalTrials`, daily `trials` |
 | `trial_promoted` | `POST /api/practice` mode=promoteTrial success | `totalPromotions` |
 | `return_logged` | `POST /api/return` with `didIt=true` and `delta > 0` | `totalReturns`, daily `returns` |
@@ -55,3 +59,54 @@ Events are fired fire-and-forget via `utils/metricsClient.ts`. They never block 
 ## Access
 
 Metrics are only accessible via `GET /api/admin/metrics`, which requires the caller's Cognito `userId` to match the `FIAPP_ADMIN_USER_ID` environment variable. No metrics data is exposed to regular authenticated users.
+
+---
+
+## Third-party analytics (GA4)
+
+FIApp v1 uses Google Analytics 4 (GA4) for behavioral funnel analysis around the anonymous assessment funnel and signup conversion. GA4 sets first-party cookies and records (anonymized) IP addresses and a GA-generated client ID. This is a deliberate trade — the strict aggregate-counter posture above does not give source/medium attribution or drop-off insight, both of which are load-bearing for the LinkedIn launch ([anonymous-assessment-funnel](../../_docs/plans/anonymous-assessment-funnel.md)).
+
+### Strict scope
+
+- **Cookie consent is required.** GA4 is gated by [`components/CookieBanner.tsx`](../../components/CookieBanner.tsx). On first visit the banner shows and GA4 is not loaded. Decline keeps GA4 entirely off. Accept loads GA4 via [`components/GA4Loader.tsx`](../../components/GA4Loader.tsx) using `@next/third-parties/google`.
+- **Anonymized IPs enabled.** Default in GA4; verify in Admin → Property Settings.
+- **Google Signals OFF.** This would merge identities across devices via Google account — explicit privacy violation here.
+- **No User-ID feature.** We never call `gtag('config', id, { user_id: ... })`. The Cognito `userId` never reaches GA4.
+- **No PII in custom dimensions or event params.** No email, no Cognito userId, no raw assessment answers, no specific practice IDs.
+- **Standard 14-month event data retention.** Set explicitly in Admin → Data Settings → Data Retention.
+
+### Allowed event params
+
+Only these are permitted on custom events fired through [`lib/analytics.ts`](../../lib/analytics.ts):
+
+- `is_anonymous: boolean` — authed vs. anonymous caller
+- `focus_pillar: <pillarId>` — the seven canonical pillar IDs only (`financial`, `relationship`, etc.); never a user-readable label
+- `source: "practice_card" | "results_bottom"` — which CTA fired a signup click
+- `error_status: number` — HTTP status code on hydration failure
+
+Any new custom param must be added to this list. Adding raw answers, identifiers, or freeform user text is forbidden — that's the line.
+
+### Event taxonomy (client-side GA4)
+
+| Event | Fires from | Params |
+|---|---|---|
+| `assessment_started` | `/assessment` mount | `is_anonymous` |
+| `assessment_submitted` | submit success | `is_anonymous`, `focus_pillar` |
+| `results_viewed` | `/results` mount with data loaded | `is_anonymous`, `focus_pillar` |
+| `signup_clicked` | "Sign up to start" CTA click on `/results` | `focus_pillar`, `source` |
+| `signup_completed` | first `/decideRoute` pass after hydration success | (none) |
+| `hydration_success` | post-signup persistence success | `focus_pillar` |
+| `hydration_failure` | post-signup persistence failure | `error_status` |
+
+GA4's built-in `page_view` covers landing/visit counting — we don't fire a custom `landing_viewed`.
+
+### Server-side funnel events (CloudWatch)
+
+Parallel to GA4, the server emits structured `console.log(JSON.stringify({ funnel_event, ts, ... }))` lines from `POST /api/assessment` and `DecideRouteClient`. These are anonymous by design (no userId field set for anonymous submissions). Use them as a non-cookie-gated funnel signal in CloudWatch Logs Insights:
+
+```
+fields @timestamp, funnel_event, focusPillar
+| filter ispresent(funnel_event)
+| stats count(*) as n by funnel_event
+| sort n desc
+```

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,44 @@
+// Client-side GA4 event helper. Fire-and-forget — never throws, never
+// blocks, and silently no-ops when consent has not been granted or GA4
+// hasn't loaded. See docs/operations/analytics-privacy-boundaries.md for
+// the strict rules on what may and may not be sent as event params.
+
+type Primitive = string | number | boolean;
+export type EventParams = Record<string, Primitive | undefined>;
+
+type GtagFn = (
+  command: "event",
+  name: string,
+  params?: EventParams,
+) => void;
+
+function isConsented(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem("cookie_consent") === "accepted";
+  } catch {
+    return false;
+  }
+}
+
+function getGtag(): GtagFn | null {
+  if (typeof window === "undefined") return null;
+  const g = (window as unknown as { gtag?: GtagFn }).gtag;
+  return typeof g === "function" ? g : null;
+}
+
+/**
+ * Send a GA4 custom event. Hard rules:
+ * - Caller must NOT pass user IDs, emails, raw answers, or any PII.
+ * - Caller may pass `is_anonymous`, `focus_pillar`, and counts/statuses.
+ */
+export function trackEvent(name: string, params?: EventParams): void {
+  const gtag = getGtag();
+  if (!gtag) return;
+  if (!isConsented()) return;
+  try {
+    gtag("event", name, params ?? {});
+  } catch {
+    // ignore
+  }
+}

--- a/lib/assessment/localResult.ts
+++ b/lib/assessment/localResult.ts
@@ -1,0 +1,99 @@
+// Transient pre-account state for the anonymous assessment funnel.
+// Cleared on signup hydration. Never read for an authenticated user.
+// See _docs/plans/anonymous-assessment-funnel.md and the db-schema.md
+// invariant: DynamoDB is the source of truth for all authenticated state;
+// localStorage holds only this transient pre-account state.
+
+import type { Pillar } from "@/lib/assessment/pillars";
+
+const RESULT_KEY = "assessment.result";
+const DRAFT_KEY = "assessment.draft";
+const CURRENT_VERSION = 1;
+
+export type LocalAssessmentResult = {
+  version: 1;
+  answers: Record<string, boolean>;
+  scoresByPillar: Record<Pillar, number>;
+  focusPillar: Pillar;
+  lowestPillarId: Pillar;
+  suggestedPracticeIds: string[];
+  takenAt: string; // ISO
+};
+
+export type LocalAssessmentDraft = {
+  version: 1;
+  answers: Record<string, boolean>;
+  index: number;
+  startedAt: string; // ISO
+};
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function safeParse<T>(raw: string | null): T | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function readLocalResult(): LocalAssessmentResult | null {
+  if (!isBrowser()) return null;
+  const parsed = safeParse<LocalAssessmentResult>(window.localStorage.getItem(RESULT_KEY));
+  if (!parsed || parsed.version !== CURRENT_VERSION) return null;
+  return parsed;
+}
+
+export function writeLocalResult(r: LocalAssessmentResult): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(RESULT_KEY, JSON.stringify(r));
+  } catch {
+    // Storage quota exceeded, Safari ITP, etc. Best-effort — fail silently.
+  }
+}
+
+export function clearLocalResult(): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.removeItem(RESULT_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function readLocalDraft(): LocalAssessmentDraft | null {
+  if (!isBrowser()) return null;
+  const parsed = safeParse<LocalAssessmentDraft>(window.localStorage.getItem(DRAFT_KEY));
+  if (!parsed || parsed.version !== CURRENT_VERSION) return null;
+  return parsed;
+}
+
+export function writeLocalDraft(d: LocalAssessmentDraft): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(DRAFT_KEY, JSON.stringify(d));
+  } catch {
+    // ignore
+  }
+}
+
+export function clearLocalDraft(): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.removeItem(DRAFT_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function ageInDays(takenAt: string): number {
+  const t = Date.parse(takenAt);
+  if (Number.isNaN(t)) return 0;
+  return (Date.now() - t) / 86_400_000;
+}
+
+export const STALE_AGE_DAYS = 30;

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,11 +2,13 @@ import { NextRequest, NextResponse } from 'next/server'
 import { fetchAuthSession } from 'aws-amplify/auth/server'
 import { runWithAmplifyServerContext } from '@/utils/amplifyServerUtils'
 
+// `/assessment` and `/results` are intentionally PUBLIC so that anonymous
+// visitors can complete the assessment and see results before being asked to
+// sign up. See _docs/plans/anonymous-assessment-funnel.md and the updated
+// per-route guard table in _docs/canon/business-logic-v2.md.
 const PROTECTED_PREFIXES = [
   '/today',
   '/practices',
-  '/results',
-  '/assessment',
   '/onboarding',
   '/progress',
   '/account',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-amplify/ui-react": "^6.13.2",
         "@aws-sdk/client-dynamodb": "^3.821.0",
         "@aws-sdk/lib-dynamodb": "^3.821.0",
+        "@next/third-parties": "^16.2.6",
         "aws-amplify": "^6.16.0",
         "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",
@@ -31864,6 +31865,19 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.6.tgz",
+      "integrity": "sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -47040,6 +47054,12 @@
       "dependencies": {
         "b4a": "^1.6.4"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tildify": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@aws-amplify/ui-react": "^6.13.2",
     "@aws-sdk/client-dynamodb": "^3.821.0",
     "@aws-sdk/lib-dynamodb": "^3.821.0",
+    "@next/third-parties": "^16.2.6",
     "aws-amplify": "^6.16.0",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",

--- a/tests/e2e/anonymous-funnel.spec.ts
+++ b/tests/e2e/anonymous-funnel.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from "@playwright/test";
+
+// Anonymous funnel — explicitly NO storageState. These tests cover the new
+// behaviour where /assessment and /results are public, and signup is asked
+// at the results gate. See _docs/plans/anonymous-assessment-funnel.md.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("Anonymous funnel", () => {
+  test("landing → 'Free · no account needed' microcopy + 8-min badge are visible", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText(/Free · no account needed to start/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    // The 35-question pill that used to be sm:inline-flex only — now always visible.
+    await expect(page.getByText(/35-question assessment.*7 pillars.*8 minutes/i)).toBeVisible();
+  });
+
+  test("cookie banner appears on first visit, can be accepted, hides afterwards", async ({ page }) => {
+    await page.goto("/");
+    const banner = page.getByRole("dialog", { name: /cookie preferences/i });
+    await expect(banner).toBeVisible({ timeout: 10_000 });
+    await banner.getByRole("button", { name: /accept/i }).click();
+    await expect(banner).not.toBeVisible({ timeout: 5_000 });
+
+    // Consent state persisted to localStorage.
+    const consent = await page.evaluate(() => localStorage.getItem("cookie_consent"));
+    expect(consent).toBe("accepted");
+  });
+
+  test("Start free assessment from / loads /assessment intro WITHOUT auth redirect", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: /Start free assessment/i }).first().click();
+    // Must land on /assessment, not get bounced to /auth.
+    await page.waitForURL(/\/assessment$/, { timeout: 10_000 });
+    await expect(
+      page.getByRole("button", { name: /start assessment/i })
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("/results with empty localStorage redirects to /assessment", async ({ page }) => {
+    // Start on a page that's known anonymous-accessible so we have an origin
+    // to evaluate against, then navigate.
+    await page.goto("/");
+    await page.evaluate(() => localStorage.clear());
+    await page.goto("/results");
+    await page.waitForURL(/\/assessment$/, { timeout: 10_000 });
+  });
+
+  test("draft survives mid-quiz refresh", async ({ page }) => {
+    await page.goto("/assessment");
+    await page.getByRole("button", { name: /start assessment/i }).click();
+
+    // Answer 3 questions.
+    for (let i = 0; i < 3; i += 1) {
+      await page.getByRole("button", { name: /^yes$/i }).click();
+    }
+    await expect(page.getByText(/Question\s*4\s*\/\s*35/i)).toBeVisible({ timeout: 5_000 });
+
+    await page.reload();
+    // After reload, the page restores from localStorage.assessment.draft and skips
+    // the intro screen entirely.
+    await expect(page.getByText(/Question\s*4\s*\/\s*35/i)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("full anonymous run: 35 answers → /results shows pillar-aware Sign up CTA", async ({ page }) => {
+    await page.goto("/assessment");
+    await page.getByRole("button", { name: /start assessment/i }).click();
+
+    // Answer all 35 with Yes. Auto-advances. The submit button replaces Next
+    // on the final question.
+    for (let i = 0; i < 34; i += 1) {
+      await page.getByRole("button", { name: /^yes$/i }).click();
+    }
+    // Final question — answering doesn't auto-advance (since there's no next);
+    // click Yes then Submit.
+    await page.getByRole("button", { name: /^yes$/i }).click();
+    await page.getByRole("button", { name: /^submit$/i }).click();
+
+    await page.waitForURL(/\/results$/, { timeout: 15_000 });
+
+    // Pillar-aware bottom CTA — proves dual-mode anonymous render path fired.
+    await expect(page.getByText(/Sign up free to start your .+ practice/i)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Per-card CTAs read "Sign up to start", not "Start this practice".
+    await expect(page.getByRole("link", { name: /Sign up to start/i }).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Start this practice" })).not.toBeVisible();
+
+    // localStorage state landed correctly.
+    const stored = await page.evaluate(() => {
+      const raw = localStorage.getItem("assessment.result");
+      return raw ? JSON.parse(raw) : null;
+    });
+    expect(stored).not.toBeNull();
+    expect(stored.focusPillar).toBeTruthy();
+    expect(stored.suggestedPracticeIds).toHaveLength(3);
+    // Draft cleared.
+    expect(await page.evaluate(() => localStorage.getItem("assessment.draft"))).toBeNull();
+  });
+
+  test("Retake (clears your result) wipes localStorage and routes to /assessment", async ({ page }) => {
+    // Seed a result so /results renders.
+    await page.goto("/");
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "assessment.result",
+        JSON.stringify({
+          version: 1,
+          answers: {},
+          scoresByPillar: {
+            financial: 5, relationship: 5, information: 5,
+            emotional: 5, nutrition: 5, dynamic: 5, sleep: 0,
+          },
+          focusPillar: "sleep",
+          lowestPillarId: "sleep",
+          suggestedPracticeIds: [
+            "sleep-consistent-bedtime",
+            "sleep-morning-light",
+            "sleep-dim-before-bed",
+          ],
+          takenAt: new Date().toISOString(),
+        })
+      );
+    });
+
+    await page.goto("/results");
+    await page.getByText(/Retake \(clears your result\)/i).click();
+    await page.waitForURL(/\/assessment$/, { timeout: 10_000 });
+
+    const stored = await page.evaluate(() => localStorage.getItem("assessment.result"));
+    expect(stored).toBeNull();
+  });
+});

--- a/tests/integration/api/assessment.test.ts
+++ b/tests/integration/api/assessment.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
 import { randomUUID } from "crypto";
 import { POST } from "@/app/api/assessment/route";
 import { GET as GET_LATEST } from "@/app/api/assessment/latest/route";
@@ -6,17 +6,20 @@ import { createDynamoClient } from "@/utils/dynamoClient";
 import { assessmentQuestions } from "@/lib/assessment/questions";
 import { makeRawClient, makeTableNames, createTables, deleteTables } from "../tableUtils";
 import { seedProfile } from "../seeds";
-import type { withAuth as WithAuthType } from "@/utils/authServer";
+import type {
+  withAuth as WithAuthType,
+  withOptionalAuth as WithOptionalAuthType,
+} from "@/utils/authServer";
 
 vi.mock("@/utils/metricsClient", () => ({ trackEvent: vi.fn(), trackPillarFocus: vi.fn() }));
 vi.mock("next/headers", () => ({ cookies: vi.fn() }));
 
 vi.mock("@/utils/authServer", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/utils/authServer")>();
-  return { ...actual, withAuth: vi.fn() };
+  return { ...actual, withAuth: vi.fn(), withOptionalAuth: vi.fn() };
 });
 
-import { withAuth } from "@/utils/authServer";
+import { withAuth, withOptionalAuth } from "@/utils/authServer";
 
 const { mainTable, returnsTable } = makeTableNames();
 const rawClient = makeRawClient();
@@ -31,9 +34,27 @@ afterAll(async () => {
   await deleteTables(rawClient, mainTable, returnsTable);
 });
 
+// POST /api/assessment uses withOptionalAuth; GET /api/assessment/latest uses
+// withAuth. Tests call asUser/asAnonymous to set up persistent impls that
+// apply to every call within the test. beforeEach resets both so impls don't
+// leak across tests.
+beforeEach(() => {
+  vi.mocked(withAuth as typeof WithAuthType).mockReset();
+  vi.mocked(withOptionalAuth as typeof WithOptionalAuthType).mockReset();
+});
+
 function asUser(userId: string) {
-  vi.mocked(withAuth as typeof WithAuthType).mockImplementationOnce(
+  vi.mocked(withAuth as typeof WithAuthType).mockImplementation(
     async (_req, handler) => handler({ userId })
+  );
+  vi.mocked(withOptionalAuth as typeof WithOptionalAuthType).mockImplementation(
+    async (_req, handler) => handler({ user: { userId } })
+  );
+}
+
+function asAnonymous() {
+  vi.mocked(withOptionalAuth as typeof WithOptionalAuthType).mockImplementation(
+    async (_req, handler) => handler({ user: null })
   );
 }
 
@@ -119,6 +140,58 @@ describe("POST /api/assessment", () => {
       })
     );
     expect(res.status).toBe(400);
+  });
+
+  describe("anonymous branch", () => {
+    it("returns 200 with computed result and no assessmentId", async () => {
+      asAnonymous();
+      const res = await postAssessment(allAnswers(true));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.assessmentId).toBeUndefined();
+      expect(json.focusPillar).toBeDefined();
+      expect(json.lowestPillarId).toBe(json.focusPillar);
+      expect(json.scoresByPillar).toBeDefined();
+      expect(json.suggestedPracticeIds).toHaveLength(3);
+    });
+
+    it("writes nothing under USER# for an anonymous submission", async () => {
+      asAnonymous();
+      const res = await postAssessment(allAnswers(true));
+      expect(res.status).toBe(200);
+
+      // No PROFILE for anonymous users and no ASSESS# anywhere keyed by USER#.
+      // Sample a wide query just to be sure no per-user write leaked through.
+      const client = createDynamoClient();
+      // Just spot-check: a brand-new randomized USER# would never exist anyway,
+      // but we also confirm the integration test's PROFILE seeds are untouched.
+      const probeUser = randomUUID();
+      const profile = await client.getItem({ PK: `USER#${probeUser}`, SK: "PROFILE" });
+      expect(profile).toBeUndefined();
+    });
+
+    it("returns deterministic suggested practices from the lowest pillar (anonymous)", async () => {
+      // All-false answers → every pillar scores 0 → tie-break by pillar order
+      // (financial first). Two consecutive anonymous calls should match.
+      asAnonymous();
+      const a = await (await postAssessment(allAnswers(false))).json();
+      asAnonymous();
+      const b = await (await postAssessment(allAnswers(false))).json();
+      expect(a.suggestedPracticeIds).toEqual(b.suggestedPracticeIds);
+      expect(a.focusPillar).toBe(b.focusPillar);
+    });
+
+    it("rejects an anonymous submission with malformed answers", async () => {
+      asAnonymous();
+      const res = await POST(
+        new Request("http://localhost/api/assessment", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ answers: { "financial-1": true } }),
+        })
+      );
+      expect(res.status).toBe(400);
+    });
   });
 });
 

--- a/tests/integration/api/returns-get.test.ts
+++ b/tests/integration/api/returns-get.test.ts
@@ -43,22 +43,32 @@ function get(practiceId: string, days?: number) {
   return GET(new Request(url.toString()));
 }
 
+// Use dates relative to today so the test doesn't drift out of the API's
+// rolling N-day window. Returns are seeded as "N days ago in UTC".
+function daysAgoUTC(n: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
 describe("GET /api/returns", () => {
   it("returns dot entries with correct didIt values for seeded returns", async () => {
     const userId = randomUUID();
     await seedProfile(userId, { timezone: "UTC", dayResetTime: 0 });
-    await seedReturn(userId, PRACTICE, "2026-05-07", true);
-    await seedReturn(userId, PRACTICE, "2026-05-08", false);
+    const dateDidIt = daysAgoUTC(3);
+    const dateMissed = daysAgoUTC(2);
+    await seedReturn(userId, PRACTICE, dateDidIt, true);
+    await seedReturn(userId, PRACTICE, dateMissed, false);
 
     asUser(userId);
     const res = await get(PRACTICE, 14);
     expect(res.status).toBe(200);
     const json = await res.json();
 
-    const may7 = json.returns.find((r: { date: string }) => r.date === "2026-05-07");
-    const may8 = json.returns.find((r: { date: string }) => r.date === "2026-05-08");
-    expect(may7?.didIt).toBe(true);
-    expect(may8?.didIt).toBe(false);
+    const yes = json.returns.find((r: { date: string }) => r.date === dateDidIt);
+    const no = json.returns.find((r: { date: string }) => r.date === dateMissed);
+    expect(yes?.didIt).toBe(true);
+    expect(no?.didIt).toBe(false);
   });
 
   it("dates with no returns have didIt=null", async () => {
@@ -74,9 +84,9 @@ describe("GET /api/returns", () => {
   it("total reflects count of didIt=true items only", async () => {
     const userId = randomUUID();
     await seedProfile(userId, { timezone: "UTC", dayResetTime: 0 });
-    await seedReturn(userId, PRACTICE, "2026-05-06", true);
-    await seedReturn(userId, PRACTICE, "2026-05-07", true);
-    await seedReturn(userId, PRACTICE, "2026-05-08", false);
+    await seedReturn(userId, PRACTICE, daysAgoUTC(4), true);
+    await seedReturn(userId, PRACTICE, daysAgoUTC(3), true);
+    await seedReturn(userId, PRACTICE, daysAgoUTC(2), false);
 
     asUser(userId);
     const res = await get(PRACTICE, 14);

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { trackEvent } from "@/lib/analytics";
+
+// Privacy invariant: trackEvent MUST be a no-op unless the user has accepted
+// cookie consent, and MUST NOT throw under any circumstances. Both are
+// load-bearing for GDPR posture (we ship GA4 only after explicit consent —
+// see docs/operations/analytics-privacy-boundaries.md §Third-party analytics).
+
+function setupWindow(opts: { consent?: string; gtag?: unknown }) {
+  const consent = opts.consent;
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: (k: string) => (k === "cookie_consent" ? consent ?? null : null),
+    },
+    gtag: opts.gtag,
+  });
+}
+
+describe("lib/analytics.trackEvent", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does NOT call gtag when consent is missing", () => {
+    const gtag = vi.fn();
+    setupWindow({ gtag });
+    trackEvent("assessment_started", { is_anonymous: true });
+    expect(gtag).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call gtag when consent is explicitly declined", () => {
+    const gtag = vi.fn();
+    setupWindow({ consent: "declined", gtag });
+    trackEvent("assessment_started", { is_anonymous: true });
+    expect(gtag).not.toHaveBeenCalled();
+  });
+
+  it("calls gtag with the right shape when consent is accepted", () => {
+    const gtag = vi.fn();
+    setupWindow({ consent: "accepted", gtag });
+    trackEvent("assessment_submitted", { focus_pillar: "sleep", is_anonymous: true });
+    expect(gtag).toHaveBeenCalledWith("event", "assessment_submitted", {
+      focus_pillar: "sleep",
+      is_anonymous: true,
+    });
+  });
+
+  it("calls gtag with an empty object when params are omitted", () => {
+    const gtag = vi.fn();
+    setupWindow({ consent: "accepted", gtag });
+    trackEvent("signup_completed");
+    expect(gtag).toHaveBeenCalledWith("event", "signup_completed", {});
+  });
+
+  it("does NOT call gtag if gtag isn't on window (script hasn't loaded)", () => {
+    setupWindow({ consent: "accepted", gtag: undefined });
+    // Should be a silent no-op, not throw.
+    expect(() => trackEvent("page_view")).not.toThrow();
+  });
+
+  it("does NOT throw if gtag throws", () => {
+    const gtag = vi.fn(() => { throw new Error("network blip"); });
+    setupWindow({ consent: "accepted", gtag });
+    expect(() => trackEvent("results_viewed")).not.toThrow();
+  });
+
+  it("does NOT throw and is a no-op when window is undefined (SSR)", () => {
+    vi.stubGlobal("window", undefined);
+    expect(() => trackEvent("anything")).not.toThrow();
+  });
+
+  it("does NOT throw when localStorage access fails", () => {
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: () => { throw new Error("blocked by browser settings"); },
+      },
+      gtag: vi.fn(),
+    });
+    expect(() => trackEvent("assessment_started")).not.toThrow();
+  });
+});

--- a/tests/unit/api/assessment.post.test.ts
+++ b/tests/unit/api/assessment.post.test.ts
@@ -119,7 +119,10 @@ describe("POST /api/assessment", () => {
     expect(res2.status).toBe(400);
   });
 
-  it("returns 401 when unauthorized", async () => {
+  // The route used to require auth. After the anonymous-funnel refactor, an
+  // unauthenticated caller is a valid anonymous submission — compute-only,
+  // no DynamoDB writes. See _docs/plans/anonymous-assessment-funnel.md.
+  it("returns 200 anonymous response (no DynamoDB writes) when unauthenticated", async () => {
     getCurrentUserMock.mockRejectedValue(new Error("Unauthorized"));
 
     const req = new Request("http://localhost/api/assessment", {
@@ -128,7 +131,16 @@ describe("POST /api/assessment", () => {
     });
 
     const res = await POST(req);
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.assessmentId).toBeUndefined();
+    expect(json.focusPillar).toBeDefined();
+    expect(json.lowestPillarId).toBe(json.focusPillar);
+    expect(json.suggestedPracticeIds).toHaveLength(3);
+
+    expect(putItemMock).not.toHaveBeenCalled();
+    expect(updateItemMock).not.toHaveBeenCalled();
   });
 
   it("returns 500 on dynamo failures", async () => {

--- a/tests/unit/assessment/localResult.test.ts
+++ b/tests/unit/assessment/localResult.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import {
+  readLocalResult,
+  writeLocalResult,
+  clearLocalResult,
+  readLocalDraft,
+  writeLocalDraft,
+  clearLocalDraft,
+  ageInDays,
+  STALE_AGE_DAYS,
+  type LocalAssessmentResult,
+  type LocalAssessmentDraft,
+} from "@/lib/assessment/localResult";
+
+// Tiny in-memory localStorage shim. Vitest's default jsdom env has a real one
+// but resetting it between tests is the awkward part — easier to swap in a
+// fresh shim per test.
+function setupLocalStorage() {
+  const store = new Map<string, string>();
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, v); },
+      removeItem: (k: string) => { store.delete(k); },
+    },
+  });
+  return store;
+}
+
+const result: LocalAssessmentResult = {
+  version: 1,
+  answers: { "financial-1": true, "sleep-3": false },
+  scoresByPillar: {
+    financial: 3, relationship: 2, information: 4,
+    emotional: 1, nutrition: 5, dynamic: 3, sleep: 0,
+  },
+  focusPillar: "sleep",
+  lowestPillarId: "sleep",
+  suggestedPracticeIds: ["sleep-1", "sleep-2", "sleep-3"],
+  takenAt: "2026-05-20T10:00:00.000Z",
+};
+
+const draft: LocalAssessmentDraft = {
+  version: 1,
+  answers: { "financial-1": true },
+  index: 5,
+  startedAt: "2026-05-20T10:00:00.000Z",
+};
+
+describe("localResult", () => {
+  beforeEach(() => {
+    setupLocalStorage();
+  });
+
+  describe("result round-trip", () => {
+    it("writes and reads back", () => {
+      writeLocalResult(result);
+      const read = readLocalResult();
+      expect(read).toEqual(result);
+    });
+
+    it("returns null when empty", () => {
+      expect(readLocalResult()).toBeNull();
+    });
+
+    it("clears stored result", () => {
+      writeLocalResult(result);
+      clearLocalResult();
+      expect(readLocalResult()).toBeNull();
+    });
+
+    it("returns null for malformed JSON", () => {
+      window.localStorage.setItem("assessment.result", "{not json");
+      expect(readLocalResult()).toBeNull();
+    });
+
+    it("returns null when version mismatches", () => {
+      window.localStorage.setItem(
+        "assessment.result",
+        JSON.stringify({ ...result, version: 999 })
+      );
+      expect(readLocalResult()).toBeNull();
+    });
+  });
+
+  describe("draft round-trip", () => {
+    it("writes and reads back", () => {
+      writeLocalDraft(draft);
+      expect(readLocalDraft()).toEqual(draft);
+    });
+
+    it("clears stored draft", () => {
+      writeLocalDraft(draft);
+      clearLocalDraft();
+      expect(readLocalDraft()).toBeNull();
+    });
+
+    it("returns null when version mismatches", () => {
+      window.localStorage.setItem(
+        "assessment.draft",
+        JSON.stringify({ ...draft, version: 999 })
+      );
+      expect(readLocalDraft()).toBeNull();
+    });
+  });
+
+  describe("ageInDays", () => {
+    it("computes recent age within sub-day precision", () => {
+      const recent = new Date(Date.now() - 6 * 3600_000).toISOString();
+      const days = ageInDays(recent);
+      expect(days).toBeGreaterThanOrEqual(0.24);
+      expect(days).toBeLessThan(0.3);
+    });
+
+    it("returns 0 for malformed input rather than NaN", () => {
+      expect(ageInDays("not-a-date")).toBe(0);
+    });
+
+    it("STALE_AGE_DAYS is 30", () => {
+      expect(STALE_AGE_DAYS).toBe(30);
+    });
+
+    it("crosses the staleness threshold at exactly 30 days", () => {
+      const day29 = new Date(Date.now() - 29.5 * 86_400_000).toISOString();
+      const day31 = new Date(Date.now() - 30.5 * 86_400_000).toISOString();
+      expect(ageInDays(day29)).toBeLessThan(STALE_AGE_DAYS);
+      expect(ageInDays(day31)).toBeGreaterThan(STALE_AGE_DAYS);
+    });
+  });
+
+  describe("SSR safety", () => {
+    it("read/write/clear are no-ops when window is undefined", () => {
+      vi.stubGlobal("window", undefined);
+      expect(readLocalResult()).toBeNull();
+      expect(readLocalDraft()).toBeNull();
+      // Don't throw:
+      writeLocalResult(result);
+      writeLocalDraft(draft);
+      clearLocalResult();
+      clearLocalDraft();
+    });
+  });
+});

--- a/tests/unit/authServer.test.ts
+++ b/tests/unit/authServer.test.ts
@@ -159,4 +159,55 @@ describe("authServer", () => {
       expect(res.headers.get("Vary")).toBe("Cookie");
     });
   });
+
+  describe("withOptionalAuth guard", () => {
+    it("invokes handler with user=null when unauthenticated (no 401)", async () => {
+      runWithAmplifyMock.mockRejectedValue(new Error("Not authenticated"));
+
+      const { withOptionalAuth } = await import("@/utils/authServer");
+      const handler = vi.fn(async () => new Response("ok", { status: 200 }));
+      const res = await withOptionalAuth(undefined, handler);
+
+      expect(handler).toHaveBeenCalledWith({ user: null });
+      expect(res.status).toBe(200);
+    });
+
+    it("invokes handler with user object when authenticated", async () => {
+      runWithAmplifyMock.mockResolvedValue({
+        user: { userId: "usr-42", username: "test" },
+      });
+
+      const { withOptionalAuth } = await import("@/utils/authServer");
+      const handler = vi.fn(async () => new Response("ok", { status: 200 }));
+      await withOptionalAuth(undefined, handler);
+
+      expect(handler).toHaveBeenCalledWith({
+        user: { userId: "usr-42", username: "test" },
+      });
+    });
+
+    it("applies no-store cache headers for both anonymous and authed responses", async () => {
+      runWithAmplifyMock.mockRejectedValue(new Error("Not authenticated"));
+
+      const { withOptionalAuth } = await import("@/utils/authServer");
+      const res = await withOptionalAuth(undefined, async () =>
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+
+      expect(res.headers.get("Cache-Control")).toBe("no-store, private");
+      expect(res.headers.get("Vary")).toBe("Cookie");
+    });
+
+    it("returns 500 with cache headers when handler throws", async () => {
+      runWithAmplifyMock.mockRejectedValue(new Error("Not authenticated"));
+
+      const { withOptionalAuth } = await import("@/utils/authServer");
+      const res = await withOptionalAuth(undefined, async () => {
+        throw new Error("boom");
+      });
+
+      expect(res.status).toBe(500);
+      expect(res.headers.get("Cache-Control")).toBe("no-store, private");
+    });
+  });
 });

--- a/tests/unit/components/CookieBanner.test.tsx
+++ b/tests/unit/components/CookieBanner.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+
+import CookieBanner from "@/components/CookieBanner";
+
+// The banner is the *only* gate that loads GA4. If it misbehaves we either
+// fire analytics without consent (GDPR risk) or never fire them at all
+// (silent launch with no funnel data). Both are bad enough to want explicit
+// coverage on this small surface.
+
+describe("CookieBanner", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+  });
+
+  it("renders the banner on first visit (no prior consent)", async () => {
+    render(<CookieBanner />);
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /accept/i })).toBeVisible();
+    expect(screen.getByRole("button", { name: /decline/i })).toBeVisible();
+  });
+
+  it("does NOT render when consent was previously accepted", async () => {
+    window.localStorage.setItem("cookie_consent", "accepted");
+    render(<CookieBanner />);
+    // Wait a frame to let the mount effect settle.
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does NOT render when consent was previously declined", async () => {
+    window.localStorage.setItem("cookie_consent", "declined");
+    render(<CookieBanner />);
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("clicking Accept writes 'accepted' to localStorage and hides the banner", async () => {
+    render(<CookieBanner />);
+    await waitFor(() => screen.getByRole("button", { name: /accept/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept/i }));
+    await waitFor(() => {
+      expect(window.localStorage.getItem("cookie_consent")).toBe("accepted");
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("clicking Decline writes 'declined' to localStorage and hides the banner", async () => {
+    render(<CookieBanner />);
+    await waitFor(() => screen.getByRole("button", { name: /decline/i }));
+    fireEvent.click(screen.getByRole("button", { name: /decline/i }));
+    await waitFor(() => {
+      expect(window.localStorage.getItem("cookie_consent")).toBe("declined");
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("dispatches a fiapp:cookie-consent event when the user decides", async () => {
+    const listener = vi.fn();
+    window.addEventListener("fiapp:cookie-consent", listener);
+    render(<CookieBanner />);
+    await waitFor(() => screen.getByRole("button", { name: /accept/i }));
+    fireEvent.click(screen.getByRole("button", { name: /accept/i }));
+    await waitFor(() => expect(listener).toHaveBeenCalled());
+    window.removeEventListener("fiapp:cookie-consent", listener);
+  });
+});

--- a/tests/unit/pages/assessment.page.test.tsx
+++ b/tests/unit/pages/assessment.page.test.tsx
@@ -9,10 +9,29 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: replaceMock }),
 }));
 
+// The assessment page now reads auth status for funnel telemetry and to flag
+// anonymous submissions. Default to 'unauthenticated' — most tests exercise
+// the anonymous path. Tests that need authed behavior override per-test.
+vi.mock("@aws-amplify/ui-react", () => ({
+  useAuthenticator: () => ({ authStatus: "unauthenticated" }),
+}));
+
+// Analytics is fire-and-forget; safe to stub to a no-op for unit tests.
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+
 describe("Assessment page", () => {
   beforeEach(() => {
     replaceMock.mockReset();
     vi.stubGlobal("fetch", vi.fn());
+    // Reset localStorage between tests — the page now persists drafts there
+    // and would otherwise restore stale state from a prior test run.
+    try {
+      window.localStorage.clear();
+    } catch {
+      // ignore — happens if a prior test stubbed window globally
+    }
   });
 
   afterEach(() => {
@@ -171,11 +190,21 @@ describe("Assessment page", () => {
     });
   });
 
-  it("redirects to /auth on unauthorized", async () => {
+  // Anonymous submission: response has no `assessmentId`. The page stores the
+  // computed result in localStorage so /results can render it.
+  it("persists anonymous result to localStorage on submit and routes to /results", async () => {
     (global.fetch as unknown as Mock).mockResolvedValue({
-      ok: false,
-      status: 401,
-      json: async () => ({ error: "Unauthorized" }),
+      ok: true,
+      status: 200,
+      json: async () => ({
+        focusPillar: "sleep",
+        lowestPillarId: "sleep",
+        scoresByPillar: {
+          financial: 5, relationship: 5, information: 5,
+          emotional: 5, nutrition: 5, dynamic: 5, sleep: 0,
+        },
+        suggestedPracticeIds: ["sleep-1", "sleep-2", "sleep-3"],
+      }),
     });
 
     render(<AssessmentPage />);
@@ -188,7 +217,50 @@ describe("Assessment page", () => {
     fireEvent.click(screen.getByRole("button", { name: "Submit" }));
 
     await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith("/auth");
+      expect(replaceMock).toHaveBeenCalledWith("/results");
     });
+
+    const stored = JSON.parse(window.localStorage.getItem("assessment.result") ?? "null");
+    expect(stored).not.toBeNull();
+    expect(stored.focusPillar).toBe("sleep");
+    expect(stored.suggestedPracticeIds).toEqual(["sleep-1", "sleep-2", "sleep-3"]);
+    expect(stored.takenAt).toBeDefined();
+    // Draft should be cleared once the result lands.
+    expect(window.localStorage.getItem("assessment.draft")).toBeNull();
+  });
+
+  // Authed submission: response includes `assessmentId`. The page must NOT
+  // write to localStorage — that data lives server-side, and stale local
+  // copies would leak to the next visitor on the same browser after logout.
+  it("does NOT write localStorage.assessment.result for an authed submission", async () => {
+    (global.fetch as unknown as Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        assessmentId: "asmt-123",
+        focusPillar: "sleep",
+        lowestPillarId: "sleep",
+        scoresByPillar: {
+          financial: 5, relationship: 5, information: 5,
+          emotional: 5, nutrition: 5, dynamic: 5, sleep: 0,
+        },
+        suggestedPracticeIds: ["sleep-1", "sleep-2", "sleep-3"],
+      }),
+    });
+
+    render(<AssessmentPage />);
+    fireEvent.click(screen.getByRole("button", { name: /Start assessment/ }));
+
+    for (let i = 0; i < assessmentQuestions.length; i += 1) {
+      fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/results");
+    });
+
+    expect(window.localStorage.getItem("assessment.result")).toBeNull();
   });
 });

--- a/tests/unit/pages/results.page.test.tsx
+++ b/tests/unit/pages/results.page.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent, cleanup } from "@testing-library/react";
+
+import ResultsPage from "@/app/results/page";
+import type { LocalAssessmentResult } from "@/lib/assessment/localResult";
+
+const replaceMock = vi.fn();
+const pushMock = vi.fn();
+
+// The router object reference must stay stable across renders — the page's
+// useCallback (loadAnonymous) depends on `router`, and a fresh object on
+// every render would cause an infinite re-render loop in tests.
+const routerMock = { replace: replaceMock, push: pushMock };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock,
+}));
+
+// Default to unauthenticated — most tests in this file cover the anonymous
+// mode, which is the new surface in this PR. Individual tests can override.
+const useAuthenticatorMock = vi.fn(() => ({ authStatus: "unauthenticated" }));
+vi.mock("@aws-amplify/ui-react", () => ({
+  useAuthenticator: () => useAuthenticatorMock(),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+
+// The radar component imports d3 dynamically. Stub to a placeholder so
+// jsdom doesn't try to render canvas paths.
+vi.mock("@/components/ui/PillarRadarChart", () => ({
+  PillarRadarChart: () => null,
+}));
+
+function makeResult(overrides: Partial<LocalAssessmentResult> = {}): LocalAssessmentResult {
+  return {
+    version: 1,
+    answers: {},
+    scoresByPillar: {
+      financial: 3, relationship: 2, information: 4,
+      emotional: 5, nutrition: 5, dynamic: 5, sleep: 0,
+    },
+    focusPillar: "sleep",
+    lowestPillarId: "sleep",
+    // First three real practice IDs from the sleep pillar in lib/practices/library.ts —
+    // letting the page do its real lookup. If the practice IDs change the test will
+    // fail loudly, which is the right signal.
+    suggestedPracticeIds: ["sleep-consistent-bedtime", "sleep-morning-light", "sleep-dim-before-bed"],
+    takenAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("ResultsPage — anonymous mode", () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+    pushMock.mockReset();
+    useAuthenticatorMock.mockReturnValue({ authStatus: "unauthenticated" });
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("redirects to /assessment when localStorage has no result", async () => {
+    render(<ResultsPage />);
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/assessment");
+    });
+  });
+
+  it("renders the focus pillar and pillar-aware signup CTA from localStorage", async () => {
+    window.localStorage.setItem("assessment.result", JSON.stringify(makeResult()));
+    render(<ResultsPage />);
+
+    // Focus Pillar card uses pillarLabels[focusPillar] + " Intelligence"
+    await waitFor(() => {
+      expect(screen.getByText(/Sleep Intelligence/)).toBeInTheDocument();
+    });
+
+    // Pillar-aware bottom CTA references the focus pillar label.
+    expect(
+      screen.getByText(/Sign up free to start your Sleep practice/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Sign up to start' on each practice card (no 'Start this practice')", async () => {
+    window.localStorage.setItem("assessment.result", JSON.stringify(makeResult()));
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      // 3 suggested practice cards × 1 button = 3 anonymous CTAs.
+      expect(
+        screen.getAllByRole("link", { name: /Sign up to start/i }).length
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    // The authed-mode label must not appear for anonymous users.
+    expect(screen.queryByRole("button", { name: "Start this practice" })).not.toBeInTheDocument();
+    // No "Active" or "Paused" badges either (anonymous users have no UPRACTICE rows).
+    expect(screen.queryByText(/^Active$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Paused$/)).not.toBeInTheDocument();
+  });
+
+  it("shows the stale-age banner when takenAt is older than 30 days", async () => {
+    const stale = new Date(Date.now() - 45 * 86_400_000).toISOString();
+    window.localStorage.setItem(
+      "assessment.result",
+      JSON.stringify(makeResult({ takenAt: stale }))
+    );
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Your result is 45 days old/i)).toBeInTheDocument();
+    });
+  });
+
+  it("does NOT show the stale-age banner for a fresh result", async () => {
+    window.localStorage.setItem("assessment.result", JSON.stringify(makeResult()));
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sleep Intelligence/)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/days old/i)).not.toBeInTheDocument();
+  });
+
+  it("'Retake (clears your result)' clears localStorage and routes to /assessment", async () => {
+    window.localStorage.setItem("assessment.result", JSON.stringify(makeResult()));
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Retake \(clears your result\)/)).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText(/Retake \(clears your result\)/));
+
+    expect(window.localStorage.getItem("assessment.result")).toBeNull();
+    expect(replaceMock).toHaveBeenCalledWith("/assessment");
+  });
+
+  it("does NOT render the authed-only 'Go to Today' CTA", async () => {
+    window.localStorage.setItem("assessment.result", JSON.stringify(makeResult()));
+    render(<ResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sleep Intelligence/)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("link", { name: /Go to Today/i })).not.toBeInTheDocument();
+  });
+});

--- a/utils/authServer.ts
+++ b/utils/authServer.ts
@@ -93,6 +93,52 @@ export function isUnauthorizedError(error: unknown): error is UnauthorizedError 
 }
 
 /**
+ * Like `withAuth`, but allows the request to be unauthenticated.
+ *
+ * Handler receives `{ user: AuthUser | null }`. Missing/invalid auth resolves
+ * to `null` (no 401); only used by endpoints that intentionally accept both
+ * authed and anonymous callers (e.g. `POST /api/assessment`). Cache headers
+ * are applied the same as `withAuth` — anonymous responses can still carry
+ * input-dependent content that we must not let intermediates cache by URL.
+ */
+export async function withOptionalAuth(
+  req: Request | undefined,
+  handler: (_args: { user: AuthUser | null }) => Promise<Response>
+): Promise<Response> {
+  const requestId = crypto.randomUUID()
+  const startedAt = Date.now()
+  const method = req?.method ?? 'UNKNOWN'
+  let route = 'unknown'
+  if (req?.url) {
+    try { route = new URL(req.url).pathname } catch { route = req.url }
+  }
+
+  let user: AuthUser | null = null;
+  try {
+    user = await getUserId(req);
+  } catch {
+    user = null;
+  }
+
+  try {
+    const response = await handler({ user })
+    const status = response.status
+    const outcome = status === 429 ? 'rate_limited' : status < 400 ? 'ok' : 'error'
+    // userId omitted from the log line indicates an anonymous caller; we don't
+    // need a separate outcome tag for it.
+    log({ requestId, route, method, outcome, status, latencyMs: Date.now() - startedAt, userId: user?.userId })
+    return applyNoStoreHeaders(response)
+  } catch (error) {
+    log({ requestId, route, method, outcome: 'error', status: 500, latencyMs: Date.now() - startedAt, userId: user?.userId }, 'error')
+    console.error('[withOptionalAuth] handler error:', error);
+    return applyNoStoreHeaders(NextResponse.json(
+      { ok: false, error: { code: 'INTERNAL_ERROR', message: 'Internal server error' } },
+      { status: 500 }
+    ));
+  }
+}
+
+/**
  * Guard wrapper for protected API handlers.
  * Resolves user or returns standardized 401 response.
  * Use for all routes that require authentication.


### PR DESCRIPTION
## Summary

- Move the auth wall from before `/assessment` to after `/results` — anonymous visitors can complete the 35-question quiz and see their full report (focus pillar + radar + per-pillar bars + 3 suggested practices with full content) without an account. Signup is asked at the results gate.
- Add GA4 with a cookie-consent banner for source/medium attribution + funnel drop-off visibility on the LinkedIn launch. Strict scope: no PII, no User-ID merging, consent-gated.
- Update the canon docs (`business-logic-v2.md`, `db-schema.md`, `analytics-privacy-boundaries.md`, `launch-checklist.md`) in the same PR so doctrine doesn't drift from code.

Full design rationale + 12 locked decisions in [`_docs/plans/anonymous-assessment-funnel.md`](https://github.com/qianhaopower/fiappV1/blob/feat/anonymous-assessment-funnel/_docs/plans/anonymous-assessment-funnel.md). Driven by: 50-friend share landed 0 signups; Cognito recorded 0 attempts; `/api/assessment` server hits = 2. The auth gate turned "Start free assessment" into a signup wall.

## What changed

- `middleware.ts`: drop `/assessment` and `/results` from `PROTECTED_PREFIXES`
- `utils/authServer.ts`: new `withOptionalAuth` helper (handler gets `{ user: AuthUser | null }`)
- `app/api/assessment/route.ts`: dual-mode POST — anonymous = compute-only (no DynamoDB writes, increments `totalAnonymousAssessments`), authed = unchanged
- `lib/assessment/localResult.ts` (new): typed localStorage helpers for transient pre-account state (draft + result), version-pinned
- `app/assessment/page.tsx`: draft persistence + restoration; anonymous submit path writes `assessment.result`, authed path does not
- `app/results/page.tsx`: dual-mode rendering. Anonymous reads localStorage, shows full content, pillar-aware signup gate, 30-day age banner
- `components/AppChrome.tsx`: skip `AppShell` for anonymous `/assessment` + `/results` (nav links would all 302 to `/auth`)
- `components/DecideRouteClient.tsx`: post-signup hydration replays anonymous answers via `POST /api/assessment` (now authed), one-shot redirect to `/results` with unlocked CTAs. Existing user case drops localStorage silently to preserve server canonical
- `app/page.tsx`: "Free · no account needed to start" microcopy + mobile-visible 8-minute badge
- `components/CookieBanner.tsx` + `components/GA4Loader.tsx` + `lib/analytics.ts` + `app/layout.tsx`: cookie consent, GA4 loader, event helper. GA4 only loads on Accept

## Pre-merge prerequisites

- [ ] Set `NEXT_PUBLIC_GA4_MEASUREMENT_ID` in Amplify env vars (both `staging` and `main` branches) — empty/missing = GA4 silently off (no banner side-effects)
- [ ] In GA4 Admin → Property Settings: set retention to 14 months, confirm Google Signals OFF, confirm anonymized IPs ON

## Test plan

### Already green locally
- [x] `npm run test` — 331/331 unit tests pass (includes new `withOptionalAuth`, `localResult`, anonymous-branch `/api/assessment` tests, anonymous + authed assessment page tests)
- [x] `npm run test:integration` — assessment integration tests 10/10 pass. 2 pre-existing `returns-get` failures are present on `staging` already (confirmed via `git stash` + re-run); not related to this PR
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean

### Required on staging before promoting to main
- [ ] Anonymous email-signup happy path: incognito → `/` → `Start free assessment` → answer 35 → `/results` → click pillar-aware Sign up → confirm email → land on `/results` with `Start this practice` CTAs working
- [ ] **Anonymous Google OAuth happy path** — highest-risk unknown per the plan. Verifies localStorage survives the OAuth redirect
- [ ] Draft survives a mid-quiz refresh
- [ ] Empty-localStorage `/results` visit redirects to `/assessment`
- [ ] 30-day-old `takenAt` shows the amber age banner
- [ ] Existing-user login on a browser with stale anonymous localStorage → preserves server data, drops local silently, lands per `decideRoute`
- [ ] Cookie banner: GA4 silent on first incognito visit until Accept clicked (DevTools Network panel, filter `google`); Decline keeps GA4 off
- [ ] After Accept: GA4 Realtime shows the visit; `assessment_started`, `assessment_submitted`, `results_viewed`, `signup_clicked`, `signup_completed`, `hydration_success` fire in order
- [ ] CloudWatch Logs Insights query for `funnel_event` returns the expected server-side events

### After merge to main
- [ ] Tag UTM-stamped launch URL: `https://friendsintelligence.net/?utm_source=linkedin&utm_medium=social&utm_campaign=launch_2026_05`

## Notes

- Plan: [`_docs/plans/anonymous-assessment-funnel.md`](https://github.com/qianhaopower/fiappV1/blob/feat/anonymous-assessment-funnel/_docs/plans/anonymous-assessment-funnel.md)
- Cross-browser limitation (take quiz on phone, sign up on laptop → answers lost) is a documented v1 accepted limitation. Server-side anonymous claim deferred.
- `decideRoute` (the pure function) is **not** modified. The post-hydration `/results` redirect is a one-shot override in `DecideRouteClient` only.
- New canon doctrine: `localStorage` may now hold transient pre-account state (assessment draft + anonymous result), cleared on signup. DynamoDB remains the source of truth for all authenticated state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)