### PR TITLE
fix(auth): /account page sign-out lands on /, not /auth

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -22,7 +22,10 @@ export default function AccountPage() {
       // ignore — still proceed with client-side signout
     } finally {
       await signOut()
-      window.location.href = '/auth'
+      // Land on the marketing landing page rather than /auth — same call as
+      // AppChrome's sign-out handler. Better "goodbye" surface and consistent
+      // with what a logged-out visitor sees by default.
+      window.location.href = '/'
     }
   }
 


### PR DESCRIPTION
## Summary

PR #425 changed `AppShell`'s sign-out handler to redirect to `/` (landing) but missed a duplicate `handleSignOut` in `app/account/page.tsx`. The Account page has its own "Sign out" button in the Session card.

The Playwright E2E suite caught it after PR #425 deployed: the test navigates via `/account` → click "Sign out" and expects URL ending in `/`. Trace shows `/account` → `/auth`, never reaching `/`.

## Fix

One-line: `window.location.href = '/auth'` → `'/'`. Same as the AppChrome version.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [ ] After deploy, re-run `tests/e2e/signout.spec.ts` against staging → should flip to passing
- [ ] Manual: log in, navigate to `/account`, click "Sign out" → lands on `/` (landing)

## Related

- PR #425 (merged) — the original sign-out redirect change in AppShell

🤖 Generated with [Claude Code](https://claude.com/claude-code)