### PR TITLE
fix(analytics): stringify booleans in trackEvent for GA4 filter compatibility

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -31,13 +31,25 @@ function getGtag(): GtagFn | null {
  * Send a GA4 custom event. Hard rules:
  * - Caller must NOT pass user IDs, emails, raw answers, or any PII.
  * - Caller may pass `is_anonymous`, `focus_pillar`, and counts/statuses.
+ *
+ * Booleans are converted to strings before sending. GA4's funnel filter
+ * "exactly matches true" does string comparison; sending a JS boolean
+ * causes the filter to silently miss matching events (confirmed during
+ * the 2026-05-22 WeChat soft launch — a real `results_viewed` event
+ * fired with is_anonymous=true but the funnel step counted 0).
  */
 export function trackEvent(name: string, params?: EventParams): void {
   const gtag = getGtag();
   if (!gtag) return;
   if (!isConsented()) return;
   try {
-    gtag("event", name, params ?? {});
+    const safeParams: Record<string, string | number | undefined> = {};
+    if (params) {
+      for (const [k, v] of Object.entries(params)) {
+        safeParams[k] = typeof v === "boolean" ? String(v) : v;
+      }
+    }
+    gtag("event", name, safeParams);
   } catch {
     // ignore
   }

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -40,9 +40,34 @@ describe("lib/analytics.trackEvent", () => {
     const gtag = vi.fn();
     setupWindow({ consent: "accepted", gtag });
     trackEvent("assessment_submitted", { focus_pillar: "sleep", is_anonymous: true });
+    // Booleans are stringified — see the comment in lib/analytics.ts for why.
     expect(gtag).toHaveBeenCalledWith("event", "assessment_submitted", {
       focus_pillar: "sleep",
+      is_anonymous: "true",
+    });
+  });
+
+  it("stringifies boolean params (false → 'false') so GA4 funnel filters match", () => {
+    const gtag = vi.fn();
+    setupWindow({ consent: "accepted", gtag });
+    trackEvent("assessment_started", { is_anonymous: false });
+    expect(gtag).toHaveBeenCalledWith("event", "assessment_started", {
+      is_anonymous: "false",
+    });
+  });
+
+  it("leaves non-boolean params untouched (strings + numbers)", () => {
+    const gtag = vi.fn();
+    setupWindow({ consent: "accepted", gtag });
+    trackEvent("assessment_question_answered", {
+      question_index: 17,
+      pillar: "sleep",
       is_anonymous: true,
+    });
+    expect(gtag).toHaveBeenCalledWith("event", "assessment_question_answered", {
+      question_index: 17,
+      pillar: "sleep",
+      is_anonymous: "true",
     });
   });
 


### PR DESCRIPTION
## Summary

WeChat soft launch on 2026-05-22 caught a tracking bug:
- A friend completed the anonymous assessment and viewed /results (radar screenshot confirmed)
- The GA4 funnel's "Viewed results (anon)" step counted **0**

Root cause: GA4 funnel filter \`Is Anonymous exactly matches true\` does string comparison; \`trackEvent\` was passing JS booleans, which gtag serializes inconsistently. Event fires, filter silently misses.

## Fix

\`lib/analytics.ts\` now stringifies booleans before calling gtag. Numbers and strings unchanged.

## What this fix doesn't do

It won't backfill the already-fired events. The existing \`results_viewed\` with boolean \`true\` stays mismatched. Workaround for the immediate launch report: drop the \`Is Anonymous = true\` filter from Step 4 until enough new traffic lands.

## Test plan

- [x] Updated existing analytics test to expect stringified boolean
- [x] Added test for \`false → "false"\`
- [x] Added test confirming non-booleans pass through untouched
- [x] \`npm run test:all\` — 39 unit files / 7 integration files all green

## Linked

- Launch baseline: \`docs/operations/launch-baselines.md\` (the WeChat snapshot that surfaced this)
- Original wiring: PR #424 (anonymous funnel + GA4)
- Per-question event added in PR #425 (also passes booleans — covered by this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)